### PR TITLE
feat(SPEC-012): wire streaming transcription into the menu-bar app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,7 @@ let package = Package(
             name: "OpenQuackKit",
             dependencies: [
                 "OpenQuackPlatform",
+                "OpenQuackStreaming",
                 .product(name: "WhisperKit", package: "argmax-oss-swift"),
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
             ],

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -69,6 +69,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let recorder = AudioRecorder()
     private let hotkey = HotkeyManager()
     private var transcriber: WhisperKitEngine?
+    private var streamer: StreamingTranscriber?   // SPEC-012; long-lived after warm
     private var overlay: RecordingOverlay?
     private let updater = UpdateChecker()
     let usageStats = UsageStats()        // SPEC-013
@@ -85,6 +86,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var elapsedTimer: Timer?
     private var permissionPollTimer: Timer?
+
+    /// SPEC-012: serial pump from the audio thread → StreamingTranscriber.
+    /// Spawning a `Task` per buffer doesn't guarantee FIFO at the actor;
+    /// the AsyncStream pump does (yield is ordered, the consumer awaits one
+    /// frame at a time).
+    private var framesContinuation: AsyncStream<(samples: [Float], rate: Double)>.Continuation?
+    private var framesPumpTask: Task<Void, Never>?
 
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -459,6 +467,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
             await MainActor.run { appState.phase = .starting }
 
+            // SPEC-012: wire the streamer before start() so we don't miss the
+            // first tap buffer. We always wire even for short utterances —
+            // stopAndTranscribe decides whether to use the streamed result or
+            // cancel the streamer and use the offline path. If the engine
+            // isn't warm yet, framesHandler stays nil and we pay nothing.
+            let language = defaultLanguage
+            let words = customWords
+            await tearDownFramesPump()
+            if let streamer {
+                // Pump pattern: the audio thread `yield`s into an unbounded
+                // AsyncStream; a single Task drains it serially into the
+                // actor. This preserves FIFO order — `Task { await ... }` per
+                // buffer would race because actor reentry isn't queued in
+                // submission order.
+                //
+                // `.unbounded` is safe: the pump consumer just hops into the
+                // actor (sub-ms) per buffer, and producer rate is ~50/s of
+                // ~10 ms buffers. The actor itself only retains samples until
+                // the next emitChunksIfReady cut, so steady-state memory is
+                // bounded by maxChunkSeconds, not stream backlog.
+                let (stream, continuation) = AsyncStream<(samples: [Float], rate: Double)>.makeStream(
+                    bufferingPolicy: .unbounded
+                )
+                self.framesContinuation = continuation
+                recorder.framesHandler = { samples, rate in
+                    continuation.yield((samples, rate))
+                }
+                self.framesPumpTask = Task { [weak streamer] in
+                    for await frame in stream {
+                        await streamer?.appendFrames(frame.samples, sampleRate: frame.rate)
+                    }
+                }
+                await streamer.begin(language: language, customWords: words)
+            } else {
+                recorder.framesHandler = nil
+            }
+
             do {
                 _ = try recorder.start(outputURL: lastRecordingURL)
                 await MainActor.run {
@@ -470,6 +515,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     playSound("Tink")
                 }
             } catch {
+                await tearDownFramesPump()
+                if let streamer { await streamer.cancel() }
                 await MainActor.run {
                     appState.phase = .error("Recording failed: \(error)")
                 }
@@ -482,6 +529,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// faster than the eye can register, which defeats the point of having
     /// progress UI in the first place.
     private static let minTranscribeDwell: TimeInterval = 0.6
+
+    /// SPEC-012: utterances at or above this duration take the streaming
+    /// path; shorter ones stay on the offline path (faster end-to-end on
+    /// short audio). Mirrors `StreamingTranscriber.Config.streamingThreshold`.
+    private static let streamingThreshold: TimeInterval = 30
 
     private func stopAndTranscribe() {
         stopElapsedTimer()
@@ -523,11 +575,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             defer { progressTask.cancel() }
 
             do {
-                let result = try await engine.transcribe(
-                    audioFile: url,
-                    language: defaultLanguage,
-                    customWords: customWords
-                )
+                // SPEC-012: streaming path on long audio, offline on short.
+                // Streaming reuses chunks transcribed during recording, so the
+                // post-stop wait stays roughly flat as utterance length grows.
+                // Teardown drains the audio-thread pump first so finish()
+                // sees every frame; cancel() is fine to call after teardown
+                // (any frames still queued become a no-op once cancelled).
+                let result: EngineTranscription
+                if audioDuration >= Self.streamingThreshold, let streamer {
+                    await tearDownFramesPump()
+                    let r = try await streamer.finish()
+                    result = EngineTranscription(
+                        text: r.text,
+                        detectedLanguage: r.detectedLanguage,
+                        audioSeconds: r.audioSeconds > 0 ? r.audioSeconds : audioDuration,
+                        wallSeconds: r.wallSeconds,
+                        timeToFirstToken: nil
+                    )
+                } else {
+                    await tearDownFramesPump()
+                    if let streamer { await streamer.cancel() }
+                    result = try await engine.transcribe(
+                        audioFile: url,
+                        language: defaultLanguage,
+                        customWords: customWords
+                    )
+                }
 
                 // Smart formatting on raw Whisper output (capitalisation,
                 // end-punctuation, fillers). Toggle: Settings → General.
@@ -609,6 +682,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         do {
             let engine = try await WhisperKitEngine(model: defaultModel)
             self.transcriber = engine
+            self.streamer = engine.makeStreamingTranscriber()  // SPEC-012
             await MainActor.run {
                 appState.phase = .idle
                 appState.modelLabel = defaultModel
@@ -658,6 +732,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func stopElapsedTimer() {
         elapsedTimer?.invalidate()
         elapsedTimer = nil
+    }
+
+    /// SPEC-012: close the audio-thread → streamer pump. Awaits the pump
+    /// task so any frames buffered in the AsyncStream actually land on
+    /// `StreamingTranscriber.appendFrames` before the caller proceeds —
+    /// load-bearing for `streamer.finish()` returning a complete transcript.
+    /// Safe to call when nothing is wired (no-op).
+    private func tearDownFramesPump() async {
+        recorder.framesHandler = nil
+        framesContinuation?.finish()
+        framesContinuation = nil
+        if let task = framesPumpTask {
+            framesPumpTask = nil
+            await task.value
+        }
     }
 
     // MARK: - SPEC-014 crash recovery

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -48,6 +48,13 @@ public final class AudioRecorder {
     /// scaled for UI). Set this before calling `start` to drive a level meter.
     public var levelHandler: ((Float) -> Void)?
 
+    /// SPEC-012: emitted on the audio thread for every captured tap buffer
+    /// (~10–20 ms at typical input rates). Set before `start()`. Called
+    /// with raw float32 samples in the input device's native rate; consumers
+    /// must resample if they need 16 kHz. Opt-in — existing dictation-only
+    /// callers leave it nil and pay nothing.
+    public var framesHandler: (([Float], Double) -> Void)?
+
     public init() {}
 
     public var isRecording: Bool {
@@ -135,6 +142,8 @@ public final class AudioRecorder {
         }
 
         let levelHandler = self.levelHandler
+        let framesHandler = self.framesHandler
+        let inputSampleRate = inputFormat.sampleRate
 
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
             do {
@@ -149,6 +158,17 @@ public final class AudioRecorder {
             if let levelHandler {
                 let level = Self.uiLevel(from: buffer)
                 DispatchQueue.main.async { levelHandler(level) }
+            }
+
+            // SPEC-012 streaming: emit raw float samples on the audio thread.
+            // Consumer (StreamingTranscriber) is an actor; it'll re-enter on
+            // its own queue, so this stays cheap on the capture thread.
+            if let framesHandler,
+               let channelData = buffer.floatChannelData?[0],
+               buffer.frameLength > 0 {
+                let count = Int(buffer.frameLength)
+                let samples = Array(UnsafeBufferPointer(start: channelData, count: count))
+                framesHandler(samples, inputSampleRate)
             }
         }
 

--- a/Sources/OpenQuackKit/OpenQuackKit.swift
+++ b/Sources/OpenQuackKit/OpenQuackKit.swift
@@ -1,5 +1,6 @@
 import Foundation
 @_exported import OpenQuackPlatform
+@_exported import OpenQuackStreaming
 
 public enum OpenQuackKit {
     /// Re-exported from `OpenQuackPlatform.version` so existing call sites keep working.

--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -22,6 +22,16 @@ public final class WhisperKitEngine: TranscriptionEngine {
     /// Reset by WhisperKit at the start of each transcribe.
     public var progress: Progress { pipe.progress }
 
+    /// Vend a `StreamingTranscriber` bound to this engine's pipe (SPEC-012).
+    /// The streamer reuses the loaded model — the expensive part — and pays
+    /// no extra cold-start cost. Caller owns the lifetime; one streamer can
+    /// be reused across many recordings (call `begin` before each).
+    public func makeStreamingTranscriber(
+        config: StreamingTranscriber.Config = .init()
+    ) -> StreamingTranscriber {
+        StreamingTranscriber(pipe: pipe, config: config)
+    }
+
     public init(model: String, downloadBase: URL? = nil) async throws {
         self.modelID = model
 

--- a/Sources/OpenQuackStreaming/StreamingTranscriber.swift
+++ b/Sources/OpenQuackStreaming/StreamingTranscriber.swift
@@ -85,12 +85,20 @@ public actor StreamingTranscriber {
         )
     }
 
-    public func begin(language: String?, customWords: String?) {
+    public func begin(language: String?, customWords: String?) async {
+        // If a prior session's drain is still in flight, fully tear it down
+        // before resetting state. Otherwise the old drain can re-check
+        // `cancelled` after we reset it to false and write its outcome into
+        // the new session's `chunkOutcomes`, mixing two recordings.
+        if let prior = drainTask {
+            cancelled = true
+            prior.cancel()
+            await prior.value
+        }
         buffer.removeAll(keepingCapacity: true)
         bufferStartSample = 0
         chunkOutcomes.removeAll()
         queue.removeAll()
-        drainTask?.cancel()
         drainTask = nil
         ended = false
         cancelled = false


### PR DESCRIPTION
## Summary
- Wires `StreamingTranscriber` into `AppDelegate`: long recordings (≥30 s) stream while the user talks, so the post-stop wait stays roughly flat instead of growing linearly with utterance length.
- Adds `AudioRecorder.framesHandler` (opt-in tap-buffer fan-out) and `WhisperKitEngine.makeStreamingTranscriber()` factory.
- Fixes a re-`begin()` race in `StreamingTranscriber` where an in-flight drain task from the previous session could write into the new session's outcome map.

## What changed
- **AudioRecorder**: optional `framesHandler` callback fires on the audio thread with raw float samples + the input sample rate. Dictation-only callers leave it nil; no overhead.
- **WhisperKitEngine**: `makeStreamingTranscriber(config:)` vends a `StreamingTranscriber` bound to the loaded pipe — reuses the model, no second cold-start.
- **AppDelegate**:
  - Holds a long-lived `streamer` after warm.
  - `startRecording`: builds an `AsyncStream` pump from `framesHandler` → `streamer.appendFrames`. Single-consumer task preserves FIFO at the actor; spawning a `Task` per buffer would race because actor reentry isn't ordered. `.unbounded` policy is safe — pump consumer is sub-ms per frame and the actor only retains samples until the next chunk cut.
  - `stopAndTranscribe`: ≥30 s → `streamer.finish()`; <30 s → `streamer.cancel()` and offline `engine.transcribe(audioFile:)`.
  - `tearDownFramesPump`: closes the stream and awaits the pump task so any frames buffered in the AsyncStream actually land before `finish()` returns.
- **StreamingTranscriber.begin**: now `async`. Cancels and awaits the prior drain task before resetting state. Without this, the old drain task could re-check `cancelled` after `begin()` reset it to `false`, then write its outcome into the new session's `chunkOutcomes`.

## Validation
- `swift build` — clean against the project's macOS-15 / Xcode toolchain.
- `swift test` — 47/47 pass.
- End-to-end behaviour previously validated by `openquack-stream-bench` (PR #1): on a 5 min clip, post-stop wait drops from ~32 s (offline) to ~3 s (streaming), with WER deltas of +0.31–0.49pp across the corpus.

## Release notes draft (v2.0.0-alpha.9)
> **Streaming transcription on long recordings**
> Recordings of 30 seconds or more now transcribe in the background while you're still talking, so when you press stop the wait is bounded by the last chunk (~2–3 s) instead of growing with the recording length. Short recordings keep the existing offline path (slightly faster end-to-end on small clips).

## Test plan
- [ ] Hold record for ≥30 s, release — popover shows transcribing for ~2–3 s rather than waiting on the full file.
- [ ] Hold record for <30 s, release — offline path used; behaviour unchanged.
- [ ] Stop mid-stream while a chunk is still transcribing — final transcript includes the tail without dropped frames.
- [ ] Start a second recording immediately after the first finishes — no cross-recording text leak (covered by the begin-race fix).
- [ ] Toggle off / on with VAD-auto-stop enabled — pump tears down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)