### PR TITLE
chore: user-facing issue templates + SUPPORT.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Something in OpenQuack isn't working — crash, wrong transcript, hotkey misfire, paste failure, etc.
+title: "[bug] <one-line summary>"
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file this. Audio and transcripts never
+        leave your Mac — same goes for this issue: don't paste anything you
+        wouldn't put on a public website. Redact personal text in any
+        screenshot.
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: One or two sentences. What did you do, and what went wrong?
+      placeholder: |
+        Pressed ⌃⇧Space, said "open the PR", and OpenQuack pasted "open the
+        peer" instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: Optional — only if it's not obvious from the above.
+      placeholder: The transcript should match what I said.
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimum steps so we can repeat it. "Always / sometimes / once" is fine if you can't pin it down.
+      placeholder: |
+        1. Launch OpenQuack
+        2. Press ⌃⇧Space
+        3. Say "..."
+        4. Press ⌃⇧Space again
+        Result: ...
+    validations:
+      required: true
+
+  - type: input
+    id: openquack_version
+    attributes:
+      label: OpenQuack version
+      description: Menu bar → right-click → Show app → About. Or `cat /Applications/OpenQuack.app/Contents/Info.plist | grep -A1 CFBundleShortVersionString`.
+      placeholder: "v2.0.0-alpha.9"
+    validations:
+      required: true
+
+  - type: input
+    id: macos_version
+    attributes:
+      label: macOS version
+      description: Apple menu → About This Mac.
+      placeholder: "macOS 15.2 (24C101)"
+    validations:
+      required: true
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Mac model + memory
+      description: e.g. "M4 / 16 GB", "M1 Pro / 32 GB", "Intel i7 / 16 GB".
+      placeholder: "M4 / 16 GB"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: model
+    attributes:
+      label: Whisper model
+      description: Settings → Models → which one is selected.
+      options:
+        - "default for my hardware (auto)"
+        - "tiny"
+        - "base"
+        - "small"
+        - "medium"
+        - "large-v3"
+        - "distil-large-v3"
+        - "other / not sure"
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Logs, screenshots, recordings — drag in here. If you can attach a short audio sample that triggers it, that's gold (only if the audio doesn't contain anything sensitive).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions — questions, feedback, ideas
+    url: https://github.com/larryxiao/openquack/discussions
+    about: Quick questions, "is this normal?", or anything that's more conversation than report.
+  - name: Bench results from your Mac
+    url: https://github.com/larryxiao/openquack/blob/main/docs/BENCHMARKS.md
+    about: Have an M1 / M2 / M3 / 8 GB / 24 GB+ Mac? See BENCHMARKS.md for how to contribute a row.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Something OpenQuack should do that it doesn't yet.
+title: "[feature] <one-line summary>"
+labels: ["feature-request", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing — skim [`docs/ROADMAP.md`](https://github.com/larryxiao/openquack/blob/main/docs/ROADMAP.md)
+        and [`docs/VISION.md`](https://github.com/larryxiao/openquack/blob/main/docs/VISION.md)
+        in case it's already on the list. If it is and you want to vote it
+        up, comment on the existing issue instead of opening a new one.
+
+        OpenQuack is privacy-first and local-only. Feature requests that
+        involve cloud calls in the dictation hot path won't ship — that's
+        the [privacy contract](https://github.com/larryxiao/openquack/blob/main/docs/VISION.md#privacy-contract).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem
+      description: What you're trying to do that OpenQuack makes harder than it should.
+      placeholder: |
+        I dictate Slack replies all day, and the transcript almost always
+        gets the project name "Quokka" wrong as "Quaker" or "kokka".
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What you'd want instead
+      description: One sentence is fine. Don't worry about whether it's the right design — that's our job.
+      placeholder: A way to teach OpenQuack a list of project names so it stops mishearing them.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds you've tried
+      description: Optional. Helps us understand what's missing about the existing options.
+
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How blocking is this for you
+      options:
+        - "I can live without it"
+        - "It would meaningfully improve my use of OpenQuack"
+        - "I'd use OpenQuack a lot more if this existed"
+        - "I want this but use a different tool today because of it"
+    validations:
+      required: true
+
+  - type: input
+    id: usage_context
+    attributes:
+      label: How you use OpenQuack
+      description: One line. e.g. "Mostly dictating prompts to Claude Code", "writing email", "Chinese messaging".
+      placeholder: "Mostly dictating prompts to Claude Code in a terminal."

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,56 @@
+# Getting help with OpenQuack
+
+A few different ways, depending on what you're after.
+
+## Something's broken
+
+[Open a bug report.](https://github.com/larryxiao/openquack/issues/new?template=bug_report.yml) Two minutes; we'll triage within a day.
+
+If it's a crash, a misfired hotkey, a wrong transcript on real speech, or auto-paste landing in the wrong app — that's a bug, please file it.
+
+## Something's missing
+
+[Open a feature request.](https://github.com/larryxiao/openquack/issues/new?template=feature_request.yml) Even if you're not sure it's the right design — that's our job to figure out.
+
+Please check [`docs/ROADMAP.md`](docs/ROADMAP.md) first; if it's already there, comment on the existing issue instead of filing a new one.
+
+## You have a question, an idea, or want to share a use case
+
+[GitHub Discussions](https://github.com/larryxiao/openquack/discussions) is the right place. Lower friction than an issue. Examples:
+
+- "Is this normal? My medium model takes 5s on a 30s clip."
+- "Anyone tried this with Cursor / Claude Code / Aider?"
+- "Here's how I use OpenQuack for Chinese messaging."
+- "What model would you suggest on an M1 / 8 GB?"
+
+Quick replies welcome. We read everything.
+
+## You want to contribute
+
+Code, docs, bench results, design feedback — all welcome. Read [`AGENTS.md`](AGENTS.md) (the workflow is the same for humans), pick a 🔵 task in [`docs/ROADMAP.md`](docs/ROADMAP.md), open a draft PR.
+
+If you have an M1 / M2 / M3 / Intel / 8 GB / 24 GB+ Mac and want to contribute a benchmark row, that's [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) — the easiest contribution and the most useful to other users.
+
+## Privacy, in one screen
+
+- Audio never leaves your Mac. Same for transcripts.
+- No analytics, no telemetry, no signup.
+- Verify with Little Snitch / Lulu, or by reading the source.
+- Full contract: [`docs/VISION.md#privacy-contract`](docs/VISION.md#privacy-contract).
+
+If a bug report or feature request would require sharing a recording or a transcript that's sensitive — don't. A short paraphrased description is fine. We can repro most things from a description.
+
+## Security disclosures
+
+Please email `security@<the-domain-on-the-repo>` privately rather than filing a public issue. (Or open a GitHub Security Advisory if you prefer that flow.)
+
+## Response time
+
+This is an open-source side project, not a SaaS. Realistic expectation:
+
+- Critical bugs (crashes, dictation broken on common configs): within 48h.
+- Other bugs: within a week.
+- Feature requests: triaged within a week, queued by priority.
+- Discussions: usually within a day.
+
+If something's been sitting >2 weeks with no response, ping it — we may have missed it.


### PR DESCRIPTION
## SPEC

n/a — pure repo infra / docs.

## Milestone

n/a (cuts across; supports M2.5 / M3 adoption).

## Why

End users have no quick path to file a bug or request a feature — existing issue templates target contributors (`agent_task`, `spec_proposal`). Distribution amplifies whatever the user finds, so the feedback loop needs to be wired before more launch work compounds. Pairs with SPEC-018 (`Send feedback…` menu item, separate PR) which links into the chooser this PR registers.

## Change

- `.github/ISSUE_TEMPLATE/bug_report.yml` — what / repro / OpenQuack version / macOS version / Mac model + memory / Whisper model / extras
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem / what they'd want / alternatives / how-blocking / usage context
- `.github/ISSUE_TEMPLATE/config.yml` — points conversational-shape questions at Discussions and bench-PR-curious users at `docs/BENCHMARKS.md`
- `SUPPORT.md` — single page mapping the user's intent ("something's broken" / "missing" / "have a question" / "want to contribute" / "privacy") to the right path

## Tests

- [x] no code change; manual verification: each template renders and validates correctly when filing a new issue
- [x] all links in `SUPPORT.md` resolve (incl. anchors into `docs/VISION.md#privacy-contract`)

## Privacy impact

None. All flows are GitHub-side; no app-side change.

## Out of scope

- In-app feedback widget — see SPEC-018 (separate PR).
- GitHub Discussions seed thread — Larry to post (scaffold ready in `gtm/posts/discussion-seed-bench.md`).
- Crash reporting — opt-in, separate spec.