### PR TITLE
feat(SPEC-018): "Send feedback" item in status-item right-click menu

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -278,9 +278,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Right-click context menu — minimal: Show app + Quit. Settings still
-    /// reachable via the popover; `showApp` opens it directly so power users
-    /// can skip the popover entirely.
+    /// Right-click context menu — Show app, Send feedback, Quit. Settings
+    /// is still reachable via the popover; `showApp` opens it directly so
+    /// power users can skip the popover entirely. SPEC-018 adds "Send
+    /// feedback" to give users a one-click path to file issues without
+    /// navigating to GitHub manually.
     @MainActor
     private func showStatusItemMenu() {
         let menu = NSMenu()
@@ -288,6 +290,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let show = NSMenuItem(title: "Show app", action: #selector(menuShowApp), keyEquivalent: ",")
         show.target = self
         menu.addItem(show)
+
+        let feedback = NSMenuItem(title: "Send feedback…", action: #selector(menuSendFeedback), keyEquivalent: "")
+        feedback.target = self
+        menu.addItem(feedback)
 
         menu.addItem(.separator())
 
@@ -306,6 +312,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     @objc private func menuShowApp() {
         SettingsWindowController.show(appState: appState)
+    }
+
+    @MainActor
+    @objc private func menuSendFeedback() {
+        // SPEC-018. Opens the GitHub issue chooser; user picks bug report
+        // or feature request from there. No app-side network IO.
+        guard let url = URL(string: "https://github.com/larryxiao/openquack/issues/new/choose") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
     }
 
     @MainActor

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,6 +84,7 @@ SPEC-006 (agent dispatch) builds on.
 | ⚪ | Live partial transcripts in the pill/popover while speaking — UX-facing (lets the user see what's being captured, catch mistakes early). Distinct from the perf streaming above; could share infra. | new SPEC | M |
 | 🔵 | Usage stats pane: words dictated via OpenQuack, time saved (vs. typing baseline), total audio processed. Local-only, opt-in display. | SPEC-013 | S |
 | 🔵 | Local audio + transcript history: keep recent recordings on disk so a crash/failure mid-long-utterance doesn't force the user to repeat 1–2 minutes of speech. Local-only, retention cap, easy purge. Privacy selling point — works offline, nothing leaves the device. | SPEC-014 | M |
+| 🟡 | Send-feedback menu item — one click from status item to GitHub issue chooser. Closes the user → repo feedback loop. | SPEC-018 | S |
 | ⚪ | Code signing + notarisation | — | S |
 | ⚪ | Sparkle auto-update | — | S |
 | ⚪ | Demo gif + landing page (GitHub Pages) | — | S |

--- a/docs/SPECS/SPEC-018-feedback-menu.md
+++ b/docs/SPECS/SPEC-018-feedback-menu.md
@@ -1,0 +1,64 @@
+# SPEC-018 — Send-feedback menu item
+
+**Status:** draft (M3 — adoption-supporting infra)
+**Owner:** `OpenQuackApp/OpenQuackApp.swift` (right-click status-item menu)
+**Last updated:** 2026-05-06
+
+## Goal
+
+Most users won't open a GitHub issue from a browser to report a bug or
+request a feature. Add a one-click path from the menu-bar status item to
+the right repo issue template, so the friction from "this is broken" to
+"filed" is one click.
+
+## Why
+
+After the May 5 launch, the bottleneck on adoption isn't the product; it's
+the feedback loop. The repo has bug-report and feature-request issue
+templates (`.github/ISSUE_TEMPLATE/bug_report.yml`,
+`feature_request.yml`) and a `SUPPORT.md` page, but a user dictating
+into Slack at 2 PM is unlikely to navigate to GitHub manually. A single
+"Send feedback" item in the status-item right-click menu collapses that
+to one click.
+
+## Non-goals
+
+- In-app feedback form. We don't want a custom form widget; GitHub's
+  templates are already structured and cover what we need.
+- Telemetry. The menu item opens a browser; nothing is sent
+  automatically.
+- Crash reporting. That's a separate spec (M3+, opt-in only).
+
+## Public surface
+
+A new `NSMenuItem` titled "Send feedback…" appears in the right-click
+menu (`OpenQuackApp.showStatusItemMenu`), between "Show app" and the
+separator before "Quit". Hotkey: none.
+
+Behaviour: opens
+`https://github.com/larryxiao/openquack/issues/new/choose` in the user's
+default browser via `NSWorkspace.shared.open(_:)`. The chooser page
+shows our two templates plus the Discussions / bench-PRs config-yml
+contact links.
+
+If a future telemetry channel exists (opt-in only), it can append a
+prefilled query-string in this URL — out of scope for this spec.
+
+## Open questions
+
+- Should the menu item link to `/issues/new/choose` (chooser) or directly
+  to `bug_report.yml`? Chooser is more general but adds one click;
+  bug-report is more common but assumes intent. Default: chooser.
+- Should there be a "Star on GitHub" item too? Probably yes, but as a
+  separate spec — different concern.
+
+## Privacy impact
+
+None. The menu item opens a URL in the user's browser. No app-side IO.
+The privacy contract is unchanged.
+
+## Test
+
+Unit-testable by inspecting the menu structure on `OpenQuackApp` after
+construction. Manual repro: launch app, right-click status item, click
+"Send feedback…", verify GitHub chooser page opens.


### PR DESCRIPTION
## SPEC

[SPEC-018 (Send-feedback menu item)](../blob/feat/spec-018-feedback-menu/docs/SPECS/SPEC-018-feedback-menu.md)

## Milestone

M3 (adoption-supporting infra).

## Why

A user dictating into Slack at 2 PM is unlikely to navigate to GitHub manually to file a bug. A "Send feedback…" item in the status-item right-click menu collapses that to one click. Pairs with the bug_report.yml / feature_request.yml templates and SUPPORT.md from #4.

## Change

- `docs/SPECS/SPEC-018-feedback-menu.md` (new) — short spec
- `docs/ROADMAP.md` — register the task under M3 (🟡)
- `Sources/OpenQuackApp/OpenQuackApp.swift` — adds `NSMenuItem("Send feedback…")` between `Show app` and the separator before `Quit OpenQuack`; handler opens `https://github.com/larryxiao/openquack/issues/new/choose` via `NSWorkspace.shared.open(_:)`

## Tests

- [x] `swift build` green
- [ ] manual repro — launch app, right-click status item, click "Send feedback…", verify GitHub chooser page opens in default browser

## Privacy impact

None. The menu item opens a URL in the user's default browser; no app-side network IO. Privacy contract unchanged. The handler doesn't read user data, doesn't append query params, doesn't route through any analytics layer.

## Out of scope

- In-app feedback form widget (we don't want one; the GitHub templates are already structured)
- Crash reporting (separate spec, opt-in only)
- "Star on GitHub" menu item (different concern; if added, separate PR)