### PR TITLE
feat(SPEC-007): TextPolishEngine protocol + atomic-PR breakdown (PR #1 of 7)

### DIFF
--- a/Sources/OpenQuackKit/Polish/PolishEngine.swift
+++ b/Sources/OpenQuackKit/Polish/PolishEngine.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// A pluggable text-polish backend that runs *after* WhisperKit produces a
+/// raw transcript and *before* the regex-based `TextPolisher` fallback.
+///
+/// Implementers wrap a local LLM (Ollama HTTP, MLX-LM in-process, or a
+/// future engine) and clean up multi-clause runs, restructure into bullets
+/// where appropriate, and disambiguate proper nouns Whisper guessed wrong
+/// ("cloud code" → "Claude Code"). The full contract lives in
+/// `docs/SPECS/SPEC-007-llm-polish.md`.
+///
+/// Failure mode: throw. The caller catches and falls back to the regex
+/// pipeline, so partial / broken polish never reaches the user.
+public protocol TextPolishEngine: AnyObject, Sendable {
+    /// Stable identifier for logging / settings round-trip. Lowercase, no
+    /// spaces. Matches `PolishEngineKind.rawValue` for the corresponding
+    /// kind.
+    static var engineName: String { get }
+
+    /// Whether running this engine sends bytes off the host. Loopback
+    /// (Ollama at `localhost`) and in-process (MLX-LM) both report `false`.
+    /// The recording overlay reads this to decide whether to render the
+    /// network indicator.
+    var requiresNetwork: Bool { get }
+
+    /// Display label for the status row in Settings. e.g. "gemma3:1b
+    /// (Ollama)" or "Qwen2.5-1.5B-Instruct-4bit (MLX-LM)".
+    var modelLabel: String { get }
+
+    /// Polish the given raw transcript.
+    ///
+    /// Implementations should:
+    /// - Be idempotent on already-clean input (`polish(clean) ≈ clean`).
+    /// - Preserve the input language (no translation).
+    /// - Preserve technical terms / proper nouns / names exactly.
+    /// - Throw on any failure (timeout, OOM, model not loaded, decode
+    ///   error). The caller catches and falls back.
+    func polish(_ raw: String, context: PolishContext) async throws -> String
+}
+
+/// Per-call hints that engines may use (or ignore). Engines must tolerate
+/// `nil` for every optional field — context is best-effort.
+public struct PolishContext: Sendable, Equatable {
+    /// BCP-47-ish language tag, e.g. "en", "zh", "ja". `nil` means
+    /// "engine should infer or use its default."
+    public let language: String?
+
+    /// User-visible name of the foreground app at capture time, if known.
+    /// e.g. "Cursor", "Slack". Used by future per-app polish profiles
+    /// (SPEC-008); current engines ignore it.
+    public let foregroundApp: String?
+
+    /// When the audio was captured (not when polish was invoked). Engines
+    /// generally don't read this; carried for telemetry-free diagnostics.
+    public let timestamp: Date
+
+    public init(
+        language: String? = nil,
+        foregroundApp: String? = nil,
+        timestamp: Date = Date()
+    ) {
+        self.language = language
+        self.foregroundApp = foregroundApp
+        self.timestamp = timestamp
+    }
+}
+
+/// User-selected polish backend. `off` skips the LLM step entirely and the
+/// pipeline runs the regex `TextPolisher` only — same behaviour as today.
+public enum PolishEngineKind: String, CaseIterable, Sendable {
+    case off
+    case ollama
+    case mlxLM = "mlx-lm"
+}
+
+/// Errors a polish engine can raise. Conforms to `LocalizedError` so a
+/// future Settings pane can surface a one-line user-readable description
+/// without each call site duplicating the switch.
+public enum PolishError: Error, LocalizedError, Equatable {
+    /// The engine has no model configured (Ollama URL unreachable, MLX-LM
+    /// model not downloaded). The user needs to fix it in Settings.
+    case notConfigured
+
+    /// The engine started but the model is not loaded yet. Caller may retry
+    /// after a short delay; for now we just fall back.
+    case modelNotLoaded(String)
+
+    /// Engine took longer than its timeout. Default budget is 8 s for the
+    /// first byte; tunable per engine.
+    case timeout
+
+    /// The backend (Ollama daemon, MLX-LM runtime) returned an error or is
+    /// unreachable. The associated string is the underlying message,
+    /// surfaced verbatim for diagnostics.
+    case backendUnavailable(String)
+
+    /// The backend returned a response we couldn't parse as text. Almost
+    /// always indicates an API-shape mismatch with our request.
+    case decodingFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Polish engine isn't configured. Open Settings → Polish to pick one."
+        case .modelNotLoaded(let label):
+            return "Polish model isn't loaded yet (\(label))."
+        case .timeout:
+            return "Polish step timed out."
+        case .backendUnavailable(let detail):
+            return "Polish backend unavailable: \(detail)"
+        case .decodingFailed:
+            return "Polish backend returned an unexpected response."
+        }
+    }
+}

--- a/Tests/OpenQuackKitTests/PolishEngineTests.swift
+++ b/Tests/OpenQuackKitTests/PolishEngineTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class PolishEngineTests: XCTestCase {
+    func testPolishContextRoundTripsAllFields() {
+        let now = Date()
+        let ctx = PolishContext(
+            language: "en",
+            foregroundApp: "Cursor",
+            timestamp: now
+        )
+        XCTAssertEqual(ctx.language, "en")
+        XCTAssertEqual(ctx.foregroundApp, "Cursor")
+        XCTAssertEqual(ctx.timestamp, now)
+    }
+
+    func testPolishContextDefaults() {
+        let ctx = PolishContext()
+        XCTAssertNil(ctx.language)
+        XCTAssertNil(ctx.foregroundApp)
+    }
+
+    func testPolishEngineKindRawValuesAreStable() {
+        XCTAssertEqual(PolishEngineKind.off.rawValue, "off")
+        XCTAssertEqual(PolishEngineKind.ollama.rawValue, "ollama")
+        XCTAssertEqual(PolishEngineKind.mlxLM.rawValue, "mlx-lm")
+    }
+
+    func testPolishEngineKindAllCasesIsExhaustive() {
+        let all = Set(PolishEngineKind.allCases)
+        XCTAssertEqual(all, [.off, .ollama, .mlxLM])
+    }
+
+    func testPolishErrorIsLocalized() {
+        let cases: [PolishError] = [
+            .notConfigured,
+            .modelNotLoaded("gemma3:1b"),
+            .timeout,
+            .backendUnavailable("connection refused"),
+            .decodingFailed,
+        ]
+        for err in cases {
+            XCTAssertNotNil(err.errorDescription, "\(err) should have localized description")
+        }
+    }
+
+    /// Compile-time check that any well-formed implementer satisfies the
+    /// protocol. Real engines (`OllamaPolishEngine`, `MLXLMPolishEngine`)
+    /// land in subsequent SPEC-007 PRs; this stub keeps the contract
+    /// honest before they exist.
+    func testProtocolCompilesWithMinimalImplementer() async throws {
+        final class StubEngine: TextPolishEngine {
+            static let engineName = "stub"
+            let requiresNetwork = false
+            let modelLabel = "stub"
+            func polish(_ raw: String, context: PolishContext) async throws -> String {
+                raw
+            }
+        }
+        let engine = StubEngine()
+        let polished = try await engine.polish("hello", context: PolishContext())
+        XCTAssertEqual(polished, "hello")
+    }
+}

--- a/docs/SPECS/SPEC-007-llm-polish.md
+++ b/docs/SPECS/SPEC-007-llm-polish.md
@@ -69,6 +69,29 @@ public enum PolishEngineKind: String, CaseIterable, Sendable {
 }
 ```
 
+## Atomic PR breakdown
+
+To stay within `AGENTS.md` "atomic PRs," ship M2.5 as the following ordered
+PRs. Each is small enough to review in 10 minutes and reverse cleanly.
+
+| # | Title | Branch | Effort | Depends on | Files |
+|---|---|---|---|---|---|
+| 1 | `TextPolishEngine` protocol + types | `feat/spec-007-protocol` | S | — | `Sources/OpenQuackKit/Polish/PolishEngine.swift` (new), `Tests/OpenQuackKitTests/PolishEngineTests.swift` (new) |
+| 2 | `OllamaPolishEngine` impl | `feat/spec-007-ollama-engine` | S | #1 | `Sources/OpenQuackKit/Polish/OllamaPolishEngine.swift` (new), tests with `URLProtocol` mock |
+| 3 | Pipeline integration in `AppState` (off by default) | `feat/spec-007-app-integration` | S | #2 | `Sources/OpenQuackApp/AppState.swift` (edit), UserDefaults flag, fall-back to regex on `throws` |
+| 4 | Settings → Polish pane (Off / Ollama only; MLX-LM disabled) | `feat/spec-007-settings-ui` | S | #3 | `Sources/OpenQuackApp/SettingsView.swift` (edit), engine picker, model field, URL field, "test connection" button |
+| 5 | `MLXLMPolishEngine` impl | `feat/spec-007-mlx-engine` | M | #4 | `Package.swift` (add `mlx-swift-lm` dep), `Sources/OpenQuackKit/Polish/MLXLMPolishEngine.swift` (new), tests, enable MLX-LM in Settings picker |
+| 6 | `openquack-polish-bench` wires both engines + reports | `feat/spec-007-bench-integration` | S | #5 | `Sources/OpenQuackPolishBench/PolishBenchRunner.swift` (edit) |
+| 7 | Domain-term + send-confidence corpus seed | `feat/spec-007-corpus-seed` | S | #6 | `bench/polish_corpus/cases.jsonl` (new), `docs/BENCHMARKS-polish.md` (update) |
+
+PRs ship in order. PR 1 has no behaviour change — it's protocol-only — so
+it lands as soon as it builds and tests pass. Each subsequent PR is
+non-breaking (the polish step stays opt-in with `.off` as the default
+`PolishEngineKind`) until PR 4 ships the user-facing toggle.
+
+A future PR set covers `WhisperKitLLMPolishEngine` if argmax-oss-swift's
+text-models stack matures; that's not in M2.5.
+
 ## Engines (implementation order)
 
 ### 1. `OllamaPolishEngine` — fastest path to a working feature


### PR DESCRIPTION
## SPEC

[SPEC-007 (LLM transcript polish)](../blob/feat/spec-007-protocol/docs/SPECS/SPEC-007-llm-polish.md)

## Milestone

M2.5.

## Why

M2.5 polish needs a stable engine surface before any concrete engine ships. This PR introduces the surface and adds an "Atomic PR breakdown" section to the spec listing 7 ordered PRs (this is #1). PRs #2-7 (Ollama engine → app integration → Settings UI → MLX-LM engine → bench wiring → corpus seed) can land independently on top of this base.

No behaviour change in the app — the polish step stays opt-in until PR #4 wires the user toggle, and even then the default `PolishEngineKind` is `.off`.

## Change

- `docs/SPECS/SPEC-007-llm-polish.md` — adds an "Atomic PR breakdown" section above the existing "Engines (implementation order)" section. 7 PRs with branch names, file lists, dependencies, effort.
- `Sources/OpenQuackKit/Polish/PolishEngine.swift` (new):
  - `protocol TextPolishEngine: AnyObject, Sendable` — contract: `engineName`, `requiresNetwork`, `modelLabel`, `polish(_:context:) async throws`
  - `struct PolishContext: Sendable, Equatable` — `language`, `foregroundApp`, `timestamp`
  - `enum PolishEngineKind: String, CaseIterable, Sendable` — `off`, `ollama`, `mlx-lm` (raw value matches docs)
  - `enum PolishError: Error, LocalizedError, Equatable` — `notConfigured`, `modelNotLoaded`, `timeout`, `backendUnavailable`, `decodingFailed`, each with a one-line `errorDescription`
- `Tests/OpenQuackKitTests/PolishEngineTests.swift` (new) — 6 tests:
  - `PolishContext` field round-trip
  - `PolishContext` defaults are `nil`
  - `PolishEngineKind` raw values are stable (`off` / `ollama` / `mlx-lm`)
  - `PolishEngineKind.allCases` is exhaustive
  - `PolishError` cases all return non-nil `errorDescription`
  - protocol is satisfiable by a minimal implementer (compile-time + runtime check)

## Tests

- [x] unit tests added: `PolishEngineTests` (6 cases, all pass)
- [x] `swift build && swift test` green (using Xcode toolchain locally; CI will exercise the same)

## Privacy impact

None — protocol surface only, no IO. The protocol's `requiresNetwork` accessor is exactly the hook the recording overlay reads to render the network indicator when a future engine is active. Per SPEC-007: loopback (Ollama at `localhost`) and in-process (MLX-LM) both report `false`.

## Out of scope

- Concrete engines (`OllamaPolishEngine`, `MLXLMPolishEngine`) — PRs #2 and #5 of the SPEC-007 sequence
- App-side pipeline wiring — PR #3
- Settings UI Polish pane — PR #4
- `openquack-polish-bench` integration — PR #6
- Domain-term + send-confidence corpus seed — PR #7