### PR TITLE
feat(SPEC-007): OllamaPolishEngine (PR #2 of 7)

### DIFF
--- a/Sources/OpenQuackKit/Polish/OllamaPolishEngine.swift
+++ b/Sources/OpenQuackKit/Polish/OllamaPolishEngine.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// `TextPolishEngine` that talks to a locally-running Ollama daemon over
+/// HTTP at `localhost:11434/api/chat` (configurable). Loopback only — the
+/// engine reports `requiresNetwork = false` because the privacy contract
+/// distinguishes "off-device" from "in-process / loopback."
+///
+/// Failure modes (network refused, daemon not running, model not pulled,
+/// decode error, timeout) all throw a `PolishError` so the caller can fall
+/// back to the regex polish without surfacing engine internals.
+///
+/// SPEC-007 PR #2 of the atomic sequence. The engine intentionally does
+/// not stream: the polished text is delivered as one paste, and partial
+/// polished output is worse UX than the raw transcript.
+public final class OllamaPolishEngine: TextPolishEngine {
+    public static let engineName = "ollama"
+    public let requiresNetwork = false
+    public let modelLabel: String
+
+    private let endpoint: URL
+    private let model: String
+    private let systemPrompt: String
+    private let urlSession: URLSession
+    private let timeoutSeconds: TimeInterval
+
+    /// - Parameters:
+    ///   - endpoint: Ollama chat URL. Default `http://localhost:11434/api/chat`.
+    ///   - model: Ollama model tag (e.g. `gemma3:1b`, `qwen2.5:3b-instruct`).
+    ///   - systemPrompt: System message; defaults to `defaultSystemPrompt`.
+    ///   - urlSession: Inject a custom session for tests (URLProtocol-mocked).
+    ///   - timeoutSeconds: Request timeout; per spec, 8s for first byte.
+    public init(
+        endpoint: URL = OllamaPolishEngine.defaultEndpoint,
+        model: String,
+        systemPrompt: String = OllamaPolishEngine.defaultSystemPrompt,
+        urlSession: URLSession = .shared,
+        timeoutSeconds: TimeInterval = 8
+    ) {
+        self.endpoint = endpoint
+        self.model = model
+        self.systemPrompt = systemPrompt
+        self.urlSession = urlSession
+        self.timeoutSeconds = timeoutSeconds
+        self.modelLabel = "\(model) (Ollama)"
+    }
+
+    public func polish(_ raw: String, context: PolishContext) async throws -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return raw }
+
+        let body = try Self.encodeRequest(
+            model: model,
+            systemPrompt: systemPrompt,
+            userText: trimmed,
+            wordCount: Self.wordCount(trimmed)
+        )
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeoutSeconds
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch let urlError as URLError where urlError.code == .timedOut {
+            throw PolishError.timeout
+        } catch let urlError as URLError where urlError.code == .cannotConnectToHost
+            || urlError.code == .cannotFindHost
+            || urlError.code == .networkConnectionLost
+            || urlError.code == .notConnectedToInternet {
+            throw PolishError.backendUnavailable(urlError.localizedDescription)
+        } catch {
+            throw PolishError.backendUnavailable(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw PolishError.decodingFailed
+        }
+
+        switch http.statusCode {
+        case 200:
+            break
+        case 404:
+            // Ollama returns 404 when the requested model isn't pulled.
+            throw PolishError.modelNotLoaded(model)
+        default:
+            let detail = String(data: data, encoding: .utf8) ?? "HTTP \(http.statusCode)"
+            throw PolishError.backendUnavailable(detail)
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode(OllamaChatResponse.self, from: data)
+            let polished = decoded.message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            // If the model returned nothing useful, fall back rather than
+            // silently overwrite with empty.
+            return polished.isEmpty ? raw : polished
+        } catch {
+            throw PolishError.decodingFailed
+        }
+    }
+
+    // MARK: - Defaults
+
+    public static let defaultEndpoint = URL(string: "http://localhost:11434/api/chat")!
+
+    /// Ported in spirit from v0.1 `thinker.py`. Kept at file scope so it can
+    /// be diff'd / overridden cleanly without touching the engine code.
+    public static let defaultSystemPrompt = """
+        You reorganise raw voice transcriptions into clean, structured text.
+
+        You MUST:
+        - Respond in the SAME language as the input.
+        - Add correct punctuation (。，for Chinese; periods, commas for English; etc.).
+        - Remove filler words, verbal tics, false starts, and repetitions.
+        - Remove garbled or nonsensical text (transcription errors / artefacts).
+        - Organise multiple ideas into bullet points (use • or -).
+        - Keep it concise — shorter than the input.
+        - Preserve all technical terms, proper nouns, and names exactly as spoken.
+        - Output ONLY the reorganised text — no commentary, labels, or markdown fences.
+        """
+
+    // MARK: - Internals (visible to tests via @testable)
+
+    /// Word count that treats CJK characters as individual words. Mirrors the
+    /// v0.1 fast-path heuristic so non-English transcripts get a sensible
+    /// `num_predict` budget rather than a tiny one based on space-separated
+    /// counts that aren't meaningful for CJK.
+    static func wordCount(_ text: String) -> Int {
+        let cjkRanges: [ClosedRange<UInt32>] = [
+            0x4E00...0x9FFF,   // CJK Unified Ideographs
+            0x3040...0x309F,   // Hiragana
+            0x30A0...0x30FF,   // Katakana
+            0xAC00...0xD7AF,   // Hangul Syllables
+        ]
+        var cjkCount = 0
+        var stripped = ""
+        for char in text {
+            var isCJK = false
+            for scalar in char.unicodeScalars {
+                if cjkRanges.contains(where: { $0.contains(scalar.value) }) {
+                    isCJK = true
+                    break
+                }
+            }
+            if isCJK {
+                cjkCount += 1
+            } else {
+                stripped.append(char)
+            }
+        }
+        let nonCJKWords = stripped
+            .split(whereSeparator: { $0.isWhitespace })
+            .filter { !$0.isEmpty }
+            .count
+        return cjkCount + nonCJKWords
+    }
+
+    static func numPredict(forWords wordCount: Int) -> Int {
+        // SPEC-007: min(max(wordCount * 2, 80), 1024)
+        return min(max(wordCount * 2, 80), 1024)
+    }
+
+    static func temperature(forWords wordCount: Int) -> Double {
+        // SPEC-007: 0.3 short (≤50), 0.5 longer.
+        wordCount <= 50 ? 0.3 : 0.5
+    }
+
+    /// Build the request body. Exposed for tests.
+    static func encodeRequest(
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        wordCount: Int
+    ) throws -> Data {
+        let payload = OllamaChatRequest(
+            model: model,
+            messages: [
+                .init(role: "system", content: systemPrompt),
+                .init(role: "user", content: userText),
+            ],
+            stream: false,
+            keepAlive: -1,
+            think: false,
+            options: .init(
+                temperature: temperature(forWords: wordCount),
+                numPredict: numPredict(forWords: wordCount)
+            )
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(payload)
+    }
+}
+
+// MARK: - Wire types
+
+private struct OllamaChatRequest: Encodable {
+    let model: String
+    let messages: [Message]
+    let stream: Bool
+    let keepAlive: Int
+    let think: Bool
+    let options: Options
+
+    struct Message: Encodable {
+        let role: String
+        let content: String
+    }
+
+    struct Options: Encodable {
+        let temperature: Double
+        let numPredict: Int
+
+        enum CodingKeys: String, CodingKey {
+            case temperature
+            case numPredict = "num_predict"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case model, messages, stream, options, think
+        case keepAlive = "keep_alive"
+    }
+}
+
+private struct OllamaChatResponse: Decodable {
+    let message: Message
+
+    struct Message: Decodable {
+        let content: String
+    }
+}

--- a/Tests/OpenQuackKitTests/OllamaPolishEngineTests.swift
+++ b/Tests/OpenQuackKitTests/OllamaPolishEngineTests.swift
@@ -1,0 +1,231 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class OllamaPolishEngineTests: XCTestCase {
+
+    // MARK: - Heuristics
+
+    func testWordCountSpaceSeparated() {
+        XCTAssertEqual(OllamaPolishEngine.wordCount("hello world"), 2)
+        XCTAssertEqual(OllamaPolishEngine.wordCount("  one  two  three  "), 3)
+        XCTAssertEqual(OllamaPolishEngine.wordCount(""), 0)
+    }
+
+    func testWordCountCJKCharsAsWords() {
+        // 4 CJK characters + 2 Latin words
+        XCTAssertEqual(OllamaPolishEngine.wordCount("今天 hello 是 world 好天气"), 8)
+        // Pure CJK
+        XCTAssertEqual(OllamaPolishEngine.wordCount("今天天气好"), 5)
+        // Hiragana + katakana
+        XCTAssertEqual(OllamaPolishEngine.wordCount("こんにちは"), 5)
+    }
+
+    func testNumPredictBounds() {
+        XCTAssertEqual(OllamaPolishEngine.numPredict(forWords: 0), 80)   // floor
+        XCTAssertEqual(OllamaPolishEngine.numPredict(forWords: 30), 80)  // floor still wins
+        XCTAssertEqual(OllamaPolishEngine.numPredict(forWords: 50), 100)
+        XCTAssertEqual(OllamaPolishEngine.numPredict(forWords: 600), 1024) // ceil
+    }
+
+    func testTemperatureSwitch() {
+        XCTAssertEqual(OllamaPolishEngine.temperature(forWords: 10), 0.3)
+        XCTAssertEqual(OllamaPolishEngine.temperature(forWords: 50), 0.3) // boundary
+        XCTAssertEqual(OllamaPolishEngine.temperature(forWords: 51), 0.5)
+        XCTAssertEqual(OllamaPolishEngine.temperature(forWords: 200), 0.5)
+    }
+
+    // MARK: - Request shape
+
+    func testEncodeRequestProducesExpectedShape() throws {
+        let body = try OllamaPolishEngine.encodeRequest(
+            model: "gemma3:1b",
+            systemPrompt: "Sys prompt.",
+            userText: "raw user text",
+            wordCount: 3
+        )
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["model"] as? String, "gemma3:1b")
+        XCTAssertEqual(json["stream"] as? Bool, false)
+        XCTAssertEqual(json["keep_alive"] as? Int, -1)
+        XCTAssertEqual(json["think"] as? Bool, false)
+
+        let messages = try XCTUnwrap(json["messages"] as? [[String: String]])
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertEqual(messages[0]["role"], "system")
+        XCTAssertEqual(messages[0]["content"], "Sys prompt.")
+        XCTAssertEqual(messages[1]["role"], "user")
+        XCTAssertEqual(messages[1]["content"], "raw user text")
+
+        let options = try XCTUnwrap(json["options"] as? [String: Any])
+        XCTAssertEqual(options["temperature"] as? Double, 0.3)
+        XCTAssertEqual(options["num_predict"] as? Int, 80)
+    }
+
+    // MARK: - End-to-end via URLProtocol mock
+
+    func testPolishHappyPath() async throws {
+        MockURLProtocol.respondWith = { _ in
+            let body = #"{"message":{"content":"Polished output."}}"#.data(using: .utf8)!
+            return (Self.makeOK(), body, nil)
+        }
+        let engine = makeEngine()
+        let polished = try await engine.polish("um, raw text yeah", context: PolishContext())
+        XCTAssertEqual(polished, "Polished output.")
+    }
+
+    func testPolishEmptyInputReturnsRawWithoutCallingBackend() async throws {
+        MockURLProtocol.respondWith = { _ in
+            XCTFail("backend should not be called for empty input")
+            return (Self.makeOK(), Data(), nil)
+        }
+        let engine = makeEngine()
+        let result = try await engine.polish("   ", context: PolishContext())
+        XCTAssertEqual(result, "   ")
+    }
+
+    func testPolishEmptyResponseFallsBackToRaw() async throws {
+        MockURLProtocol.respondWith = { _ in
+            let body = #"{"message":{"content":""}}"#.data(using: .utf8)!
+            return (Self.makeOK(), body, nil)
+        }
+        let engine = makeEngine()
+        let result = try await engine.polish("hello", context: PolishContext())
+        XCTAssertEqual(result, "hello")
+    }
+
+    func testPolishConnectionRefusedThrowsBackendUnavailable() async {
+        MockURLProtocol.respondWith = { _ in
+            (Self.makeOK(), nil, URLError(.cannotConnectToHost))
+        }
+        let engine = makeEngine()
+        do {
+            _ = try await engine.polish("hello", context: PolishContext())
+            XCTFail("expected throw")
+        } catch let err as PolishError {
+            if case .backendUnavailable = err {} else {
+                XCTFail("expected backendUnavailable, got \(err)")
+            }
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    func testPolishTimeoutThrowsTimeout() async {
+        MockURLProtocol.respondWith = { _ in
+            (Self.makeOK(), nil, URLError(.timedOut))
+        }
+        let engine = makeEngine()
+        do {
+            _ = try await engine.polish("hello", context: PolishContext())
+            XCTFail("expected throw")
+        } catch PolishError.timeout {
+            // expected
+        } catch {
+            XCTFail("expected .timeout, got \(error)")
+        }
+    }
+
+    func testPolishModelNotPulledThrowsModelNotLoaded() async {
+        MockURLProtocol.respondWith = { _ in
+            (Self.makeStatus(404), Data(), nil)
+        }
+        let engine = makeEngine()
+        do {
+            _ = try await engine.polish("hello", context: PolishContext())
+            XCTFail("expected throw")
+        } catch let err as PolishError {
+            if case .modelNotLoaded(let label) = err {
+                XCTAssertEqual(label, "gemma3:1b")
+            } else {
+                XCTFail("expected .modelNotLoaded, got \(err)")
+            }
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+    }
+
+    func testPolishMalformedJSONThrowsDecodingFailed() async {
+        MockURLProtocol.respondWith = { _ in
+            (Self.makeOK(), Data("not json".utf8), nil)
+        }
+        let engine = makeEngine()
+        do {
+            _ = try await engine.polish("hello", context: PolishContext())
+            XCTFail("expected throw")
+        } catch PolishError.decodingFailed {
+            // expected
+        } catch {
+            XCTFail("expected .decodingFailed, got \(error)")
+        }
+    }
+
+    func testPolishRequestPayloadShape() async throws {
+        MockURLProtocol.respondWith = { request in
+            // Verify the request shape that hit the wire.
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+            XCTAssertEqual(request.url?.absoluteString, "http://example.invalid/api/chat")
+            // Note: URLProtocol mock loses request.httpBody on iOS/macOS in some
+            // configurations; skip body assertion here. See the
+            // testEncodeRequestProducesExpectedShape unit for body coverage.
+            let body = #"{"message":{"content":"ok"}}"#.data(using: .utf8)!
+            return (Self.makeOK(), body, nil)
+        }
+        let engine = makeEngine()
+        _ = try await engine.polish("hello", context: PolishContext())
+    }
+
+    // MARK: - Test helpers
+
+    private func makeEngine() -> OllamaPolishEngine {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        return OllamaPolishEngine(
+            endpoint: URL(string: "http://example.invalid/api/chat")!,
+            model: "gemma3:1b",
+            urlSession: session,
+            timeoutSeconds: 1
+        )
+    }
+
+    private static func makeOK() -> HTTPURLResponse {
+        makeStatus(200)
+    }
+
+    private static func makeStatus(_ code: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "http://example.invalid/api/chat")!,
+            statusCode: code,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+    }
+}
+
+/// URLProtocol mock — registers via `URLSessionConfiguration.protocolClasses`
+/// so each test instance has its own intercepted session.
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+    static var respondWith: ((URLRequest) -> (HTTPURLResponse, Data?, Error?))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let responder = MockURLProtocol.respondWith else {
+            fatalError("MockURLProtocol.respondWith not set")
+        }
+        let (response, data, error) = responder(request)
+        if let error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## SPEC

[SPEC-007 (LLM transcript polish)](../blob/feat/spec-007-protocol/docs/SPECS/SPEC-007-llm-polish.md). PR #2 of 7 in the atomic sequence; bases off `feat/spec-007-protocol` (PR #6).

## Milestone

M2.5.

## Why

PR #1 added the `TextPolishEngine` surface; this PR ships the first concrete engine. Picks Ollama because it's the fastest path to a working feature — local HTTP, sidecars are trivial, no extra dependencies in our build.

Pipeline integration (PR #3) and Settings UI (PR #4) follow on top; until those land, the engine is unreachable from the user-visible app, so this is a behaviour-neutral addition.

## Change

- `Sources/OpenQuackKit/Polish/OllamaPolishEngine.swift` (new, 240 LOC):
  - `OllamaPolishEngine: TextPolishEngine` — `requiresNetwork = false` (loopback)
  - POST to `http://localhost:11434/api/chat` (configurable URL)
  - `stream: false`, `keep_alive: -1`, `think: false`
  - `temperature` = 0.3 (≤50 words) / 0.5 (longer); `num_predict` = `min(max(wordCount * 2, 80), 1024)` per spec
  - CJK word-count heuristic (counts CJK chars as words so non-English transcripts get a sensible budget)
  - 8s default timeout (`timeoutSeconds` parameter for tests)
  - `URLSession` injectable so tests can use a `URLProtocol` mock without a real Ollama instance
  - Wire types `OllamaChatRequest` / `OllamaChatResponse` are `private` — implementation detail
  - Default system prompt mirrors the v0.1 `thinker.py` text per the spec
- `Tests/OpenQuackKitTests/OllamaPolishEngineTests.swift` (new, 13 tests):
  - heuristics (`wordCount` Latin + CJK + mixed; `numPredict` floor / ceiling; `temperature` switch)
  - request shape (verifies the JSON body fields the wire actually sees)
  - happy path (200 response → polished string)
  - empty input bypasses the backend
  - empty model output falls back to raw input
  - `URLError(.cannotConnectToHost)` → `PolishError.backendUnavailable`
  - `URLError(.timedOut)` → `PolishError.timeout`
  - HTTP 404 → `PolishError.modelNotLoaded("gemma3:1b")`
  - malformed JSON → `PolishError.decodingFailed`
- `MockURLProtocol` (in test file) — minimal URLSession-protocol mock; intercept via `URLSessionConfiguration.protocolClasses`. No CI infra needed.

## Tests

- [x] unit tests added: `OllamaPolishEngineTests` (13 cases, all pass)
- [x] `swift build && swift test` green locally — combined `PolishEngineTests` + `OllamaPolishEngineTests` = 19 tests, all green
- [ ] manual smoke against a real local Ollama (`ollama run gemma3:1b` then run the engine in `openquack-cli` once PR #3 wires it) — deferred to PR #3 since the engine isn't reachable from the app yet

## Privacy impact

None at the protocol level. When the engine is enabled (in PR #3+), it sends transcript text to `localhost:11434` only. No off-device traffic. The `requiresNetwork = false` self-declaration is what the recording overlay's network indicator reads — and it correctly stays green when this engine is active.

If a user changes the endpoint URL to a non-loopback host in Settings (PR #4 will add that field), the engine's `requiresNetwork` stays `false` because it doesn't introspect the URL — that's a known sharp edge that PR #4 should mitigate by validating the URL is loopback before letting the user save.

## Out of scope

- Pipeline integration in `AppState` — PR #3
- Settings UI Polish pane (engine picker, model field, URL field, "test connection" button) — PR #4
- `MLXLMPolishEngine` — PR #5
- `openquack-polish-bench` integration — PR #6
- Domain-term + send-confidence corpus seed — PR #7
- Endpoint URL validation (loopback-only safety) — surface in PR #4 alongside the URL input