### PR TITLE
feat(SPEC-007): pipeline integration in AppDelegate (PR #3 of 7)

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -65,6 +65,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.bool(forKey: "saveAudio")
     }
 
+    // SPEC-007 PR #3 — optional LLM polish before the regex pass.
+    // Default `polishEngine = "off"` so behaviour is unchanged for users
+    // who don't opt in; Settings → Polish (PR #4) surfaces the toggle.
+    private var polishEngineKind: PolishEngineKind {
+        let raw = UserDefaults.standard.string(forKey: "polishEngine") ?? "off"
+        return PolishEngineKind(rawValue: raw) ?? .off
+    }
+    private var polishOllamaURLValue: URL {
+        let raw = UserDefaults.standard.string(forKey: "polishOllamaURL") ?? ""
+        return URL(string: raw) ?? OllamaPolishEngine.defaultEndpoint
+    }
+    private var polishOllamaModel: String {
+        UserDefaults.standard.string(forKey: "polishOllamaModel") ?? ""
+    }
+
+    /// Resolve current settings into a `TextPolishEngine`. Returns `nil`
+    /// when polish is off or unconfigured — the dictation pipeline treats
+    /// `nil` exactly like a throwing engine and runs only the regex pass.
+    /// Cheap to call per dictation: the engine init does not load weights;
+    /// `keep_alive: -1` keeps Ollama warm server-side.
+    private func currentPolishEngine() -> TextPolishEngine? {
+        PolishPipeline.makeEngine(
+            kind: polishEngineKind,
+            ollamaURL: polishOllamaURLValue,
+            ollamaModel: polishOllamaModel
+        )
+    }
+
     private var lastVoiceAt: Date?
     private static let voiceThreshold: Float = 0.06
     private static let vadMinDuration: Double = 0.8
@@ -610,12 +638,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // script preference before any other text shaping.
                 let scripted = ChineseScriptConverter.convert(result.text, to: chineseScript)
 
+                // SPEC-007 PR #3: optional LLM polish before the regex
+                // pass. `nil` engine or any throw → fall back to `scripted`
+                // so the regex pass below is the unconditional safety net.
+                let llmPolished = await PolishPipeline.applyLLMPolish(
+                    scripted,
+                    engine: currentPolishEngine(),
+                    context: PolishContext(
+                        language: result.detectedLanguage,
+                        foregroundApp: nil,
+                        timestamp: Date()
+                    )
+                )
+
                 // Smart formatting on raw Whisper output (capitalisation,
                 // end-punctuation, fillers). Toggle: Settings → General.
                 let polishEnabled = UserDefaults.standard.object(forKey: "polishText") as? Bool ?? true
                 let polished = polishEnabled
-                    ? TextPolisher.polish(scripted)
-                    : scripted
+                    ? TextPolisher.polish(llmPolished)
+                    : llmPolished
 
                 // Hold the progress bar at full briefly so the user sees the
                 // transition land instead of jumping straight to "Pasted".
@@ -821,8 +862,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 customWords: customWords
             )
             let scripted = ChineseScriptConverter.convert(result.text, to: chineseScript)
+            // SPEC-007 PR #3: same LLM-polish-then-regex chain as the main
+            // path; recovery is best-effort, errors silently fall through.
+            let llmPolished = await PolishPipeline.applyLLMPolish(
+                scripted,
+                engine: currentPolishEngine(),
+                context: PolishContext(
+                    language: result.detectedLanguage,
+                    foregroundApp: nil,
+                    timestamp: Date()
+                )
+            )
             let polishEnabled = UserDefaults.standard.object(forKey: "polishText") as? Bool ?? true
-            let polished = polishEnabled ? TextPolisher.polish(scripted) : scripted
+            let polished = polishEnabled ? TextPolisher.polish(llmPolished) : llmPolished
             let autoPasteEnabled = UserDefaults.standard.object(forKey: "autoPaste") as? Bool ?? true
             if autoPasteEnabled {
                 _ = PasteService.paste(polished)

--- a/Sources/OpenQuackKit/Polish/PolishPipeline.swift
+++ b/Sources/OpenQuackKit/Polish/PolishPipeline.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Helpers that wire `TextPolishEngine` into the dictation pipeline.
+///
+/// PR #3 of SPEC-007. Keeps the AppDelegate integration thin: a factory
+/// that resolves user settings into an engine instance, and a single-call
+/// "apply polish, fall back on failure" wrapper. Both are pure functions
+/// over their inputs so they can be unit-tested without an app.
+public enum PolishPipeline {
+
+    /// Build a `TextPolishEngine` from user settings, or return `nil` if
+    /// polish is off / not yet configured. The caller treats `nil` exactly
+    /// like an engine that throws — the dictation pipeline still runs the
+    /// regex `TextPolisher` afterward.
+    ///
+    /// Returning `nil` (instead of an `OffEngine` instance) is deliberate:
+    /// the caller's `if let engine = ...` short-circuit avoids the Swift
+    /// Concurrency cost of an unnecessary `await` on the no-op path.
+    public static func makeEngine(
+        kind: PolishEngineKind,
+        ollamaURL: URL,
+        ollamaModel: String,
+        urlSession: URLSession = .shared
+    ) -> TextPolishEngine? {
+        switch kind {
+        case .off:
+            return nil
+        case .ollama:
+            // Empty model = user hasn't picked one yet. Treat as off so we
+            // don't issue a request the daemon will 404 on.
+            guard !ollamaModel.trimmingCharacters(in: .whitespaces).isEmpty else {
+                return nil
+            }
+            return OllamaPolishEngine(
+                endpoint: ollamaURL,
+                model: ollamaModel,
+                urlSession: urlSession
+            )
+        case .mlxLM:
+            // PR #5 of SPEC-007 lands MLXLMPolishEngine. Until then, treat
+            // as off so a half-configured Settings pane doesn't drop the
+            // user's transcript on the floor.
+            return nil
+        }
+    }
+
+    /// Apply LLM polish if the engine is configured. On any throw or `nil`
+    /// engine, return the input unchanged so the caller's regex polish
+    /// (`TextPolisher.polish`) can still run as the safety net.
+    ///
+    /// This wrapper is the *only* place LLM-polish errors are caught in the
+    /// dictation hot path. Engines must throw on any failure (timeout,
+    /// model not loaded, decode error) — they must not return a partial /
+    /// broken polished string. See `PolishError` for the cases.
+    public static func applyLLMPolish(
+        _ raw: String,
+        engine: TextPolishEngine?,
+        context: PolishContext
+    ) async -> String {
+        guard let engine else { return raw }
+        do {
+            return try await engine.polish(raw, context: context)
+        } catch {
+            // The caller has the original `raw` text via the regex polish
+            // step, so a swallowed error here is the right call. We do not
+            // log because the dictation hot path is also the privacy hot
+            // path — engine identity / failure mode is not for telemetry.
+            return raw
+        }
+    }
+}

--- a/Tests/OpenQuackKitTests/PolishPipelineTests.swift
+++ b/Tests/OpenQuackKitTests/PolishPipelineTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class PolishPipelineTests: XCTestCase {
+
+    // MARK: - makeEngine
+
+    func testMakeEngineOffReturnsNil() {
+        let engine = PolishPipeline.makeEngine(
+            kind: .off,
+            ollamaURL: URL(string: "http://localhost:11434/api/chat")!,
+            ollamaModel: "gemma3:1b"
+        )
+        XCTAssertNil(engine)
+    }
+
+    func testMakeEngineOllamaWithModelReturnsEngine() {
+        let engine = PolishPipeline.makeEngine(
+            kind: .ollama,
+            ollamaURL: URL(string: "http://localhost:11434/api/chat")!,
+            ollamaModel: "gemma3:1b"
+        )
+        XCTAssertNotNil(engine)
+        XCTAssertEqual(type(of: engine!).engineName, "ollama")
+    }
+
+    func testMakeEngineOllamaWithEmptyModelReturnsNil() {
+        let engine = PolishPipeline.makeEngine(
+            kind: .ollama,
+            ollamaURL: URL(string: "http://localhost:11434/api/chat")!,
+            ollamaModel: ""
+        )
+        XCTAssertNil(engine, "empty model should be treated as off")
+    }
+
+    func testMakeEngineOllamaWithWhitespaceModelReturnsNil() {
+        let engine = PolishPipeline.makeEngine(
+            kind: .ollama,
+            ollamaURL: URL(string: "http://localhost:11434/api/chat")!,
+            ollamaModel: "   "
+        )
+        XCTAssertNil(engine)
+    }
+
+    func testMakeEngineMlxLMReturnsNilUntilPR5() {
+        let engine = PolishPipeline.makeEngine(
+            kind: .mlxLM,
+            ollamaURL: URL(string: "http://localhost:11434/api/chat")!,
+            ollamaModel: "qwen2.5:1.5b-instruct"
+        )
+        XCTAssertNil(engine, "MLX-LM engine lands in SPEC-007 PR #5; until then, .mlxLM is a no-op")
+    }
+
+    // MARK: - applyLLMPolish
+
+    func testApplyLLMPolishWithNilEngineReturnsRaw() async {
+        let result = await PolishPipeline.applyLLMPolish(
+            "raw text",
+            engine: nil,
+            context: PolishContext()
+        )
+        XCTAssertEqual(result, "raw text")
+    }
+
+    func testApplyLLMPolishWithSucceedingEngineReturnsEngineOutput() async {
+        final class StubEngine: TextPolishEngine {
+            static let engineName = "stub-ok"
+            let requiresNetwork = false
+            let modelLabel = "stub"
+            func polish(_ raw: String, context: PolishContext) async throws -> String {
+                "polished: " + raw
+            }
+        }
+        let result = await PolishPipeline.applyLLMPolish(
+            "raw text",
+            engine: StubEngine(),
+            context: PolishContext()
+        )
+        XCTAssertEqual(result, "polished: raw text")
+    }
+
+    func testApplyLLMPolishWithThrowingEngineReturnsRaw() async {
+        final class ThrowingEngine: TextPolishEngine {
+            static let engineName = "stub-throws"
+            let requiresNetwork = false
+            let modelLabel = "stub"
+            func polish(_ raw: String, context: PolishContext) async throws -> String {
+                throw PolishError.timeout
+            }
+        }
+        let result = await PolishPipeline.applyLLMPolish(
+            "raw text",
+            engine: ThrowingEngine(),
+            context: PolishContext()
+        )
+        XCTAssertEqual(result, "raw text", "engine throw must fall back to raw")
+    }
+
+    func testApplyLLMPolishPassesContextToEngine() async {
+        final class CapturingEngine: TextPolishEngine, @unchecked Sendable {
+            static let engineName = "stub-capture"
+            let requiresNetwork = false
+            let modelLabel = "stub"
+            var capturedContext: PolishContext?
+            func polish(_ raw: String, context: PolishContext) async throws -> String {
+                capturedContext = context
+                return raw
+            }
+        }
+        let engine = CapturingEngine()
+        let ctx = PolishContext(language: "en", foregroundApp: "Cursor")
+        _ = await PolishPipeline.applyLLMPolish("hello", engine: engine, context: ctx)
+        XCTAssertEqual(engine.capturedContext?.language, "en")
+        XCTAssertEqual(engine.capturedContext?.foregroundApp, "Cursor")
+    }
+}


### PR DESCRIPTION
## SPEC

[SPEC-007 (LLM transcript polish)](../blob/feat/spec-007-protocol/docs/SPECS/SPEC-007-llm-polish.md). PR #3 of 7 in the atomic sequence; bases off `feat/spec-007-ollama-engine` (PR #7).

## Milestone

M2.5.

## Why

PR #1 added the protocol surface; PR #2 added the concrete `OllamaPolishEngine`. Without this PR, both are dead code — the engine isn't reachable from the dictation hot path. PR #3 wires it in **off by default**: behaviour is unchanged for users who don't opt in, and the user-facing toggle lands in PR #4 (Settings UI).

The pipeline becomes:

```
Whisper → ChineseScript convert → optional LLM polish (this PR)
                                → optional regex TextPolisher
                                → paste at cursor
```

If the LLM engine is `nil` (default — user hasn't picked one) or throws (timeout, model-not-loaded, HTTP 5xx, decode-fail), `applyLLMPolish` returns the input unchanged so the existing regex `TextPolisher.polish` is the unconditional safety net. Engine errors are swallowed by design — the dictation hot path is also the privacy hot path; engine identity / failure mode is not for telemetry.

## Change

- `Sources/OpenQuackKit/Polish/PolishPipeline.swift` (new):
  - `PolishPipeline.makeEngine(kind:ollamaURL:ollamaModel:)` — factory that resolves user settings into an engine instance. Returns `nil` for `.off` / empty model / `.mlxLM` (deferred to PR #5).
  - `PolishPipeline.applyLLMPolish(_:engine:context:)` — single-call "apply, fall back on throw" wrapper for the dictation hot path.
- `Tests/OpenQuackKitTests/PolishPipelineTests.swift` (new) — 9 tests:
  - `makeEngine` for `.off` (returns nil), `.ollama` with model (returns engine), `.ollama` with empty model (nil), `.ollama` with whitespace model (nil), `.mlxLM` (nil — deferred)
  - `applyLLMPolish` for nil engine (returns raw), succeeding engine (returns engine output), throwing engine (returns raw), context pass-through (engine receives the right `language`/`foregroundApp`)
- `Sources/OpenQuackApp/OpenQuackApp.swift` (edit):
  - 3 new private computed properties — `polishEngineKind`, `polishOllamaURLValue`, `polishOllamaModel` — all read from UserDefaults (defaults: `"off"` / Ollama default endpoint / empty)
  - `currentPolishEngine()` private helper — wraps `PolishPipeline.makeEngine`
  - `stopAndTranscribe` — adds `applyLLMPolish` between `scripted` and the regex polish step
  - `recoverEntry` — same chain for the history-recovery path

## Tests

- [x] unit tests added: `PolishPipelineTests` (9 cases, all pass)
- [x] `swift build && swift test` green locally — **81 tests pass** (9 new + 72 existing); no regressions
- [ ] manual smoke against a real local Ollama:
  1. `ollama pull gemma3:1b` (or any small model)
  2. `ollama serve` (if not already running)
  3. `defaults write com.larryxiao.openquack polishEngine ollama`
  4. `defaults write com.larryxiao.openquack polishOllamaModel gemma3:1b`
  5. Press the dictation hotkey, speak a multi-clause sentence, verify polish applied (transcript reads cleaner than raw)
  6. Quit Ollama mid-flight, dictate again — verify graceful fall-back to regex-only

## Privacy impact

- `requiresNetwork = false` per `OllamaPolishEngine` (loopback only). The recording overlay's future network indicator (later PR) will read this accessor and stay green for Ollama / MLX-LM.
- When the engine is **off** (default), there is **zero behaviour change** — same code path as before this PR.
- When the engine is **on**, transcript text is sent to `localhost:11434` only. No off-device traffic. Privacy contract is preserved.
- A future Settings UI (PR #4) needs to validate the URL is loopback before letting the user save — flagged in PR #2's "Out of scope" and reiterated here.

## Out of scope

- Settings UI (engine picker, model field, URL validation, "test connection" button) — PR #4
- `MLXLMPolishEngine` — PR #5
- `openquack-polish-bench` integration — PR #6
- Domain-term + send-confidence corpus seed — PR #7
- Live recording-overlay network indicator surface — separate spec