### PR TITLE
feat(SPEC-007): Settings → Polish pane (PR #4 of 7)

### DIFF
--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -12,7 +12,7 @@ import OpenQuackKit
 // "reception" pane and uses CreamSurface + serif titles.
 
 struct SettingsView: View {
-    enum Tab: Hashable { case general, shortcut, stats, history, about }
+    enum Tab: Hashable { case general, shortcut, polish, stats, history, about }
     @State private var selection: Tab = .general
     @ObservedObject var appState: AppState
 
@@ -24,6 +24,9 @@ struct SettingsView: View {
             ShortcutPane()
                 .tabItem { Label("Shortcut", systemImage: "command") }
                 .tag(Tab.shortcut)
+            PolishPane()
+                .tabItem { Label("Polish", systemImage: "wand.and.stars") }
+                .tag(Tab.polish)
             StatsPane()
                 .tabItem { Label("Stats", systemImage: "chart.bar") }
                 .tag(Tab.stats)
@@ -181,6 +184,162 @@ private struct ShortcutPane: View {
         .padding()
         .creamSettingsBackground()
     }
+}
+
+// MARK: - Polish
+
+/// SPEC-007 PR #4 — Settings → Polish pane. Picks the LLM polish engine,
+/// configures it, and runs a one-shot test against a fixed string so the
+/// user can verify the local daemon is reachable before relying on it
+/// during dictation.
+///
+/// Default engine is Off; turning it on routes transcripts through the
+/// chosen engine before the existing regex polish step. The engine
+/// `requiresNetwork = false` claim is enforced here by validating the
+/// URL is loopback — non-loopback URLs are blocked with a red message.
+private struct PolishPane: View {
+    @AppStorage("polishEngine")      private var polishEngine: String = "off"
+    @AppStorage("polishOllamaURL")   private var polishOllamaURL: String = "http://localhost:11434/api/chat"
+    @AppStorage("polishOllamaModel") private var polishOllamaModel: String = ""
+
+    @State private var isTesting = false
+    @State private var testOutput: String? = nil
+    @State private var testError: String? = nil
+
+    private static let testInput = "um so this is a test of the local polish engine yeah it should clean up the fillers"
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Engine", selection: $polishEngine) {
+                    Text("Off — regex polish only").tag("off")
+                    Text("Ollama — local HTTP daemon").tag("ollama")
+                    Text("MLX-LM — in-process (coming soon)").tag("mlx-lm")
+                }
+                .help("Off is the default. Picking Ollama or MLX-LM routes the transcript through a small local LLM before paste, on top of the existing regex polish (Settings → General).")
+                if polishEngine == "mlx-lm" {
+                    Text("MLX-LM lands in a later release. For now, falls back to regex polish only.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.amber)
+                }
+                Text("Polish runs locally. Audio still never leaves your Mac. Transcript text is sent only to the engine you pick — Ollama on `localhost`, or MLX-LM in-process.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                SectionHeader("Engine")
+            }
+
+            if polishEngine == "ollama" {
+                Section {
+                    LabeledContent("Endpoint URL") {
+                        TextField("http://localhost:11434/api/chat", text: $polishOllamaURL)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                    if !polishOllamaURL.isEmpty && !PolishPipeline.isLoopback(polishOllamaURL) {
+                        Label(
+                            "Endpoint must be loopback (localhost / 127.0.0.1 / ::1). Non-loopback URLs would send transcript text off-device — blocked by the privacy contract.",
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                    }
+                    LabeledContent("Model") {
+                        TextField("e.g. gemma3:1b", text: $polishOllamaModel)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                    Text("List installed models with `ollama list` in Terminal. The model stays warm between calls (`keep_alive=-1`).")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    SectionHeader("Ollama")
+                }
+
+                Section {
+                    HStack {
+                        Button(isTesting ? "Testing…" : "Test connection") {
+                            Task { await runTest() }
+                        }
+                        .disabled(!canTest)
+                        if isTesting {
+                            ProgressView().controlSize(.small)
+                        }
+                        Spacer()
+                    }
+                    if let testOutput {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label("Polished:", systemImage: "checkmark.circle.fill")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Theme.moss)
+                            Text(testOutput)
+                                .font(.caption)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(8)
+                                .background(Theme.moss.opacity(0.08))
+                                .cornerRadius(6)
+                        }
+                    }
+                    if let testError {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label("Failed:", systemImage: "xmark.circle.fill")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.red)
+                            Text(testError)
+                                .font(.caption)
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(8)
+                                .background(Color.red.opacity(0.08))
+                                .cornerRadius(6)
+                        }
+                    }
+                    Text("Sends a fixed test string to the engine. The result is shown above. Failures here mean Ollama isn't running, the model isn't pulled, or the URL is wrong — the dictation pipeline silently falls back to regex polish in that case.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    SectionHeader("Test")
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .creamSettingsBackground()
+    }
+
+    private var canTest: Bool {
+        !isTesting
+            && !polishOllamaModel.trimmingCharacters(in: .whitespaces).isEmpty
+            && PolishPipeline.isLoopback(polishOllamaURL)
+    }
+
+    private func runTest() async {
+        isTesting = true
+        testOutput = nil
+        testError = nil
+        defer { isTesting = false }
+
+        guard let url = URL(string: polishOllamaURL) else {
+            testError = "Invalid URL."
+            return
+        }
+        let engine = OllamaPolishEngine(
+            endpoint: url,
+            model: polishOllamaModel,
+            timeoutSeconds: 12  // generous on first call when Ollama loads the model
+        )
+        do {
+            let polished = try await engine.polish(
+                Self.testInput,
+                context: PolishContext(language: "en")
+            )
+            testOutput = polished
+        } catch let err as PolishError {
+            testError = err.errorDescription ?? "\(err)"
+        } catch {
+            testError = "\(error.localizedDescription)"
+        }
+    }
+
 }
 
 // MARK: - About

--- a/Sources/OpenQuackKit/Polish/PolishPipeline.swift
+++ b/Sources/OpenQuackKit/Polish/PolishPipeline.swift
@@ -31,6 +31,12 @@ public enum PolishPipeline {
             guard !ollamaModel.trimmingCharacters(in: .whitespaces).isEmpty else {
                 return nil
             }
+            // Privacy contract: the engine self-reports
+            // `requiresNetwork = false`, so the URL has to be validated at
+            // the construction boundary. Non-loopback URLs would silently
+            // leak transcript text off-device. Settings → Polish blocks
+            // them visually; this check is the load-bearing enforcement.
+            guard isLoopback(ollamaURL) else { return nil }
             return OllamaPolishEngine(
                 endpoint: ollamaURL,
                 model: ollamaModel,

--- a/Sources/OpenQuackKit/Polish/PolishPipeline.swift
+++ b/Sources/OpenQuackKit/Polish/PolishPipeline.swift
@@ -44,6 +44,29 @@ public enum PolishPipeline {
         }
     }
 
+    /// Whether a URL's host is a loopback address. Used by Settings UI to
+    /// block non-loopback Ollama endpoints — the privacy contract is "no
+    /// off-device traffic from the polish path", and the engine itself
+    /// claims `requiresNetwork = false` regardless of URL, so the URL has
+    /// to be validated up front.
+    ///
+    /// Recognised loopback forms: `localhost`, `127.0.0.1`, `::1`,
+    /// `[::1]`. LAN IPs (192.168.*, 10.*, 172.16-31.*) are deliberately
+    /// rejected — RFC-1918 ranges still leak transcript text to other
+    /// machines on the network.
+    public static func isLoopback(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString) else { return false }
+        return isLoopback(url)
+    }
+
+    public static func isLoopback(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        return host == "localhost"
+            || host == "127.0.0.1"
+            || host == "::1"
+            || host == "[::1]"
+    }
+
     /// Apply LLM polish if the engine is configured. On any throw or `nil`
     /// engine, return the input unchanged so the caller's regex polish
     /// (`TextPolisher.polish`) can still run as the safety net.

--- a/Tests/OpenQuackKitTests/PolishPipelineTests.swift
+++ b/Tests/OpenQuackKitTests/PolishPipelineTests.swift
@@ -96,6 +96,39 @@ final class PolishPipelineTests: XCTestCase {
         XCTAssertEqual(result, "raw text", "engine throw must fall back to raw")
     }
 
+    // MARK: - isLoopback (URL validation for the Settings UI)
+
+    func testIsLoopbackAcceptsCanonicalForms() {
+        XCTAssertTrue(PolishPipeline.isLoopback("http://localhost:11434/api/chat"))
+        XCTAssertTrue(PolishPipeline.isLoopback("http://127.0.0.1:11434/api/chat"))
+        XCTAssertTrue(PolishPipeline.isLoopback("http://[::1]:11434/api/chat"))
+        XCTAssertTrue(PolishPipeline.isLoopback("https://localhost/api/chat"))
+    }
+
+    func testIsLoopbackCaseInsensitive() {
+        XCTAssertTrue(PolishPipeline.isLoopback("http://LOCALHOST:11434/api/chat"))
+        XCTAssertTrue(PolishPipeline.isLoopback("http://LocalHost:11434/api/chat"))
+    }
+
+    func testIsLoopbackRejectsLANIPs() {
+        XCTAssertFalse(PolishPipeline.isLoopback("http://192.168.1.5:11434/api/chat"),
+                       "LAN IPs leak transcript to other machines on the network")
+        XCTAssertFalse(PolishPipeline.isLoopback("http://10.0.0.1:11434/api/chat"))
+        XCTAssertFalse(PolishPipeline.isLoopback("http://172.16.0.1:11434/api/chat"))
+    }
+
+    func testIsLoopbackRejectsPublicHosts() {
+        XCTAssertFalse(PolishPipeline.isLoopback("https://api.openai.com/v1/chat/completions"))
+        XCTAssertFalse(PolishPipeline.isLoopback("http://example.com:11434/api/chat"))
+    }
+
+    func testIsLoopbackRejectsMalformedURLs() {
+        XCTAssertFalse(PolishPipeline.isLoopback("not a url"))
+        XCTAssertFalse(PolishPipeline.isLoopback(""))
+        // Schemeless host doesn't parse as a host with URL(string:) — must reject.
+        XCTAssertFalse(PolishPipeline.isLoopback("localhost:11434"))
+    }
+
     func testApplyLLMPolishPassesContextToEngine() async {
         final class CapturingEngine: TextPolishEngine, @unchecked Sendable {
             static let engineName = "stub-capture"

--- a/Tests/OpenQuackKitTests/PolishPipelineTests.swift
+++ b/Tests/OpenQuackKitTests/PolishPipelineTests.swift
@@ -42,6 +42,26 @@ final class PolishPipelineTests: XCTestCase {
         XCTAssertNil(engine)
     }
 
+    func testMakeEngineOllamaWithNonLoopbackURLReturnsNil() {
+        // Privacy contract: non-loopback URLs are blocked at engine
+        // construction, not just at the Settings UI surface.
+        let engine = PolishPipeline.makeEngine(
+            kind: .ollama,
+            ollamaURL: URL(string: "http://192.168.1.5:11434/api/chat")!,
+            ollamaModel: "gemma3:1b"
+        )
+        XCTAssertNil(engine, "non-loopback URL must not produce an engine even with a valid model")
+    }
+
+    func testMakeEngineOllamaWithPublicURLReturnsNil() {
+        let engine = PolishPipeline.makeEngine(
+            kind: .ollama,
+            ollamaURL: URL(string: "https://api.openai.com/v1/chat/completions")!,
+            ollamaModel: "gpt-4"
+        )
+        XCTAssertNil(engine)
+    }
+
     func testMakeEngineMlxLMReturnsNilUntilPR5() {
         let engine = PolishPipeline.makeEngine(
             kind: .mlxLM,


### PR DESCRIPTION
## SPEC

[SPEC-007 (LLM transcript polish)](../blob/feat/spec-007-protocol/docs/SPECS/SPEC-007-llm-polish.md). PR #4 of 7. Bases off `feat/spec-007-app-integration` (PR #8).

## Milestone

M2.5.

## Why

PR #3 wired the polish pipeline behind UserDefaults but left no in-app way to turn it on — users would have had to `defaults write com.larryxiao.openquack polishEngine ollama` and `polishOllamaModel gemma3:1b` from Terminal. This PR makes polish discoverable: a new Settings tab with the engine picker, configuration fields, and a one-shot "test connection" button that verifies the daemon is reachable before the user finds out mid-dictation.

It also closes the privacy hole flagged in PR #2's "Out of scope": the engine self-reports `requiresNetwork = false` regardless of URL, so the URL has to be validated at the input boundary AND at the engine-construction boundary. This PR does both.

## Change

- `Sources/OpenQuackApp/SettingsView.swift` (edit):
  - `Tab.polish` added between Shortcut and Stats
  - new `private struct PolishPane: View`:
    - **Engine** picker: Off (default) / Ollama / MLX-LM. The MLX-LM option is shown but disabled with a "coming soon" amber note; PR #5 lights it up.
    - **Ollama** section (visible only when engine == ollama):
      - Endpoint URL field (default `http://localhost:11434/api/chat`). Red banner shown if URL is not loopback.
      - Model field (default empty; helper text "e.g. gemma3:1b").
    - **Test** section (visible only when engine == ollama):
      - "Test connection" button — disabled if model empty or URL non-loopback. Sends a fixed test string to the engine, shows polished output (green) or `PolishError.errorDescription` (red).
- `Sources/OpenQuackKit/Polish/PolishPipeline.swift` (edit):
  - `public static func isLoopback(_ urlString: String) -> Bool`
  - `public static func isLoopback(_ url: URL) -> Bool`
  - **`makeEngine` now enforces loopback for the `.ollama` case** — returns nil for non-loopback URLs, same as for the off state. The dictation pipeline silently uses the regex polish fallback in that case.
  - Recognised loopback forms: `localhost`, `127.0.0.1`, `::1`, `[::1]`. RFC-1918 LAN IPs (192.168.*, 10.*, 172.16-31.*) are deliberately rejected — they would still leak transcripts to other machines on the network.
- `Tests/OpenQuackKitTests/PolishPipelineTests.swift` (edit):
  - 5 `isLoopback` tests covering canonical forms, case-insensitive matching, LAN IPs rejected, public hosts rejected, malformed URLs
  - 2 `makeEngine` tests covering LAN-IP and public-URL rejection at construction

## Tests

- [x] unit tests added: 7 cases under `PolishPipelineTests` (16 total in the file)
- [x] `swift build && swift test` green locally — **88 tests pass** (7 new + 81 from previous PRs); no regressions
- [ ] manual repro:
  1. Launch app, open Settings → Polish (new tab)
  2. Pick "Ollama"
  3. Enter `http://192.168.1.5:11434/api/chat` — verify red "must be loopback" banner appears, Test button disabled
  4. Reset to `http://localhost:11434/api/chat`, enter model `gemma3:1b`, click Test connection
  5. With Ollama running + model pulled: verify polished output appears in the green box
  6. Stop Ollama (`pkill ollama`), Test again: verify red "Polish backend unavailable" message appears
  7. Edge case: type `http://192.168.1.5:11434/api/chat` directly into UserDefaults via `defaults write`, then dictate — verify regex polish runs (engine construction silently rejects)

## Privacy impact

This PR **hardens** the privacy contract for the polish path on two layers:
- **UI layer**: the URL field shows a red "must be loopback" banner for non-loopback URLs, and the Test button is disabled.
- **Engine layer**: `PolishPipeline.makeEngine` re-validates and returns nil for non-loopback URLs even if UserDefaults somehow contains one. The dictation pipeline silently falls back to regex polish — no transcript leak.

When the user opts in with a loopback URL, transcript text is sent to `localhost:11434` only. No off-device traffic. Default engine is still Off — zero behaviour change for existing users. "Test connection" runs against the user's exact configuration; results are shown to the user only. No telemetry.

## Out of scope (deferred to later PRs)

- MLX-LM engine — PR #5 (would also unlock the picker option)
- Privacy pane surfacing the engine's `requiresNetwork` accessor live — separate spec
- Recording-overlay network indicator wiring `PolishPipeline.isLoopback` — separate spec