### PR TITLE
docs: add docs/blog/ stub + README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ OpenQuack is **AI-native open source** — every PR cites a SPEC, atomic tasks c
 
 Start with [`AGENTS.md`](AGENTS.md), pick a 🔵 task in [`docs/ROADMAP.md`](docs/ROADMAP.md), open a draft PR.
 
-Under the hood: [`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md).
+Under the hood: [`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md) · [`BLOG`](docs/blog/README.md).
 
 ## License
 

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -1,0 +1,33 @@
+# Engineering posts
+
+Long-form notes from the project — methodology, benchmarks, design
+decisions, things we learned the hard way. Distinct from the
+[README](../../README.md) (the product) and
+[`docs/VISION.md`](../VISION.md) (the direction).
+
+## Posts
+
+_None yet — first post coming with the Whisper-on-Mac bench
+writeup._
+
+## Why this exists
+
+The README is for "what is OpenQuack." The blog is for "what we
+learned along the way." Posts that live here:
+
+- Are dated (filename: `YYYY-MM-<short-slug>.md`)
+- Stand on their own — readable without the README
+- Cite primary sources (the bench output paths, the SPEC IDs, the
+  repos and tools we build on)
+- Are hand-written, end-to-end. No LLM-drafted bodies; the writing is
+  the thing.
+
+If you want to read a specific post, the filename names the date.
+
+## Contributing
+
+Engineering writeups from contributors are welcome — same shape as
+above. Open a draft PR with the post under `docs/blog/`, link it from
+the Posts list above, and (if relevant) reference the SPEC or bench
+output that motivated it. Same atomic-PR discipline as everything else
+in the repo (see [`AGENTS.md`](../../AGENTS.md)).


### PR DESCRIPTION
## SPEC

n/a — pure docs.

## Milestone

n/a (cuts across; supports the bench-blog post that unblocks the TLDR Tech newsletter pitch).

## Why

The TLDR Tech pitch (and iOS Dev Weekly) gating condition is "a standalone bench blog post on a project surface." We have a hand-writeable scaffold ready in `gtm/posts/bench-blog-scaffold.md`. This PR sets up the publish path so the moment Larry hand-writes the body, it has a stable URL with proper navigation:

`https://github.com/larryxiao/openquack/blob/main/docs/blog/YYYY-MM-<slug>.md`

## Change

- `docs/blog/README.md` (new) — one-page index. Notes the convention: filename = `YYYY-MM-<short-slug>.md`, posts are hand-written, contributors welcome.
- `README.md` (edit) — adds `BLOG` to the "Under the hood" footer line so the surface is discoverable from the canonical landing page.

## Tests

- [x] No code change; manual verification: links resolve.

## Privacy impact

None.

## Out of scope

- The bench blog post body itself (Larry hand-writes per the no-LLM-drafted-promo rule).
- `docs/blog/` cross-linking from `docs/BENCHMARKS.md` — straightforward follow-up once the first post lands.