### PR TITLE
docs(SPEC-019): i18n SPEC + root CONTRIBUTING.md with translation path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,132 @@
+# Contributing to OpenQuack
+
+OpenQuack is a one-person side project that ships in public. Most of
+the help we want isn't code — it's bench results from your Mac, beta
+testing on your hardware / language, translation, and feedback when
+something doesn't fit your workflow.
+
+If you want to help, here's where each kind of contribution goes.
+
+## Help us test it (any Mac, any language)
+
+OpenQuack is in alpha. The dictation path is solid, the polish path
+(M2.5) is in progress, the agent layer (M3) is on the roadmap. What
+we need most: people running it on configurations we can't —
+non-M4 Macs, 8 GB and 24+ GB memory tiers, Intel Macs, less-common
+languages (the Whisper model handles 99 of them; we've validated a
+handful).
+
+**How to help:**
+
+1. Install via [`brew tap larryxiao/openquack && brew install --cask openquack`](README.md#install) or grab the [DMG](https://github.com/larryxiao/openquack/releases).
+2. Use it for a few real dictations — short, long, in your primary
+   language.
+3. If something feels off, [file a bug report](https://github.com/larryxiao/openquack/issues/new?template=bug_report.yml).
+   The bug template asks for OpenQuack version + macOS + hardware +
+   model — please fill those in, they're the load-bearing fields.
+4. If something is missing, [request a feature](https://github.com/larryxiao/openquack/issues/new?template=feature_request.yml).
+5. Quick questions or "is this normal?" → [Discussions](https://github.com/larryxiao/openquack/discussions).
+
+## Help us benchmark on your Mac
+
+OpenQuack picks default models per memory tier based on bench data —
+but our matrix is M4 / 16 GB only. Adding rows from M1, M2, M3, Intel
+Macs, 8 GB, 24+ GB is the **single most useful contribution** at
+this stage.
+
+[`bench/CONTRIBUTING.md`](bench/CONTRIBUTING.md) walks through it:
+
+```sh
+bash bench/corpus/fetch.sh
+swift run openquack-bench \
+  --engines whisperkit \
+  --models tiny,small,large-v3-turbo \
+  --corpus bench/corpus \
+  --verbose
+```
+
+Output lands in `bench/out/<host-tag>/`. PR that directory; we merge
+quickly.
+
+## Help us translate the app and docs
+
+OpenQuack supports 99 Whisper languages for dictation, but the UI
+and documentation are English-only today. Translation contributions
+are very welcome:
+
+- **README translations** — there are machine-translated stubs in
+  `README.zh-CN.md`, `README.ja.md`, `README.ko.md`, `README.fr.md`,
+  `README.es.md`, `README.de.md`. Each has a "machine-translated;
+  native-speaker contributions welcome" disclaimer. PRs improving
+  any of these are merged on sight.
+- **App UI translations** — see [SPEC-019](docs/SPECS/SPEC-019-i18n.md)
+  for the i18n infrastructure. Once PRs 1-5 of that sequence land,
+  community translators can fill `Sources/OpenQuackApp/Resources/Localizable.xcstrings`
+  per-locale via PR.
+- **A new language not in the list** — if you want to translate
+  OpenQuack to a language we don't list yet (e.g. Vietnamese, Hindi,
+  Arabic), open a Discussion thread first so we can sequence it.
+
+Native speakers only, please. Auto-translation tells in body prose
+hurt more than no translation in target communities — same rule we
+apply to ourselves (we don't auto-translate any promo or
+discussions copy). The README files use machine translation **with
+explicit disclaimers** because they're reference docs that benefit
+from imperfect translation; promo and Discussions are different.
+
+## Contribute code
+
+[`AGENTS.md`](AGENTS.md) is the full workflow doc — applies equally to
+human contributors and AI agents. Quick form:
+
+1. Pick a 🔵 task in [`docs/ROADMAP.md`](docs/ROADMAP.md).
+2. Read the cited SPEC under `docs/SPECS/`.
+3. Open a draft PR within ~24h naming the task in the title.
+4. Atomic — one PR, one SPEC.
+5. Tests are non-optional (unit test for logic, manual repro steps
+   for UX).
+6. The PR template at `.github/pull_request_template.md` is enforced.
+
+The hardest parts of the codebase — Streaming transcription
+(SPEC-012), Polish engine (SPEC-007), Agent dispatch (SPEC-006) —
+all have detailed SPECs. Reading the SPEC before opening a PR
+prevents most rework.
+
+## Spread the word — only if it works for you
+
+If OpenQuack genuinely fits your workflow, telling others helps.
+But please:
+
+- Don't post in communities you haven't been participating in.
+- Don't lead with the marketing voice (the README's lead
+  paragraph is fine to quote; the rest is yours to summarise).
+- Real comparisons against tools you've used both of are way more
+  useful than generic praise.
+
+If you write something about OpenQuack — a blog post, a thread, a
+review — link it back via [Discussions](https://github.com/larryxiao/openquack/discussions/new?category=show-and-tell)
+in the "Show and tell" category. We'll read everything.
+
+## Privacy and conduct
+
+- **Privacy contract** is binding for every contribution: audio
+  never leaves the user's Mac; no telemetry; default agent does no
+  network IO. Contributions that introduce a network call in the
+  dictation hot path will be rejected. See [`docs/VISION.md#privacy-contract`](docs/VISION.md#privacy-contract).
+- **Code of conduct**: assume good faith, prefer questions over
+  accusations, and be patient — the maintainer responds in their
+  own timezone, on a side-project schedule. Most issues triaged
+  within a week; bench-result PRs faster.
+
+## Where to start if you have 30 minutes
+
+- **Bench contributor**: run the bench on your Mac, PR the output
+  directory.
+- **Translator**: fix a section in any of the `README.<lang>.md`
+  files (machine translation isn't great).
+- **Tester**: install, dictate for 30 minutes, file one issue if
+  anything fits the bug-report template.
+- **Reader**: open `docs/VISION.md` and `docs/ROADMAP.md`, see if
+  any 🔵 task feels like yours.
+
+Thanks for being here. The duck quacks because of you.

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,136 @@
+<p align="center">
+  <img src="docs/images/banner.png" alt="OpenQuack — Sprich. Schick. Privat. Das Aufnahme-Overlay zeigt 'Listening' mit einer Live-Pegelanzeige; das Menüleisten-Popover zeigt 'Pasted at cursor' mit dem letzten Transkript und einer Settings / Quit-Fußzeile.">
+</p>
+
+<div align="center">
+
+**OpenQuack** *Sprich. Schick. Privat.*
+
+Sprachdiktat für macOS. Nichts verlässt dein Gerät — kein Audio, kein Text, nichts.
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey.svg)](docs/INSTALL.md)
+[![Status](https://img.shields.io/badge/status-alpha-yellow.svg)](docs/ROADMAP.md)
+
+</div>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.es.md">Español</a> ·
+  <strong>Deutsch</strong>
+</p>
+
+> 🌐 **Maschinell übersetzt.** Beiträge von Muttersprachler:innen sind willkommen — öffne einen PR oder schau in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+---
+
+> 📢 **Neu — [v2.0.0-alpha.9](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.9):** rasend schnelles Diktat, auch bei langen Clips. Plus ein frischer neuer Look. Hoffentlich gefällt's dir!
+
+## Was es ist
+
+OpenQuack ist eine winzige Menüleisten-App für macOS. Drück einen Hotkey, sprich, drück nochmal — dein Transkript erscheint am Cursor. Wo du tippen kannst, kannst du reden.
+
+Spracherkennung läuft auf deinem Mac. Keine Cloud, kein Account, keine Anmeldung, keine Telemetrie.
+
+## Warum
+
+**Lokal.** Alles läuft auf deinem Gerät — Aufnahme, Transkription, optionales Polieren. Nichts geht raus: kein Audio, kein Text, keine Telemetrie, keine Anmeldung. Vertrauliche Arbeit bleibt vertraulich, von der Bauart her. Und weil im Loop kein API-Aufruf ist, läuft es einfach weiter — offline, im Flugzeug, hinter einer Firmen-Firewall.
+
+**Schnell.** Whisper auf Apple Silicon transkribiert in etwa einem Fünftel der Zeit, die du fürs Sprechen gebraucht hast. ~2,6 % Wortfehlerrate auf echter menschlicher Sprache auf einem Basis-M4 / 16 GB. In den meisten Fällen schneller als Tippen. Volle Bench-Matrix in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
+
+**Offen.** MIT-lizenziert. Jede Zeile ist auditierbar; jede Änderung passiert öffentlich. Die Version, die in deiner Menüleiste läuft, ist die Version aus diesem Repo.
+
+## Was du bekommst
+
+- **Diktat per Tastendruck.** Such dir einen Hotkey aus (Standard ⌃⇧Space). Toggle oder Push-to-Talk.
+- **Alles lokal.** Spracherkennung läuft auf deinem Mac. Kein Internet fürs Diktieren — funktioniert offline, im Flugzeug, im Tunnel, hinter einer Firmen-Firewall. Keine API-Keys, keine Rate-Limits, keine Service-Ausfälle. Gleiches Diktat, ob privat oder geschäftlich.
+- **Mehrsprachig.** Whisper kann 99 Sprachen — Englisch, Chinesisch, Japanisch, Koreanisch, Spanisch, Französisch, Deutsch, Italienisch und Portugiesisch sind direkt in den Einstellungen; Auto-Erkennung ist standardmäßig an.
+- **Auto-Einfügen am Cursor** in jeder App. (Fällt auf die Zwischenablage zurück, wenn du lieber selbst einfügst.)
+- **Smarte Formatierung** — Großschreibung, Endzeichen, Aufräumen von „äh / ähm".
+- **Eigenes Wörterbuch** — bring ihm die Eigennamen und Projektnamen bei, die du wirklich benutzt.
+- **Auto-Stop bei Stille.** Wenn du fertig gesprochen hast, beendet OpenQuack von selbst.
+- **Live-Mikrofonpegel** als Overlay, damit du siehst, dass es zuhört.
+- **Schnelle Ersteinrichtung** — Berechtigungen, Hotkey, in einer Minute fertig.
+- **Winzig.** Eine 8 MB große Menüleisten-App, plus das Sprachmodell beim ersten Start.
+- **Open Source**, MIT.
+
+## Datenschutz, auf einem Bildschirm
+
+1. **Nichts verlässt dein Gerät — kein Audio, kein Text, nichts.** Aufnahme und Transkription sind komplett lokal. Immer.
+2. **Keine Analytik, keine Telemetrie, keine Anmeldung.**
+
+Der vollständige Datenschutz-Vertrag steht in [`docs/VISION.md`](docs/VISION.md#privacy-contract).
+
+## Was als Nächstes kommt
+
+Ein Blick auf das, was in der Pipeline ist. Beides baut auf der Diktat-Grundlage auf, die heute schon ausgeliefert wird.
+
+**Kontextsensitive Transkription.** OpenQuack wird den Text rund um die Stelle lesen, an die du gerade einfügen willst — die Zeile über dem Cursor, die Funktion, in der du gerade bist, den Chat-Thread, auf den du antwortest — und das dem Sprachmodell als Kontext mitgeben. Fachbegriffe werden anhand dessen disambiguiert, was du wirklich tust („cloud code" wird im Terminal zu „Claude Code", und nicht andersherum). Weniger Bastelei am eigenen Wörterbuch.
+
+**Denk-Modus.** Ein zweiter Durchgang nach der Transkription, durch ein kleines lokales LLM, der einen rohen gesprochenen Satz in einen geschriebenen verwandelt, bei dem du wirklich auf Senden drücken würdest. Füllwörter raus, Struktur gestrafft, richtige Großschreibung bei den Wörtern, die zählen. Standardmäßig aus, mit einem Toggle einschaltbar. Vollständig lokal — Ollama oder MLX-LM, deine Wahl.
+
+Zeitplan und SPEC-Details in [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+Die Ente hat größere Pläne. Wohin das geht: [`docs/VISION.md`](docs/VISION.md).
+
+## Installation
+
+```sh
+brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+brew install --cask openquack
+```
+
+Oder [DMG laden](https://github.com/larryxiao/openquack/releases) und in den Programme-Ordner ziehen. Erster Start: Rechtsklick → **Öffnen** → **Öffnen** (einmalige Gatekeeper-Umgehung).
+
+Erlaube **Mikrofon**, wenn macOS fragt, und such dir einen Hotkey unter **Einstellungen → Kurzbefehl** aus (Standard ⌃⇧Space).
+
+Lieber ein geführter Rundgang? Schau in [`docs/TUTORIAL.md`](docs/TUTORIAL.md) — fünf Minuten von der Installation bis zum ersten Diktat.
+
+### Oder lass deinen KI-Agenten ran
+
+Kopier das in Claude Code, Codex, opencode, Hermes oder ähnliche:
+
+```text
+Install OpenQuack on this Mac:
+
+  brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+  brew install --cask openquack
+
+(Or grab the DMG from https://github.com/larryxiao/openquack/releases
+and drag it into /Applications; first open right-click → Open → Open.)
+
+Then launch /Applications/OpenQuack.app, grant Microphone, and pick a
+hotkey in Settings → Shortcut. Default ⌃⇧Space.
+```
+
+Mehr Optionen (Deinstallation, Build aus dem Quellcode, was beim ersten Start heruntergeladen wird): [`docs/INSTALL.md`](docs/INSTALL.md).
+
+## Danksagung
+
+OpenQuack steht auf den Schultern großzügiger Open-Source-Arbeit. Riesigen Dank an:
+
+- [**OpenAI Whisper**](https://github.com/openai/whisper) — das Sprachmodell, das das alles erst möglich macht.
+- [**WhisperKit**](https://github.com/argmaxinc/WhisperKit) von Argmax — Whisper, schnell und nativ auf Apple Silicon.
+- [**KeyboardShortcuts**](https://github.com/sindresorhus/KeyboardShortcuts) von Sindre Sorhus — die Hotkey-Mechanik, die du jeden Tag drückst.
+- [**voxt**](https://github.com/hehehai/voxt) — ein verwandtes Projekt, von dem wir technisch viel gelernt haben.
+- [**Typeless**](https://www.typeless.com/) und [**Wispr Flow**](https://wisprflow.ai/) — die Closed-Source-Apps, die gezeigt haben, wie schön sich Voice-First-Eingabe anfühlen kann; wir zielen auf dasselbe Gefühl, lokal und offen.
+
+Und an alle, die Issues schreiben, PRs öffnen und Freund:innen davon erzählen: Danke. Die Ente quakt wegen euch.
+
+## Mitmachen
+
+OpenQuack ist **AI-native Open Source** — jeder PR zitiert ein SPEC, atomare Aufgaben kommen aus der Roadmap, der Workflow ist freundlich zu Coding-Agenten in großem Maßstab (und zu Menschen auf demselben Weg).
+
+Fang mit [`AGENTS.md`](AGENTS.md) an, schnapp dir eine 🔵-Aufgabe in [`docs/ROADMAP.md`](docs/ROADMAP.md), öffne einen Draft-PR.
+
+Unter der Haube: [`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md) · [`BLOG`](docs/blog/README.md).
+
+## Lizenz
+
+MIT — siehe [LICENSE](LICENSE).
+
+(Übersetzungs-Feedback gerne per PR oder über [GitHub Discussions](https://github.com/larryxiao/openquack/discussions).)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,136 @@
+<p align="center">
+  <img src="docs/images/banner.png" alt="OpenQuack — Habla. Envía. En privado. El overlay de grabación muestra 'Listening' con un medidor de nivel en vivo; el popover de la barra de menús muestra 'Pasted at cursor' con la última transcripción y un pie con Settings / Quit.">
+</p>
+
+<div align="center">
+
+**OpenQuack** *Habla. Envía. En privado.*
+
+Dictado por voz para macOS. Nada sale de tu dispositivo — ni audio, ni texto, nada.
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey.svg)](docs/INSTALL.md)
+[![Status](https://img.shields.io/badge/status-alpha-yellow.svg)](docs/ROADMAP.md)
+
+</div>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <strong>Español</strong> ·
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+> 🌐 **Traducido por máquina.** Damos la bienvenida a contribuciones de hablantes nativos — abre una PR o consulta [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+---
+
+> 📢 **Novedades — [v2.0.0-alpha.9](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.9):** dictado a toda velocidad, incluso en clips largos. Y un look renovado. ¡Esperamos que te guste!
+
+## Qué es
+
+OpenQuack es una pequeña app de barra de menús para macOS. Pulsa un atajo, habla, púlsalo de nuevo — la transcripción aparece en el cursor. Donde puedas escribir, puedes hablar.
+
+El reconocimiento de voz ocurre en tu Mac. Sin nube, sin cuenta, sin registro, sin telemetría.
+
+## Por qué
+
+**Local.** Todo corre en tu dispositivo — grabación, transcripción, pulido opcional. Nada sale: ni audio, ni texto, ni telemetría, ni registro. El trabajo confidencial se queda confidencial, por diseño. Y como no hay llamadas a API en el camino, simplemente sigue funcionando — sin conexión, en un avión, detrás del firewall corporativo.
+
+**Rápido.** Whisper sobre Apple Silicon transcribe en aproximadamente un quinto del tiempo que tardaste en hablar. Tasa de error de palabras de ~2,6 % sobre habla humana real en un M4 / 16 GB de base. Más rápido que escribir en la mayoría de los casos. Matriz completa en [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
+
+**Abierto.** Licencia MIT. Cada línea es auditable; cada cambio ocurre en público. La versión que corre en tu barra de menús es la versión de este repo.
+
+## Lo que recibes
+
+- **Dictado con una sola tecla.** Elige un atajo (por defecto ⌃⇧Space). Modo conmutar o pulsar para hablar.
+- **Todo local.** El reconocimiento de voz corre en tu Mac. No necesitas Internet para dictar — funciona sin conexión, en un avión, en un túnel, detrás del firewall corporativo. Sin claves de API, sin límites de uso, sin caídas de servicio. El mismo dictado en lo personal y en lo profesional.
+- **Multilingüe.** Whisper maneja 99 idiomas — inglés, chino, japonés, coreano, español, francés, alemán, italiano y portugués están directamente en Ajustes; detección automática activada por defecto.
+- **Pegado automático en el cursor** en cualquier app. (Cae al portapapeles si prefieres pegar tú mismo.)
+- **Formato inteligente** — mayúsculas, puntuación final, limpieza de muletillas tipo «eh / em».
+- **Diccionario personalizado** — enséñale los nombres propios y de proyecto que realmente usas.
+- **Parada automática tras silencio.** Cuando terminas de hablar, OpenQuack cierra solo.
+- **Medidor de micro en vivo** para que veas que está escuchando.
+- **Configuración rápida en el primer arranque** — permisos, atajo, listo en un minuto.
+- **Diminuto.** Una app de barra de menús de 8 MB, más el modelo de voz en el primer arranque.
+- **Código abierto**, MIT.
+
+## Privacidad, en una pantalla
+
+1. **Nada sale de tu dispositivo — ni audio, ni texto, nada.** Grabación y transcripción son completamente locales. Siempre.
+2. **Sin analítica, sin telemetría, sin registro.**
+
+El contrato de privacidad completo está en [`docs/VISION.md`](docs/VISION.md#privacy-contract).
+
+## Lo que viene
+
+Vista previa de lo que está en cola. Ambas cosas se apoyan en la base de dictado que ya está disponible hoy.
+
+**Transcripción con contexto.** OpenQuack leerá el texto que rodea el sitio donde vas a pegar — la línea encima del cursor, la función en la que estás dentro, el hilo de chat al que respondes — y se lo dará como contexto al modelo de voz. Los términos del dominio se desambiguan por lo que estás haciendo realmente (cuando estás en un terminal, «cloud code» se convierte en «Claude Code», y no al revés). Menos jugueteo con el diccionario personalizado.
+
+**Modo pensante.** Una segunda pasada después de la transcripción, a través de un pequeño LLM local, que convierte una frase hablada cruda en una frase escrita que tú realmente pulsarías «enviar». Muletillas recortadas, estructura ajustada, mayúsculas correctas en las palabras que importan. Desactivado por defecto, activable con un toque. Totalmente local — Ollama o MLX-LM, tú eliges.
+
+Calendario y detalles de SPEC en [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+El pato tiene planes más grandes. Hacia dónde va esto: [`docs/VISION.md`](docs/VISION.md).
+
+## Instalación
+
+```sh
+brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+brew install --cask openquack
+```
+
+O [descarga el DMG](https://github.com/larryxiao/openquack/releases) y arrástralo a Aplicaciones. Primer arranque: clic derecho → **Abrir** → **Abrir** (saltar Gatekeeper, una sola vez).
+
+Da permiso de **Micrófono** cuando macOS lo pida, elige un atajo en **Ajustes → Atajo** (por defecto ⌃⇧Space).
+
+¿Quieres un recorrido guiado? Ve [`docs/TUTORIAL.md`](docs/TUTORIAL.md) — cinco minutos de la instalación al primer dictado.
+
+### O díselo a tu agente de IA
+
+Pega esto en Claude Code, Codex, opencode, Hermes o similar:
+
+```text
+Install OpenQuack on this Mac:
+
+  brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+  brew install --cask openquack
+
+(Or grab the DMG from https://github.com/larryxiao/openquack/releases
+and drag it into /Applications; first open right-click → Open → Open.)
+
+Then launch /Applications/OpenQuack.app, grant Microphone, and pick a
+hotkey in Settings → Shortcut. Default ⌃⇧Space.
+```
+
+Más opciones (desinstalación, build desde fuente, qué se descarga en el primer arranque): [`docs/INSTALL.md`](docs/INSTALL.md).
+
+## Agradecimientos
+
+OpenQuack se apoya en los hombros de trabajo open source generoso. Muchísimas gracias a:
+
+- [**OpenAI Whisper**](https://github.com/openai/whisper) — el modelo de voz que hace posible todo esto.
+- [**WhisperKit**](https://github.com/argmaxinc/WhisperKit) de Argmax — Whisper, rápido y nativo sobre Apple Silicon.
+- [**KeyboardShortcuts**](https://github.com/sindresorhus/KeyboardShortcuts) de Sindre Sorhus — la maquinaria de atajos que pulsas cada día.
+- [**voxt**](https://github.com/hehehai/voxt) — un proyecto hermano del que hemos aprendido mucho en lo técnico.
+- [**Typeless**](https://www.typeless.com/) y [**Wispr Flow**](https://wisprflow.ai/) — las apps de código cerrado que demostraron lo agradable que puede sentirse la entrada por voz; apuntamos a la misma sensación, en local y en abierto.
+
+Y a quienes abren issues, mandan PRs y se lo cuentan a sus amigos: gracias. El pato grazna gracias a vosotros.
+
+## Contribuir
+
+OpenQuack es **open source AI-native** — cada PR cita un SPEC, las tareas atómicas vienen del roadmap, el flujo es amigable para agentes de código a escala (y humanos en el mismo camino).
+
+Empieza por [`AGENTS.md`](AGENTS.md), elige una tarea 🔵 en [`docs/ROADMAP.md`](docs/ROADMAP.md), abre una PR en borrador.
+
+Bajo el capó: [`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md) · [`BLOG`](docs/blog/README.md).
+
+## Licencia
+
+MIT — ver [LICENSE](LICENSE).
+
+(Comentarios sobre la traducción bienvenidos vía PR o [GitHub Discussions](https://github.com/larryxiao/openquack/discussions).)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,136 @@
+<p align="center">
+  <img src="docs/images/banner.png" alt="OpenQuack — Parle. Envoie. En privé. L'overlay d'enregistrement affiche 'Listening' avec un vumètre en direct ; le popover de la barre de menus affiche 'Pasted at cursor' avec la dernière transcription et un pied de page Settings / Quit.">
+</p>
+
+<div align="center">
+
+**OpenQuack** *Parle. Envoie. En privé.*
+
+Dictée vocale pour macOS. Rien ne quitte ton appareil — ni audio, ni texte, rien.
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey.svg)](docs/INSTALL.md)
+[![Status](https://img.shields.io/badge/status-alpha-yellow.svg)](docs/ROADMAP.md)
+
+</div>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <strong>Français</strong> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+> 🌐 **Traduction automatique.** Les contributions de locuteurs natifs sont les bienvenues — ouvre une PR ou consulte [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+---
+
+> 📢 **Du nouveau — [v2.0.0-alpha.9](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.9) :** dictée ultra-rapide, même sur les longs extraits. Et un nouveau look. On espère qu'il te plaira !
+
+## C'est quoi
+
+OpenQuack est une petite app de barre de menus pour macOS. Tu appuies sur un raccourci, tu parles, tu réappuies — ta transcription apparaît au curseur. Partout où tu peux taper, tu peux parler.
+
+La reconnaissance vocale tourne sur ton Mac. Pas de cloud, pas de compte, pas d'inscription, pas de télémétrie.
+
+## Pourquoi
+
+**Local.** Tout tourne sur ton appareil — enregistrement, transcription, polissage optionnel. Rien ne sort : pas d'audio, pas de texte, pas de télémétrie, pas d'inscription. Le travail confidentiel reste confidentiel, par construction. Et comme il n'y a pas d'appel API dans la boucle, ça continue à fonctionner — hors ligne, dans un avion, derrière un pare-feu d'entreprise.
+
+**Rapide.** Whisper sur Apple Silicon transcrit en environ un cinquième du temps que tu as passé à parler. Taux d'erreur de mots d'environ ~2,6 % sur de la vraie parole humaine sur un M4 / 16 Go de base. Plus rapide que la frappe dans la plupart des cas. Matrice complète dans [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
+
+**Ouvert.** Sous licence MIT. Chaque ligne est auditable ; chaque changement se fait en public. La version qui tourne dans ta barre de menus est la version de ce dépôt.
+
+## Ce que tu obtiens
+
+- **Dictée en une touche.** Choisis un raccourci (par défaut ⌃⇧Space). Bascule ou push-to-talk.
+- **Tout local.** La reconnaissance vocale tourne sur ton Mac. Pas besoin d'Internet pour dicter — fonctionne hors ligne, dans un avion, dans un tunnel, derrière un pare-feu d'entreprise. Pas de clé API, pas de limite de taux, pas de panne de service. Même dictée en perso ou en pro.
+- **Multilingue.** Whisper gère 99 langues — anglais, chinois, japonais, coréen, espagnol, français, allemand, italien et portugais sont directement dans les Réglages ; détection automatique activée par défaut.
+- **Collage automatique au curseur** dans n'importe quelle app. (Repli sur le presse-papiers si tu préfères coller toi-même.)
+- **Mise en forme intelligente** — majuscules, ponctuation finale, nettoyage des « euh / hum ».
+- **Dictionnaire personnalisé** — apprends-lui les noms propres et noms de projet que tu utilises vraiment.
+- **Arrêt automatique en cas de silence.** Quand tu finis de parler, OpenQuack se débrouille pour finir tout seul.
+- **Vumètre micro en direct** pour voir qu'il écoute.
+- **Configuration rapide au premier lancement** — permissions, raccourci, c'est plié en une minute.
+- **Minuscule.** Une app de barre de menus de 8 Mo, plus le modèle vocal au premier lancement.
+- **Open source**, MIT.
+
+## Vie privée, sur un seul écran
+
+1. **Rien ne quitte ton appareil — ni audio, ni texte, rien.** Enregistrement et transcription sont entièrement locaux. Toujours.
+2. **Pas d'analytique, pas de télémétrie, pas d'inscription.**
+
+Le contrat de vie privée complet est dans [`docs/VISION.md`](docs/VISION.md#privacy-contract).
+
+## La suite
+
+Aperçu de ce qui est en file d'attente. Les deux s'appuient sur la base de dictée disponible dès aujourd'hui.
+
+**Transcription contextuelle.** OpenQuack lira le texte autour de l'endroit où tu vas coller — la ligne au-dessus du curseur, la fonction dans laquelle tu te trouves, le fil de discussion auquel tu réponds — et le donnera comme contexte au modèle vocal. Les termes du domaine sont désambiguïsés par ce que tu fais réellement (« cloud code » devient « Claude Code » quand tu es dans un terminal, et pas l'inverse). Moins de bricolage de dictionnaire personnalisé.
+
+**Mode réflexion.** Une seconde passe après la transcription, à travers un petit LLM local, qui transforme une phrase parlée brute en phrase écrite que tu appuierais vraiment sur envoyer. Tics nettoyés, structure resserrée, bonne capitalisation sur les mots qui comptent. Désactivé par défaut, activable d'un seul clic. Entièrement local — Ollama ou MLX-LM, à ton choix.
+
+Calendrier et détails SPEC dans [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+Le canard a des plans plus ambitieux. Vers où ça va : [`docs/VISION.md`](docs/VISION.md).
+
+## Installation
+
+```sh
+brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+brew install --cask openquack
+```
+
+Ou [télécharge le DMG](https://github.com/larryxiao/openquack/releases) et glisse-le dans Applications. Premier lancement : clic droit → **Ouvrir** → **Ouvrir** (contournement unique de Gatekeeper).
+
+Accorde **Microphone** quand macOS le demande, choisis un raccourci dans **Réglages → Raccourci** (par défaut ⌃⇧Space).
+
+Tu veux un guide pas à pas ? Voir [`docs/TUTORIAL.md`](docs/TUTORIAL.md) — cinq minutes de l'installation à la première dictée.
+
+### Ou demande à ton agent IA
+
+Colle ceci dans Claude Code, Codex, opencode, Hermes ou similaire :
+
+```text
+Install OpenQuack on this Mac:
+
+  brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+  brew install --cask openquack
+
+(Or grab the DMG from https://github.com/larryxiao/openquack/releases
+and drag it into /Applications; first open right-click → Open → Open.)
+
+Then launch /Applications/OpenQuack.app, grant Microphone, and pick a
+hotkey in Settings → Shortcut. Default ⌃⇧Space.
+```
+
+Plus d'options (désinstallation, build depuis les sources, ce qui est téléchargé au premier lancement) : [`docs/INSTALL.md`](docs/INSTALL.md).
+
+## Remerciements
+
+OpenQuack se tient sur les épaules d'un travail open source généreux. Un immense merci à :
+
+- [**OpenAI Whisper**](https://github.com/openai/whisper) — le modèle vocal qui rend tout ça possible.
+- [**WhisperKit**](https://github.com/argmaxinc/WhisperKit) par Argmax — Whisper, rapide et natif sur Apple Silicon.
+- [**KeyboardShortcuts**](https://github.com/sindresorhus/KeyboardShortcuts) par Sindre Sorhus — la mécanique de raccourci que tu enfonces tous les jours.
+- [**voxt**](https://github.com/hehehai/voxt) — un projet frère dont on a beaucoup appris côté technique.
+- [**Typeless**](https://www.typeless.com/) et [**Wispr Flow**](https://wisprflow.ai/) — les apps closed source qui ont prouvé à quel point la saisie vocale peut être agréable ; on vise la même sensation, en local et en ouvert.
+
+Et à toutes les personnes qui ouvrent des issues, des PR, qui en parlent à leurs amis : merci. Le canard cancane grâce à vous.
+
+## Contribuer
+
+OpenQuack est un **open source AI-native** — chaque PR cite un SPEC, les tâches atomiques viennent de la roadmap, le workflow est pensé pour les agents de code à grande échelle (et les humains sur le même chemin).
+
+Commence par [`AGENTS.md`](AGENTS.md), choisis une tâche 🔵 dans [`docs/ROADMAP.md`](docs/ROADMAP.md), ouvre une PR en draft.
+
+Sous le capot : [`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md) · [`BLOG`](docs/blog/README.md).
+
+## Licence
+
+MIT — voir [LICENSE](LICENSE).
+
+(Retours sur la traduction bienvenus via PR ou [GitHub Discussions](https://github.com/larryxiao/openquack/discussions).)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,136 @@
+<p align="center">
+  <img src="docs/images/banner.png" alt="OpenQuack — 話す。送る。プライベートに。録音オーバーレイには 'Listening' とライブレベルメーター、メニューバーのポップオーバーには 'Pasted at cursor' と直近の文字起こし、フッターに Settings / Quit ボタンが表示されている。">
+</p>
+
+<div align="center">
+
+**OpenQuack** *話す。送る。プライベートに。*
+
+macOS 向けの音声入力。何もデバイスから出ない —— 音声もテキストも、何も。
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey.svg)](docs/INSTALL.md)
+[![Status](https://img.shields.io/badge/status-alpha-yellow.svg)](docs/ROADMAP.md)
+
+</div>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <strong>日本語</strong> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+> 🌐 **機械翻訳です。** ネイティブの方からの貢献を歓迎します —— PR を送るか、[`CONTRIBUTING.md`](CONTRIBUTING.md) を参照してください。
+
+---
+
+> 📢 **新着 — [v2.0.0-alpha.9](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.9):** 長いクリップでも爆速の音声入力。さらに新しい外観も。気に入ってもらえると嬉しいです!
+
+## これは何?
+
+OpenQuack は macOS 向けの小さなメニューバーアプリ。ホットキーを押して話し、もう一度押す —— 文字起こしがカーソル位置に現れる。タイプできる場所なら、どこでも話せる。
+
+音声認識は Mac の中で完結。クラウドなし、アカウントなし、サインアップなし、テレメトリなし。
+
+## なぜ作ったか
+
+**ローカル。** すべてがデバイス上で動く —— 録音、文字起こし、オプションの整形まで。何も外に出ない:音声、テキスト、テレメトリ、サインアップ、すべてなし。機密の作業は、設計レベルで機密のまま。フローに API コールがないので、ずっと動き続ける —— オフラインでも、飛行機の中でも、企業ファイアウォールの後ろでも。
+
+**速い。** Apple Silicon 上の Whisper は、話した時間のおよそ 5 分の 1 で文字起こしする。ベースラインの M4 / 16 GB で、リアルな人間の音声に対する単語誤り率はおよそ 2.6%。多くの場合、タイプより速い。フルベンチマークは [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md)。
+
+**オープン。** MIT ライセンス。すべての行が監査可能で、すべての変更は公開で行われる。メニューバーで動いているバージョンが、このリポジトリにあるバージョン。
+
+## 使えるもの
+
+- **ワンキー入力。** ホットキーを選ぶ(デフォルトは ⌃⇧Space)。トグル式またはプッシュ・トゥ・トーク。
+- **すべてローカル。** 音声認識は Mac で動く。入力にネット接続は不要 —— オフライン、飛行機、トンネル、企業ファイアウォールの後ろでも動く。API キーなし、レート制限なし、サービス停止もなし。個人でも仕事でも、同じ音声入力。
+- **多言語対応。** Whisper は 99 言語に対応 —— 英語、中国語、日本語、韓国語、スペイン語、フランス語、ドイツ語、イタリア語、ポルトガル語は設定からそのまま選べる;自動検出はデフォルトでオン。
+- **カーソル位置に自動ペースト**、どんなアプリでも。(自分で貼りたければクリップボードにフォールバック。)
+- **スマートフォーマット** —— 大文字化、文末の句読点、「えー / あのー」のクリーンアップ。
+- **カスタム辞書** —— あなたが実際に使う固有名詞やプロジェクト名を覚えさせられる。
+- **無音で自動停止。** 話し終われば、OpenQuack が自分で締めくくる。
+- **ライブのマイクレベル表示**、ちゃんと聞いてるのが見える。
+- **初回起動の高速セットアップ** —— 権限とホットキー、1 分で完了。
+- **小さい。** 8 MB のメニューバーアプリ、プラス初回起動時に音声モデル。
+- **オープンソース**、MIT。
+
+## プライバシー、1 画面で
+
+1. **何もデバイスから出ない —— 音声、テキスト、何も。** 録音と文字起こしは完全にローカル。常に。
+2. **アナリティクスなし、テレメトリなし、サインアップなし。**
+
+プライバシーの完全な契約は [`docs/VISION.md`](docs/VISION.md#privacy-contract)。
+
+## 次に来るもの
+
+控えている機能のプレビュー。どちらも今日出荷されている音声入力の土台の上に乗っている。
+
+**コンテキスト対応の文字起こし。** OpenQuack は、これからペーストする周辺のテキストを読む —— カーソル上の行、いま中にいる関数、返信中のチャットスレッド —— そしてそれをコンテキストとして音声モデルに渡す。専門用語は、いま実際にやっていることに基づいて曖昧さが解消される(ターミナルにいるとき、「cloud code」は「Claude Code」になり、その逆ではない)。カスタム辞書をいじる頻度が減る。
+
+**シンキングモード。** 文字起こしの後にもう一段、小さなローカル LLM を通して、話した生の文を、実際に送信ボタンを押せる書き言葉に変える。フィラーをカット、構造を引き締め、大事な言葉に正しい大文字化。デフォルトはオフ、ワンクリックで有効化。完全ローカル —— Ollama または MLX-LM、お好みで。
+
+スケジュールと SPEC の詳細は [`docs/ROADMAP.md`](docs/ROADMAP.md)。
+
+このアヒルにはもっと大きな計画がある。向かう先は [`docs/VISION.md`](docs/VISION.md)。
+
+## インストール
+
+```sh
+brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+brew install --cask openquack
+```
+
+または [DMG をダウンロード](https://github.com/larryxiao/openquack/releases) して Applications にドラッグ。初回起動:右クリック → **開く** → **開く**(Gatekeeper を一回だけバイパス)。
+
+macOS が聞いてきたら **マイク** を許可、**設定 → ショートカット** でホットキーを選ぶ(デフォルトは ⌃⇧Space)。
+
+ガイド付きの手順がほしい? [`docs/TUTORIAL.md`](docs/TUTORIAL.md) を見てください —— インストールから最初の音声入力まで 5 分。
+
+### または AI エージェントに任せる
+
+これを Claude Code、Codex、opencode、Hermes などに貼り付ける:
+
+```text
+Install OpenQuack on this Mac:
+
+  brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+  brew install --cask openquack
+
+(Or grab the DMG from https://github.com/larryxiao/openquack/releases
+and drag it into /Applications; first open right-click → Open → Open.)
+
+Then launch /Applications/OpenQuack.app, grant Microphone, and pick a
+hotkey in Settings → Shortcut. Default ⌃⇧Space.
+```
+
+その他のオプション(アンインストール、ソースからのビルド、初回起動でダウンロードされるもの):[`docs/INSTALL.md`](docs/INSTALL.md)。
+
+## 謝辞
+
+OpenQuack は、寛大なオープンソースの仕事の肩の上に立っている。深く感謝します:
+
+- [**OpenAI Whisper**](https://github.com/openai/whisper) —— これすべてを可能にした音声モデル。
+- [**WhisperKit**](https://github.com/argmaxinc/WhisperKit) by Argmax —— Apple Silicon 上で速くネイティブに動く Whisper。
+- [**KeyboardShortcuts**](https://github.com/sindresorhus/KeyboardShortcuts) by Sindre Sorhus —— 毎日押しているホットキーの仕組み。
+- [**voxt**](https://github.com/hehehai/voxt) —— 同じ志を持つプロジェクト、技術面でたくさん学ばせてもらった。
+- [**Typeless**](https://www.typeless.com/) と [**Wispr Flow**](https://wisprflow.ai/) —— クローズドソースのアプリだが、音声優先の入力がどれほど気持ちよくなれるかを示してくれた;同じ感触を、ローカルでオープンに目指している。
+
+そして、issue を立ててくれた人、PR を送ってくれた人、友人に教えてくれた人、みんなに:ありがとう。このアヒルがクワッと鳴くのは、あなたたちがいるから。
+
+## コントリビュート
+
+OpenQuack は **AI ネイティブのオープンソース** —— すべての PR が SPEC を参照し、アトミックなタスクはロードマップから来る。ワークフローはコーディングエージェントにも(同じ道を行く人間にも)優しい設計。
+
+[`AGENTS.md`](AGENTS.md) から始めて、[`docs/ROADMAP.md`](docs/ROADMAP.md) で 🔵 のタスクを選び、ドラフト PR を開く。
+
+裏側:[`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md) · [`BLOG`](docs/blog/README.md)。
+
+## ライセンス
+
+MIT —— [LICENSE](LICENSE) を参照。
+
+(翻訳のフィードバックは PR か [GitHub Discussions](https://github.com/larryxiao/openquack/discussions) で歓迎。)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,136 @@
+<p align="center">
+  <img src="docs/images/banner.png" alt="OpenQuack — 말하면. 입력된다. 비공개로. 녹음 오버레이에 'Listening' 과 실시간 음량 미터, 메뉴바 팝오버에 'Pasted at cursor' 와 최근 받아쓰기 결과, 푸터에 Settings / Quit 버튼이 표시된다.">
+</p>
+
+<div align="center">
+
+**OpenQuack** *말하면. 입력된다. 비공개로.*
+
+macOS 용 음성 받아쓰기. 무엇도 기기를 떠나지 않는다 —— 오디오도, 텍스트도, 아무것도.
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey.svg)](docs/INSTALL.md)
+[![Status](https://img.shields.io/badge/status-alpha-yellow.svg)](docs/ROADMAP.md)
+
+</div>
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <strong>한국어</strong> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+> 🌐 **기계 번역입니다.** 원어민의 기여를 환영합니다 —— PR 을 열어주시거나 [`CONTRIBUTING.md`](CONTRIBUTING.md) 를 참고하세요.
+
+---
+
+> 📢 **새 소식 — [v2.0.0-alpha.9](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.9):** 긴 음성도 빠르게 받아쓰기. 그리고 새로워진 외관. 마음에 들었으면 좋겠어요!
+
+## 이게 뭔가요
+
+OpenQuack 은 macOS 메뉴바에 사는 작은 앱이에요. 단축키를 누르고 말한 뒤 다시 누르면 —— 받아쓰기 결과가 커서 위치에 나타납니다. 타이핑이 가능한 곳이라면, 어디서든 말할 수 있어요.
+
+음성 인식은 Mac 안에서 처리돼요. 클라우드도, 계정도, 가입도, 텔레메트리도 없어요.
+
+## 왜 만들었나
+
+**로컬.** 모든 게 기기 위에서 돌아가요 —— 녹음, 받아쓰기, 선택적 다듬기까지. 아무것도 외부로 나가지 않아요: 오디오, 텍스트, 텔레메트리, 가입, 전부 없음. 기밀 작업은 설계 단계부터 기밀로 유지돼요. 그리고 흐름 안에 API 호출이 없으니 계속 작동해요 —— 오프라인에서도, 비행기 안에서도, 사내 방화벽 뒤에서도.
+
+**빠릅니다.** Apple Silicon 위의 Whisper 는 말한 시간의 약 1/5 만에 받아쓰기를 끝내요. 베이스라인 M4 / 16 GB 에서 실제 사람 음성에 대한 단어 오류율은 약 ~2.6%. 대부분의 경우 타이핑보다 빠릅니다. 전체 벤치 매트릭스는 [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) 참고.
+
+**오픈.** MIT 라이선스. 모든 줄이 감사 가능하고, 모든 변경은 공개로 일어납니다. 메뉴바에서 도는 버전이 곧 이 저장소의 버전이에요.
+
+## 받게 되는 것
+
+- **단축키 하나로 받아쓰기.** 단축키 선택 (기본값 ⌃⇧Space). 토글 또는 푸시 투 토크.
+- **모두 로컬.** 음성 인식은 Mac 에서 돌아요. 받아쓰기에 인터넷이 필요 없어요 —— 오프라인, 비행기, 터널 안, 사내 방화벽 뒤에서도 작동. API 키 없음, 속도 제한 없음, 서비스 장애 없음. 개인이든 업무 환경이든 동일한 받아쓰기.
+- **다국어.** Whisper 는 99 개 언어를 처리해요 —— 영어, 중국어, 일본어, 한국어, 스페인어, 프랑스어, 독일어, 이탈리아어, 포르투갈어가 설정에 바로 있고, 자동 감지가 기본 켜짐.
+- **커서 위치에 자동 붙여넣기**, 어떤 앱에서든. (직접 붙여넣고 싶다면 클립보드로 폴백.)
+- **스마트 포맷팅** —— 대문자화, 문장 끝 구두점, "음/어" 같은 군말 정리.
+- **사용자 사전** —— 실제로 쓰는 고유명사와 프로젝트명을 가르쳐 둘 수 있어요.
+- **무음 시 자동 정지.** 말이 끝나면 OpenQuack 이 알아서 마무리.
+- **실시간 마이크 레벨 오버레이**, 듣고 있다는 게 눈에 보여요.
+- **첫 실행 빠른 설정** —— 권한, 단축키, 1 분이면 끝.
+- **작아요.** 8 MB 짜리 메뉴바 앱, 그리고 첫 실행 때 받는 음성 모델.
+- **오픈소스**, MIT.
+
+## 프라이버시, 한 화면에
+
+1. **무엇도 기기를 떠나지 않아요 —— 오디오, 텍스트, 아무것도.** 녹음과 받아쓰기는 완전히 로컬. 언제나.
+2. **분석 없음, 텔레메트리 없음, 가입 없음.**
+
+전체 프라이버시 계약은 [`docs/VISION.md`](docs/VISION.md#privacy-contract) 에 있어요.
+
+## 다음에 올 것
+
+대기 중인 기능 미리보기. 둘 다 오늘 출시된 받아쓰기 토대 위에 올라갑니다.
+
+**문맥 인식 받아쓰기.** OpenQuack 이 곧 붙여넣을 위치 주변의 텍스트를 읽어요 —— 커서 위 줄, 지금 들어와 있는 함수, 답장 중인 채팅 스레드 —— 그리고 그것을 음성 모델에 컨텍스트로 넘겨요. 도메인 용어가 실제로 하고 있는 일에 따라 자동으로 풀려요 (터미널에 있을 때 "cloud code" 가 "Claude Code" 로 잡히지, 그 반대가 아니라요). 사용자 사전을 만질 일이 줄어듭니다.
+
+**씽킹 모드.** 받아쓰기 후 한 번 더, 작은 로컬 LLM 을 거쳐서, 말로 뱉은 원문을 실제로 보내기 버튼을 누를 수 있는 글로 바꿔줘요. 군말 잘라내고, 구조 다듬고, 중요한 단어에 알맞은 대문자. 기본은 꺼짐, 토글 한 번으로 켜짐. 완전 로컬 —— Ollama 또는 MLX-LM, 원하는 쪽으로.
+
+일정과 SPEC 상세는 [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+이 오리는 더 큰 계획이 있어요. 향하는 곳: [`docs/VISION.md`](docs/VISION.md).
+
+## 설치
+
+```sh
+brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+brew install --cask openquack
+```
+
+또는 [DMG 다운로드](https://github.com/larryxiao/openquack/releases) 후 Applications 에 드래그. 첫 실행: 우클릭 → **열기** → **열기** (Gatekeeper 일회성 우회).
+
+macOS 가 물어보면 **마이크** 권한을 주고, **설정 → 단축키** 에서 단축키를 골라요 (기본값 ⌃⇧Space).
+
+가이드 투어가 필요하다면? [`docs/TUTORIAL.md`](docs/TUTORIAL.md) 참고 —— 설치부터 첫 받아쓰기까지 5 분.
+
+### 또는 AI 에이전트에게 시키기
+
+이걸 Claude Code, Codex, opencode, Hermes 등에 붙여넣으세요:
+
+```text
+Install OpenQuack on this Mac:
+
+  brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+  brew install --cask openquack
+
+(Or grab the DMG from https://github.com/larryxiao/openquack/releases
+and drag it into /Applications; first open right-click → Open → Open.)
+
+Then launch /Applications/OpenQuack.app, grant Microphone, and pick a
+hotkey in Settings → Shortcut. Default ⌃⇧Space.
+```
+
+추가 옵션 (제거, 소스 빌드, 첫 실행 시 받는 것): [`docs/INSTALL.md`](docs/INSTALL.md).
+
+## 감사의 말
+
+OpenQuack 은 너그러운 오픈소스 작업의 어깨 위에 서 있습니다. 큰 감사를 전합니다:
+
+- [**OpenAI Whisper**](https://github.com/openai/whisper) —— 이 모든 것을 가능하게 한 음성 모델.
+- [**WhisperKit**](https://github.com/argmaxinc/WhisperKit) by Argmax —— Apple Silicon 위에서 빠르고 네이티브로 도는 Whisper.
+- [**KeyboardShortcuts**](https://github.com/sindresorhus/KeyboardShortcuts) by Sindre Sorhus —— 매일 누르는 단축키 메커니즘.
+- [**voxt**](https://github.com/hehehai/voxt) —— 같은 결의 프로젝트, 기술적인 면에서 많이 배웠어요.
+- [**Typeless**](https://www.typeless.com/) 와 [**Wispr Flow**](https://wisprflow.ai/) —— 클로즈드 소스이지만, 음성 우선 입력이 얼마나 기분 좋은지 증명해준 앱들; 같은 감각을 로컬에서, 오픈으로 목표하고 있어요.
+
+그리고 이슈를 올려주신 분들, PR 을 보내주신 분들, 친구에게 알려주신 모든 분들에게: 감사합니다. 이 오리가 꽥거리는 건 여러분 덕분이에요.
+
+## 기여
+
+OpenQuack 은 **AI 네이티브 오픈소스** —— 모든 PR 이 SPEC 을 인용하고, 원자적 작업은 로드맵에서 옵니다. 워크플로는 코딩 에이전트에게도 (같은 길을 가는 사람에게도) 친화적이에요.
+
+[`AGENTS.md`](AGENTS.md) 에서 시작해서, [`docs/ROADMAP.md`](docs/ROADMAP.md) 에서 🔵 작업을 골라, 드래프트 PR 을 열어주세요.
+
+내부:[`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md) · [`BLOG`](docs/blog/README.md).
+
+## 라이선스
+
+MIT —— [LICENSE](LICENSE) 참고.
+
+(번역 피드백은 PR 또는 [GitHub Discussions](https://github.com/larryxiao/openquack/discussions) 로 환영합니다.)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Voice dictation for macOS. Nothing leaves your device — audio, text, nothing.
 
 </div>
 
+<p align="center">
+  <strong>English</strong> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.es.md">Español</a> ·
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+> 🌐 Translations are machine-translated stubs. Native-speaker contributions very welcome — open a PR or see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ---
 
 > 📢 **What's new — [v2.0.0-alpha.9](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.9):** blazing-fast dictation, even on long clips. Plus a fresh new look. Hope you like it!

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,127 @@
+<p align="center">
+  <img src="docs/images/banner.png" alt="OpenQuack — 开口说，立即输入,隐私优先。录音浮层显示 'Listening' 与实时音量条；菜单栏弹窗显示 'Pasted at cursor' 以及最近一次转写,底部带 Settings / Quit 按钮。">
+</p>
+
+<div align="center">
+
+**OpenQuack** *开口说，立即输入。隐私优先。*
+
+macOS 上的语音听写工具。一切都不离开你的设备 —— 音频不传、文本不传，什么都不传。
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Platform](https://img.shields.io/badge/platform-macOS%2013%2B-lightgrey.svg)](docs/INSTALL.md)
+[![Status](https://img.shields.io/badge/status-alpha-yellow.svg)](docs/ROADMAP.md)
+
+</div>
+
+> 🌐 **机器翻译。** 欢迎母语者贡献 —— 提交 PR 或参见 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
+> English: [README.md](README.md)
+
+---
+
+> 📢 **新版本 — [v2.0.0-alpha.9](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.9):** 听写飞快,长片段也不卡。还有焕然一新的外观。希望你喜欢!
+
+## 这是什么
+
+OpenQuack 是一个 macOS 菜单栏小程序。按一下快捷键开口说话,再按一下结束 —— 转写文本就出现在光标位置。能打字的地方,都能说话。
+
+语音识别在你的 Mac 上完成。不上云、不要账号、不用注册、零遥测。
+
+## 为什么要做
+
+**本地。** 一切都在你的设备上运行 —— 录音、转写、可选润色。什么都不外传:不传音频、不传文本、零遥测、不用注册。机密内容从设计层面就保持机密。而且因为流程中没有任何 API 调用,所以一直能用 —— 离线、飞机上、企业防火墙后,都不影响。
+
+**快。** Whisper 在 Apple Silicon 上的转写速度大约是说话耗时的五分之一。在 M4 / 16 GB 基准机型上,真实人类语音的词错误率约 ~2.6%。多数情况下比打字更快。完整测试矩阵见 [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md)。
+
+**开源。** MIT 许可证。每一行代码都可审计;每一次改动都在公开进行。你菜单栏里跑的版本,就是这个仓库里的版本。
+
+## 你能得到什么
+
+- **一键听写。** 选个快捷键(默认 ⌃⇧Space)。可设为切换式或按住说话。
+- **全本地。** 语音识别在你 Mac 上跑。听写不需要联网 —— 离线、飞机上、隧道里、企业防火墙后,都能用。不用 API key,没有速率限制,不会服务中断。个人或工作场合,听写体验完全一样。
+- **多语种。** Whisper 支持 99 种语言 —— 英语、中文、日语、韩语、西班牙语、法语、德语、意大利语、葡萄牙语,在设置里直接选;默认开启自动检测。
+- **自动粘贴到光标位置**,适用于任何 app。(也可以回退到剪贴板,自己粘贴。)
+- **智能格式化** —— 大写、句末标点、清理 "嗯/呃" 之类的填充词。
+- **自定义词典** —— 让它认识你真正在用的专有名词和项目名。
+- **静音自动停止。** 你说完了,OpenQuack 自己结束。
+- **实时麦克风音量浮层**,看得见它正在听。
+- **首次启动快速设置** —— 权限、快捷键,一分钟搞定。
+- **极小。** 8 MB 的菜单栏 app,加上首次运行时下载的语音模型。
+- **开源**, MIT。
+
+## 隐私,一屏说清
+
+1. **什么都不离开你的设备 —— 音频、文本,什么都不传。** 录音和转写完全本地。永远是。
+2. **没有数据分析、没有遥测、不用注册。**
+
+完整的隐私契约见 [`docs/VISION.md`](docs/VISION.md#privacy-contract)。
+
+## 即将到来
+
+排队中的功能预览。两者都建立在今天已经发布的听写基础上。
+
+**上下文感知转写。** OpenQuack 会读取你即将粘贴位置周围的文本 —— 光标上方那行、你所在的函数、你正在回复的聊天串 —— 把它作为上下文喂给语音模型。专业术语会根据你正在做的事情自动消歧(在终端里, "cloud code" 会被识别成 "Claude Code",而不是反过来)。需要手动调自定义词典的场景就少了。
+
+**思考模式。** 转写后再加一遍处理,通过一个本地小型 LLM,把你说出来的原话变成你真正会按下发送键的书面句子。剔除冗余、收紧结构、关键词大写正确。默认关闭,一键开启。完全本地 —— Ollama 或 MLX-LM,你选。
+
+时间表和 SPEC 详情见 [`docs/ROADMAP.md`](docs/ROADMAP.md)。
+
+这只鸭子还有更大的计划。整体走向看 [`docs/VISION.md`](docs/VISION.md)。
+
+## 安装
+
+```sh
+brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+brew install --cask openquack
+```
+
+或 [下载 DMG](https://github.com/larryxiao/openquack/releases),拖进 Applications 文件夹。首次启动:右键 → **打开** → **打开**(一次性绕过 Gatekeeper)。
+
+macOS 询问时授予 **麦克风** 权限,在 **设置 → 快捷键** 里选一个快捷键(默认 ⌃⇧Space)。
+
+想要图文教程? 看 [`docs/TUTORIAL.md`](docs/TUTORIAL.md) —— 从安装到第一次听写,五分钟。
+
+### 或者让你的 AI agent 来装
+
+把这段贴给 Claude Code、Codex、opencode、Hermes 或类似工具:
+
+```text
+Install OpenQuack on this Mac:
+
+  brew tap larryxiao/openquack https://github.com/larryxiao/openquack
+  brew install --cask openquack
+
+(Or grab the DMG from https://github.com/larryxiao/openquack/releases
+and drag it into /Applications; first open right-click → Open → Open.)
+
+Then launch /Applications/OpenQuack.app, grant Microphone, and pick a
+hotkey in Settings → Shortcut. Default ⌃⇧Space.
+```
+
+更多选项(卸载、源码构建、首次运行下载了什么):见 [`docs/INSTALL.md`](docs/INSTALL.md)。
+
+## 致谢
+
+OpenQuack 站在了慷慨的开源工作的肩膀上。特别感谢:
+
+- [**OpenAI Whisper**](https://github.com/openai/whisper) —— 让这一切成为可能的语音模型。
+- [**WhisperKit**](https://github.com/argmaxinc/WhisperKit) by Argmax —— Whisper 在 Apple Silicon 上的快速原生实现。
+- [**KeyboardShortcuts**](https://github.com/sindresorhus/KeyboardShortcuts) by Sindre Sorhus —— 你每天按下的那套快捷键机制。
+- [**voxt**](https://github.com/hehehai/voxt) —— 一个志同道合的项目,我们在技术层面学到了很多。
+- [**Typeless**](https://www.typeless.com/) 和 [**Wispr Flow**](https://wisprflow.ai/) —— 闭源应用,但它们证明了语音优先的输入可以多么愉快;我们要做的是同样的体验,以本地、开源的方式。
+
+还有所有提 issue、开 PR、把它推荐给朋友的人:谢谢你们。这只鸭子的每一声叫,都因为你们。
+
+## 贡献
+
+OpenQuack 是 **AI-native 的开源项目** —— 每个 PR 都引用一份 SPEC,原子任务来自路线图,工作流对编程 agent(以及走同一条路的人类)都很友好。
+
+从 [`AGENTS.md`](AGENTS.md) 开始,在 [`docs/ROADMAP.md`](docs/ROADMAP.md) 里挑一个 🔵 任务,开一个 draft PR。
+
+技术细节:[`TUTORIAL`](docs/TUTORIAL.md) · [`DEVELOPMENT`](docs/DEVELOPMENT.md) · [`ARCHITECTURE`](docs/ARCHITECTURE.md) · [`BENCHMARKS`](docs/BENCHMARKS.md) · [`DESIGN`](docs/DESIGN.md) · [`INSTALL`](docs/INSTALL.md) · [`BLOG`](docs/blog/README.md)。
+
+## 许可证
+
+MIT —— 见 [LICENSE](LICENSE)。
+
+(欢迎通过 PR 或 [GitHub Discussions](https://github.com/larryxiao/openquack/discussions) 反馈翻译问题。)

--- a/docs/SPECS/SPEC-019-i18n.md
+++ b/docs/SPECS/SPEC-019-i18n.md
@@ -1,0 +1,234 @@
+# SPEC-019 — App localisation (i18n)
+
+**Status:** draft (M3 — community-translation foundation)
+**Owner:** `OpenQuackApp/Localizable.xcstrings` (new) + `OpenQuackKit`
+**Last updated:** 2026-05-07
+
+## Goal
+
+OpenQuack's UI is English-only today. The app already transcribes 99
+Whisper languages, and we have organic non-English signal (Chinese
+audience trickling from awesome-mac). Localised UI lets users dictate
+in their language **and** read the menus, settings, and onboarding in
+their language — closing the loop.
+
+This spec ships the **infrastructure**, not the translations. Empty
+`.xcstrings` files for each target locale are the deliverable; the
+actual translations come from community contributors via PR (per the
+`docs/CONTRIBUTING.md` translation flow and the `README.zh-CN.md` /
+`README.ja.md` / etc. precedent).
+
+## Why this is M3 priority
+
+- The international-venues research (2026-05-07) found that
+  jaywcjlove/awesome-mac auto-syndicates our entry to its
+  README-zh / README-ja / README-ko parallel lists. So drive-by
+  visitors already arrive in their native language to a localised
+  list — a localised README + localised app closes the loop.
+- The polish bench (M2.5) is built around 99 Whisper languages, so
+  the model side scales naturally. The UI was the bottleneck.
+- Calling for translators is a strong contributor on-ramp — a
+  single-language PR is much smaller than a code contribution and
+  builds attachment from translators who feel ownership.
+
+## Non-goals
+
+- Translating the documentation (`docs/*.md`) in this SPEC. README
+  translations exist (zh-CN, ja, ko, fr, es, de via auto-translation
+  with native-speaker-correction PRs). Other docs follow if there's
+  signal.
+- Locale-specific feature behaviour (e.g., different default models
+  per locale). Defaults stay global.
+- Right-to-left layout support (Arabic, Hebrew). Defer to a later
+  SPEC if signal arrives.
+- Translating SPECs / contributor docs. AGENTS.md, ROADMAP.md, etc.
+  stay English-only — they're for contributors who are already in
+  the dev workflow.
+
+## Target locales (initial)
+
+Match the language picker in `Sources/OpenQuackApp/SettingsView.swift`
+(Settings → General → Transcription language) — same locales the
+app already understands for Whisper:
+
+- `zh-Hans` (Simplified Chinese)
+- `ja` (Japanese)
+- `ko` (Korean)
+- `fr` (French)
+- `es` (Spanish)
+- `de` (German)
+- `it` (Italian)
+- `pt` (Portuguese)
+
+`zh-Hant` (Traditional Chinese) deferred — Whisper's Chinese output
+already has a script picker (`zh-Hans` / `zh-Hant` / `auto`); we
+default zh- to zh-Hans for UI strings until traditional-script signal
+shows up.
+
+The infrastructure ships **empty** for all locales. Translations land
+as PRs.
+
+## Public surface (sketch)
+
+### File layout
+
+```
+Sources/OpenQuackApp/Resources/
+└── Localizable.xcstrings    # NEW — String catalog file
+```
+
+`.xcstrings` is the modern Xcode 15+ string-catalog format. Single
+file, all locales co-resident, JSON-backed. Replaces the older
+per-locale `.strings` + `.stringsdict` directory layout.
+
+### Migration
+
+Every visible string in the app gets converted from a literal to a
+localised lookup:
+
+```swift
+// Before
+Text("Send feedback…")
+
+// After
+Text(String(localized: "settings.menu.send_feedback", defaultValue: "Send feedback…"))
+
+// Or in SwiftUI shorthand:
+Text("Send feedback…", comment: "Status-item right-click menu item")
+```
+
+The `comment:` parameter is what translators see — make every comment
+descriptive (where the string appears, what action it represents).
+The `defaultValue` (or the literal string itself) is the English
+source of truth.
+
+Key files to migrate (~20-30 strings each):
+- `Sources/OpenQuackApp/MenuBarContent.swift`
+- `Sources/OpenQuackApp/SettingsView.swift`
+- `Sources/OpenQuackApp/RecordingOverlay.swift`
+- `Sources/OpenQuackApp/OnboardingFlow.swift`
+- `Sources/OpenQuackApp/OpenQuackApp.swift` (right-click menu)
+- `Sources/OpenQuackApp/SettingsWindowController.swift`
+
+Total estimated: ~150-200 user-visible strings across the app.
+
+### Locale detection + override
+
+Default behaviour: follow the system locale. macOS gives us
+`Locale.current.language.languageCode?.identifier` — if it matches a
+target locale, use it; otherwise fall back to English.
+
+Override surface: a new picker in **Settings → General**:
+
+```swift
+@AppStorage("displayLanguage") private var displayLanguage: String = "system"
+
+Picker("Display language", selection: $displayLanguage) {
+    Text("System").tag("system")
+    Text("English").tag("en")
+    Text("简体中文").tag("zh-Hans")
+    Text("日本語").tag("ja")
+    // …
+}
+```
+
+This is **distinct** from the existing "Transcription language" picker
+(which controls Whisper) — display language is for the UI, transcription
+language is for the speech model. Both live in Settings → General.
+
+The `displayLanguage` UserDefault is read at app launch via
+`Bundle.main.preferredLocalizations` override (set
+`AppleLanguages` defaults key). Locale change requires app restart;
+surface a "restart to apply" hint when the user changes it.
+
+### Pluralization
+
+Swift's `String(localized:)` supports plurals via `.xcstrings` plural
+variations. Strings that pluralize (e.g., "%d transcript" /
+"%d transcripts") use the variation form per locale.
+
+Example:
+```swift
+Text("\(history.count) recorded", comment: "History count, plural-aware")
+```
+
+Translators handle the plural rules per locale (e.g., Russian has 3
+plural categories, Polish has 4, Japanese has 1).
+
+### Privacy contract — no change
+
+Localisation is pure UI; no audio, no network, no telemetry. The
+privacy contract in `docs/VISION.md#privacy-contract` is unaffected.
+
+## Implementation order
+
+Atomic PRs:
+
+| # | Title | Branch | Effort | Files |
+|---|---|---|---|---|
+| 1 | Add `Localizable.xcstrings` (empty) + Settings → Display Language picker | `feat/spec-019-infra` | S | `Sources/OpenQuackApp/Resources/Localizable.xcstrings` (new), `Sources/OpenQuackApp/SettingsView.swift` (edit) |
+| 2 | Migrate `MenuBarContent.swift` strings to localised lookups | `feat/spec-019-menubar` | S | `MenuBarContent.swift` (edit), `Localizable.xcstrings` (auto-extracted) |
+| 3 | Migrate `SettingsView.swift` strings | `feat/spec-019-settings` | M | `SettingsView.swift` (edit) — biggest single file |
+| 4 | Migrate `RecordingOverlay.swift` + `OnboardingFlow.swift` strings | `feat/spec-019-overlay-onboarding` | S | both files |
+| 5 | Migrate `OpenQuackApp.swift` (right-click menu) + remaining surfaces | `feat/spec-019-app-menus` | S | OpenQuackApp.swift + any leftovers |
+| 6 | First community translation lands (e.g., zh-Hans) | external PR | — | `Localizable.xcstrings` (translator fills the zh-Hans column) |
+
+PRs 1-5 are infrastructure (we write them). PR 6+ are community
+contributions.
+
+### CI: lint that strings are localised
+
+After PR 5 lands, add a CI check that fails if a SwiftUI `Text("…")`
+literal appears outside a `String(localized:)` / commented form. Cheap
+guard against regressions.
+
+## Translation contribution flow
+
+Documented in `docs/CONTRIBUTING.md` and the language switcher
+section of each `README.<lang>.md`:
+
+1. Fork the repo.
+2. Open `Sources/OpenQuackApp/Resources/Localizable.xcstrings` in
+   Xcode 15+ (renders as a string-catalog editor with per-locale
+   columns).
+3. Translate the English source strings to your locale.
+4. Open a PR titled `i18n: translate to <locale-name>`.
+5. We merge if the translations are complete enough to be useful
+   (≥80% coverage, no UI-breaking length issues — long German
+   strings need testing).
+
+Maintainer responsibilities:
+- Don't write translations ourselves unless we're a native speaker
+  (the same hand-write-or-native-speaker rule that applies to promo
+  copy).
+- Merge community translations promptly (≤7 days).
+- If a translator vanishes mid-locale, mark the locale "partial" in
+  the README and welcome follow-on PRs.
+
+## Open questions
+
+- **Bundle vs runtime locale switch.** macOS prefers per-app
+  `AppleLanguages` defaults. Our override picker writes that key
+  and prompts restart. Verify on macOS 13 (our minimum) — the API
+  is stable but the key name has had variations.
+- **Onboarding-flow first-launch locale.** First-launch onboarding
+  runs before the user can change preferences — should it use the
+  system locale or English? Lean system; if the user picks a
+  display language during onboarding, that becomes their override.
+- **Long-string fallback.** Some translations are 1.5-2× longer
+  than English (notably German). Verify Settings layout doesn't
+  truncate. Add max-width hints in `comment:` where the layout is
+  tight.
+- **Translation-currency badge.** As Whisper / model menus evolve,
+  some strings may go stale. Consider a "translation currency"
+  display in About — shows the % of strings translated per locale.
+  Defer to post-PR-5.
+
+## References
+
+- [Swift String Catalogs WWDC 2023](https://developer.apple.com/videos/play/wwdc2023/10155/) — the introduction.
+- [`String.LocalizationValue`](https://developer.apple.com/documentation/swift/string/localizationvalue)
+  — the API surface.
+- AGENTS.md — atomic PR + SPEC-cite workflow applies to all 6 PRs.
+- `docs/CONTRIBUTING.md` — community-side guidance for translators.
+- `docs/VISION.md#privacy-contract` — preserved (UI-only change).


### PR DESCRIPTION
## SPEC

[SPEC-019 (i18n)](../blob/docs/spec-019-i18n-contributing/docs/SPECS/SPEC-019-i18n.md) — new spec landing in this PR.

## Milestone

M3 (community-translation foundation).

## Why

The international-venues research (catalog: `gtm/international-venues.md`) found that `jaywcjlove/awesome-mac` maintains parallel `README-zh.md` / `README-ja.md` / `README-ko.md` and auto-syndicates English entries to those localised lists. So drive-by visitors already arrive in their native language to a localised list — a localised README + localised app closes the loop.

Independently: we have organic Chinese-audience signal (3 stars + 1 fork attributable to the awesome-mac merge), which is the strongest single channel-audience effect we've measured. Translation is the natural multiplier.

This PR ships the **infrastructure motivation** (the SPEC) and the **community contribution path** (the CONTRIBUTING.md) — not the translations themselves. Translations are community PRs against `Localizable.xcstrings` (per the SPEC) and against the `README.<lang>.md` files (machine-translated stubs ship in a follow-up PR).

## Change

- `docs/SPECS/SPEC-019-i18n.md` (new) — the i18n contract:
  - Single `Localizable.xcstrings` file (Xcode 15+ string catalog format)
  - 8 target locales matching the existing Whisper language picker (`zh-Hans`, `ja`, `ko`, `fr`, `es`, `de`, `it`, `pt`)
  - 6-PR migration sequence (MenuBarContent → SettingsView → Overlay/Onboarding → app menus → first community translation)
  - Settings → Display Language picker (distinct from the existing Transcription Language picker)
  - Restart-to-apply hint when Display Language changes
  - Pluralization via `.xcstrings` plural variations
  - CI lint that strings are localised after PR 5 lands
  - Translation contribution flow (fork → Xcode → translate → PR)
- `CONTRIBUTING.md` (new, repo root) — five sections:
  1. Help us test it (any Mac, any language)
  2. Help us benchmark on your Mac → links `bench/CONTRIBUTING.md`
  3. Help us translate the app and docs → links SPEC-019 + the future `README.<lang>.md` stubs
  4. Contribute code → links AGENTS.md
  5. Spread the word — only if it works for you

## Tests

- [x] No code change; manual verification: all internal links resolve, file references match the repo.

## Privacy impact

None. SPEC-019 is UI-only. The privacy contract in `docs/VISION.md#privacy-contract` is unaffected when the i18n implementation ships in follow-up PRs.

## Out of scope

- The 6 atomic implementation PRs (separate branches per the SPEC's "Implementation order" table)
- Translating `docs/*.md` beyond the README — defer to a later spec
- Right-to-left layout (Arabic, Hebrew) — defer
- The `README.<lang>.md` stubs themselves — coming in a follow-up PR after the in-flight translation subagent lands