### PR TITLE
docs(integrations): Claude Code + Cursor pairing guides

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,28 @@
+# Integrations
+
+Practical workflow guides for pairing OpenQuack with tools you already
+use. Each guide is short, focused on one tool, and centered on what
+the tool's users actually do — not "here's how OpenQuack works."
+
+These are written for users of the *other* tool first. If you don't
+use the tool already, skip the guide.
+
+## Available
+
+- [Using OpenQuack with Claude Code](claude-code.md) — voice-driven
+  prompts in your terminal
+- [Using OpenQuack with Cursor](cursor.md) — voice as the input
+  modality for Cursor's Composer / chat panes
+
+## Coming
+
+- Aider (similar shape to Claude Code; deferred until written)
+- Obsidian (waits on the PKM workflow content; SPEC-019 i18n landing
+  first)
+- Generic shell / zsh-line-editing patterns
+
+## Contributions welcome
+
+If you've found a workflow that pairs OpenQuack well with a tool we
+don't list, open a PR with the guide. Same shape as the existing
+files: short, practical, written for that tool's users.

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,103 @@
+# Using OpenQuack with Claude Code
+
+Claude Code (the CLI) takes long, intent-rich prompts well. Typing
+those prompts is the bottleneck. Speaking them through OpenQuack
+removes it.
+
+This guide is for people who already use Claude Code. If you're new
+to it, install via `npm install -g @anthropic-ai/claude-code` and run
+`claude` in any directory; the documentation lives at
+[claude.com/claude-code](https://claude.com/claude-code).
+
+## The pairing in one sentence
+
+Press the OpenQuack hotkey, describe what you want Claude Code to do
+(as long as you'd think it), release — the transcript appears at
+your cursor in the Claude Code prompt. Press Enter.
+
+## Why it works well
+
+Claude Code prompts have an unusual shape: they reward **detail and
+context**. "Fix the bug" is worse than "There's a race in the
+streaming-pump frame ordering — Task spawning per buffer doesn't
+guarantee FIFO at the actor; the AsyncStream pump fixes it. Apply
+that pattern in `Sources/OpenQuackApp/OpenQuackApp.swift` line ~498."
+The longer prompt is faster to *speak* than to *type*. Voice
+collapses the typing tax on detail.
+
+OpenQuack is built for this specific shape — long-form dictation
+where the wait time after stop stays constant in clip length. A
+30-second prompt finishes pasting ~3 seconds after you stop talking
+(see [`docs/BENCHMARKS.md`](../BENCHMARKS.md)). On most other
+dictation tools, the post-stop wait scales with your prompt length.
+
+## Setup (5 minutes)
+
+1. Install OpenQuack ([`docs/INSTALL.md`](../INSTALL.md)).
+2. Grant Microphone + Accessibility when macOS asks. Accessibility
+   is what lets the transcript paste at your cursor in the terminal;
+   without it the transcript only goes to the clipboard.
+3. Pick a hotkey in **Settings → Shortcut** that you'd want to press
+   while your hands are on the keyboard. The default ⌃⇧Space works
+   well in most terminals; alternatives that don't conflict with
+   common terminal bindings: F5, F12, ⌥⇧V.
+4. In Claude Code, position your cursor in the prompt area, press
+   the hotkey, speak your intent, press the hotkey again to stop.
+   Press Enter to send.
+
+## Workflow patterns that pair well
+
+**Steering the agent.** Describe the higher-level direction and
+constraints, then let Claude Code handle the implementation. Voice
+is faster than typing for this because most of what you'd say is
+intent, not code. Example: *"Read the polish engine spec, scope down
+PR #2 to just the protocol surface, file it as a draft PR."*
+
+**Reviewing diffs aloud.** Read what Claude Code wrote back to it as
+you scan. *"That's right — but rename `currentPolishEngine` to
+`makePolishEngine` since it constructs rather than fetches. Apply."*
+Voice keeps your hands free to scroll.
+
+**Running approval prompts.** Claude Code asks for approval before
+running commands. Voice the approval if your hands are away from
+the keyboard. *"Yes, run it."*
+
+**Dictating commit messages.** OpenQuack pastes anywhere a cursor
+sits, including the `git commit -e` editor. Speak the commit body
+naturally; the multi-paragraph cadence translates well.
+
+## Pitfalls
+
+- **Don't dictate code blocks.** Whisper transcribes prose, not
+  syntax. If you need to drop in a code snippet, copy-paste — voice
+  is for the surrounding intent.
+- **Proper nouns and jargon.** Add project names, file paths, and
+  technical terms to **Settings → General → Custom dictionary**
+  (one per line). Whisper biases toward those words during
+  decoding. Without it: "Whisper Kit" might come out two words;
+  "Claude Code" might come out "cloud code."
+- **First transcription is slow.** Whisper has a cold start on
+  Apple Silicon (~10-30 s for `medium` on M-series). Open OpenQuack
+  before Claude Code so the model is warm when you press the
+  hotkey.
+
+## Why not just type
+
+You can. The point isn't that voice is universally better — it's
+that for *long, detailed prompts*, voice is faster end-to-end. A
+40-word prompt takes ~10 seconds to speak and ~3 seconds to paste.
+Same prompt takes 30+ seconds to type at 90 WPM (and that's a
+typing speed most people don't sustain).
+
+If you mostly send 5-word prompts, OpenQuack doesn't help. If your
+prompts to Claude Code are paragraphs of context, it's the right
+shape.
+
+## Privacy
+
+Claude Code itself routes your prompts through Anthropic's API
+under your auth. OpenQuack doesn't change that — it just gets the
+prompt from your voice into the prompt field. Audio and the
+transcript stay on your Mac (transcribed locally via WhisperKit);
+nothing OpenQuack does adds a network hop. The privacy gradient is
+yours to set per Claude Code's settings.

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,96 @@
+# Using OpenQuack with Cursor
+
+Cursor's Composer and chat panes take prompts well — and the longer
+and more contextual the prompt, the better the result. Voice is the
+fastest way to produce that kind of prompt.
+
+This guide is for people who already use Cursor. If you're new,
+download from [cursor.sh](https://cursor.sh).
+
+## The pairing in one sentence
+
+Click into Composer (`⌘I`) or the chat pane, press the OpenQuack
+hotkey, describe what you want Cursor to do as you'd describe it
+to a teammate, release — the transcript pastes into Cursor's input.
+
+## Why it works well
+
+The prompts that produce the best Cursor output are the ones that
+spell out **what to change, why, and the constraints**. That shape
+is verbose by nature. "Refactor `parseConfig` to handle the new
+schema, keep the old format readable as a fallback, throw on
+ambiguity rather than guessing — see how `parseLegacy` handles the
+same case for reference" is a paragraph. Speaking it takes ~12
+seconds; typing it takes 40+.
+
+OpenQuack's streaming transcription means the post-stop wait stays
+~constant in clip length. A 30-second prompt pastes ~3 seconds
+after you stop speaking, regardless of length (see
+[`docs/BENCHMARKS.md`](../BENCHMARKS.md)). Most dictation tools'
+post-stop wait scales with prompt length, which interrupts the
+think-then-send flow.
+
+## Setup (5 minutes)
+
+1. Install OpenQuack ([`docs/INSTALL.md`](../INSTALL.md)).
+2. Grant Microphone + Accessibility when macOS asks. Accessibility
+   is what lets the transcript paste at the cursor inside Cursor;
+   without it the transcript only lands on the clipboard.
+3. Pick a hotkey in **Settings → Shortcut**. Cursor uses ⌘K, ⌘L,
+   and ⌘I heavily; ⌃⇧Space (default), F5, or ⌥⇧V are safe choices.
+4. Click into Composer or the chat input, press hotkey, speak,
+   press again to stop. Press Enter to send.
+
+## Workflow patterns
+
+**Composer, with Cmd+I:** open Composer, dictate the change spec
+naturally — file scope, target behaviour, constraints, references
+to existing patterns. Hit Enter. Cursor reads, applies. Review the
+diff visually.
+
+**Chat pane for clarification:** when Cursor proposes something
+that's *almost* right, voice the correction. Voice is faster than
+typing for the kind of micro-feedback that comes naturally in the
+moment ("yes but use `Result<T,E>` not `throws` — match the rest of
+the file").
+
+**Cmd+K for inline edits:** speak the change at the line level. Hit
+return. Cursor inserts the edit at the cursor.
+
+**Long-form refactor briefs:** for changes spanning multiple files,
+the brief is often a paragraph. Voice it once into Composer rather
+than typing it into chat. The streaming-tail latency win is the
+biggest here.
+
+## Pitfalls
+
+- **Don't dictate code.** Whisper transcribes prose, not syntax.
+  Type literal code; voice the surrounding intent.
+- **Proper nouns and project names.** Add them in **Settings →
+  General → Custom dictionary** (one per line). "Whisper Kit"
+  becomes one word, "Cursor's Composer" stays as written.
+- **Cursor's UI takes focus.** If your hotkey doesn't fire, click
+  into the Cursor input first to make sure focus is there, then
+  press the OpenQuack hotkey.
+- **First transcription is slow.** Whisper cold-starts on Apple
+  Silicon (~10-30 s for `medium` on M-series). Open OpenQuack
+  before Cursor so the model is warm when you press the hotkey.
+
+## Why not just type
+
+For short questions ("what does this function do?"), typing is
+fine. For *long, contextual prompts*, voice is faster end-to-end:
+a 50-word brief takes ~15 seconds to speak and ~3 seconds to paste,
+vs ~40+ seconds to type at sustained 90 WPM.
+
+If you find Cursor most useful for short edits, OpenQuack adds
+little. If you produce paragraph-length specs, the latency win is
+the difference between flow and stop-and-go.
+
+## Privacy
+
+Cursor's prompts route through Cursor's services per their privacy
+settings. OpenQuack doesn't change that — it just gets your voice
+into the prompt field. Audio and the transcript stay on your Mac
+(transcribed locally via WhisperKit); OpenQuack adds no network
+hop. The privacy gradient is yours to set per Cursor's settings.


### PR DESCRIPTION
## SPEC

n/a — pure docs.

## Milestone

n/a — E4 from the D-014 / D-013 experiment plan (cross-tool integration content). Value-creation for users of those tools; not promotional.

## Why

Claude Code and Cursor users routinely produce long, contextual prompts — the shape that benefits most from voice input. There's no current canonical guide for "how to pair voice dictation with these tools." This PR adds two.

The framing matters: each guide is written **for users of the other tool first**. The pitch is "here's how to add voice to your existing workflow," not "here's why you should switch dictation tools." That makes them genuinely useful (and shareable in r/cursor / r/ClaudeAI as workflow guides rather than promo).

The long-form-dictation USP (5-min clip → 2.8s post-stop, vs polish-by-default tools that scale with length) is the load-bearing reason to dictate at all into long Claude Code / Cursor prompts. The guides anchor on this without making it the headline.

## Change

- `docs/integrations/README.md` (new) — index + contribution invite for community-PR'd guides for other tools (Aider, Obsidian, etc.)
- `docs/integrations/claude-code.md` (new) — voice-driven prompts for the Claude Code CLI; setup, workflow patterns (steering, diff review, approval, commit messages), pitfalls, "why not just type" tradeoff, privacy note
- `docs/integrations/cursor.md` (new) — same shape for Cursor (Composer, chat, Cmd+K surfaces)

Each guide:
- Opens with "the pairing in one sentence"
- Anchors the productivity argument on the bench-verified streaming-tail latency win
- 5-min setup steps (install + permissions + hotkey)
- 3-4 workflow patterns specific to that tool
- Pitfalls (don't-dictate-code, custom-dictionary for jargon, cold-start)
- Honest "why not just type" tradeoff — voice doesn't help for short prompts
- Privacy note — explicit that the user's existing routing (Anthropic API for Claude Code, Cursor's services for Cursor) is unchanged; OpenQuack adds no network hop

## Tests

- [x] No code change; manual: relative links resolve, file references match repo paths.

## Privacy impact

None.

## Out of scope

- Aider, Obsidian, generic shell guides — deferred (community contributions welcome per the README)
- Translations — defer to community PRs
- Linking from main README's "Contribute" or "Coming next" sections — straightforward follow-up
- Posting these guides as workflow content in r/cursor / r/ClaudeAI — that's a Larry-bound action; the docs are the prerequisite