### PR TITLE
docs: surface long-form-dictation USP in README "Why" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Speech recognition happens on your Mac. No cloud, no account, no signup, no tele
 
 **Local.** Everything runs on your device — recording, transcription, optional polish. Nothing leaves: no audio, no text, no telemetry, no signup. Confidential work stays confidential, by construction. And because there's no API call in the loop, it just keeps working — offline, on a plane, behind a corporate firewall.
 
-**Fast.** Whisper on Apple Silicon transcribes in roughly a fifth of the time you spent speaking. ~2.6% word-error rate on real human speech on a baseline M4 / 16 GB. Faster than typing in most cases. Full bench matrix in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
+**Fast.** Whisper on Apple Silicon transcribes in roughly a fifth of the time you spent speaking. ~2.6% word-error rate on real human speech on a baseline M4 / 16 GB. Faster than typing in most cases. Especially fast on long dictations: a 5-minute clip finishes in about 3 seconds after you stop, regardless of length, because we stream chunks while you speak. Full bench matrix in [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
 
 **Open.** MIT-licensed. Every line is auditable; every change happens in public. The version running in your menu bar is the version in this repo.
 


### PR DESCRIPTION
## SPEC

n/a — pure docs.

## Milestone

n/a (D-014 follow-up — README callout was deferred from that decision pending PR #10 conflict resolution; safe to land separately since PR #10 touches the footer line, this touches the "Why" section).

## Why

Per D-014: the load-bearing USP is the streaming-tail latency win on long-form dictation (post-stop wait ~constant in clip length). The README's "Why" → "Fast" paragraph previously surfaced only WER + RTF — both dev-audience numbers — and didn't surface what's distinct about *long-form* usage.

The PKM / thinker / journaler audience opened by D-014 (catalog: `gtm/pkm-thinker-audience.md`) needs to see the latency claim front-and-center to recognize the fit. Without it, drive-by visitors skim past us as "yet another dictation app."

## Change

`README.md` — adds one sentence to the "Fast" paragraph:

> Especially fast on long dictations: a 5-minute clip finishes in about 3 seconds after you stop, regardless of length, because we stream chunks while you speak.

That's the entire diff. Anchored on `bench/out/stream/M4-16GB-paced/report.md` (5-min clip: 2.77s post-stop vs 34.44s offline, 12.4× speedup).

## Tests

- [x] No code change; manual: link to `docs/BENCHMARKS.md` continues to resolve, sentence reads naturally in context, no em-dash bloat.
- [x] No conflict with PR #10 (different sections).

## Privacy impact

None.

## Out of scope

- Linking to `docs/COMPARISON.md` (PR #13), `docs/WHISPER-ON-MAC-FAQ.md` (PR #14), `docs/integrations/` (PR #15) — those PRs aren't merged yet; bundle README cross-links once they all land.