### PR TITLE
feat(SPEC-020): one-click Copy button on the last-transcript card

### DIFF
--- a/Sources/OpenQuackApp/MenuBarContent.swift
+++ b/Sources/OpenQuackApp/MenuBarContent.swift
@@ -169,7 +169,7 @@ struct MenuBarContent: View {
     private var transcriptSection: some View {
         if let transcript = state.lastTranscript, !transcript.isEmpty {
             VStack(alignment: .leading, spacing: Theme.s8) {
-                HStack {
+                HStack(spacing: Theme.s8) {
                     SectionHeader("Last transcript")
                     Spacer()
                     if let dur = state.lastAudioSeconds, let wall = state.lastWallSeconds {
@@ -178,6 +178,7 @@ struct MenuBarContent: View {
                             .font(.caption2.monospacedDigit())
                             .foregroundStyle(.tertiary)
                     }
+                    CopyTranscriptButton(text: transcript)
                 }
                 Text(transcript)
                     .font(.body)
@@ -262,5 +263,38 @@ private struct PopoverLevelMeter: View {
         let total = max(1, history.count - 1)
         let position = Double(index) / Double(total)
         return 0.45 + 0.45 * position
+    }
+}
+
+// MARK: - Copy-to-clipboard button (SPEC-020)
+
+/// One-click copy of the last transcript. Lives next to the dur·rtf metric
+/// in the "Last transcript" section header. Label flips to "Copied" for
+/// 1.5s after a tap; tapping again before that resets the timer cleanly.
+private struct CopyTranscriptButton: View {
+    let text: String
+    @State private var copied = false
+    @State private var resetTask: Task<Void, Never>?
+
+    var body: some View {
+        Button(action: handleTap) {
+            Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
+                .font(.caption2)
+                .labelStyle(.titleAndIcon)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .accessibilityLabel(copied ? "Transcript copied to clipboard" : "Copy transcript to clipboard")
+    }
+
+    private func handleTap() {
+        PasteService.copyToClipboard(text)
+        resetTask?.cancel()
+        copied = true
+        resetTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            copied = false
+        }
     }
 }

--- a/docs/SPECS/SPEC-020-copy-transcript-button.md
+++ b/docs/SPECS/SPEC-020-copy-transcript-button.md
@@ -1,0 +1,47 @@
+# SPEC-020 — One-click "Copy" button for the last transcript
+
+## Goal
+
+Give users a one-click way to copy the last transcript to the clipboard from the menu-bar popover. Today the transcript card has `textSelection(.enabled)` (manual ⌘A → ⌘C works) but no button. When the user dictated into a window that has since lost focus — the most common failure mode for paste-at-cursor — they need to grab the text and paste it manually elsewhere. Selecting text by hand inside the popover is fiddly because closing the popover (e.g., switching to Mail) can collapse the selection.
+
+## What it does
+
+- Adds a small `Copy` button in the "Last transcript" section header of `MenuBarContent.swift`, sibling to the existing `dur · rtf` metric.
+- On tap: writes `state.lastTranscript` to the general pasteboard via the existing `PasteService.copyToClipboard(_:)` helper. No clearing of previous clipboard, no special types.
+- Visual feedback: the button label flips to `Copied` for ~1.5s, then reverts to `Copy`. Implemented with a `@State` flag + `Task.sleep`. SF Symbol on the button: `doc.on.doc` (the standard "copy" glyph).
+- The button is only rendered inside the same `if let transcript = state.lastTranscript, !transcript.isEmpty` guard that already governs the section, so it's never visible when there's nothing to copy.
+
+## Non-goals
+
+- No new keyboard shortcut. The popover's existing `textSelection(.enabled)` continues to handle ⌘A / ⌘C for power users.
+- No clipboard history — that's `SPEC-014-local-history.md`.
+- No analytics on usage. (Privacy contract: nothing leaves the device.)
+- No haptic / sound feedback. The label flip is sufficient on macOS.
+
+## Why this is small
+
+- One-file change in `Sources/OpenQuackApp/MenuBarContent.swift`.
+- No new dependencies, no new SwiftUI surface, no settings.
+- `PasteService.copyToClipboard(_:)` already exists (defined as the "Copy buttons / fallback paths" helper at `Sources/OpenQuackKit/Output/PasteService.swift` line 45) — this SPEC just wires the button to it.
+- No model migration, no settings persistence, no SettingsView change.
+
+## How it interacts with existing behaviour
+
+- The transcript already lands on the clipboard automatically in two cases:
+  - Paste-at-cursor succeeds — clipboard is restored to its previous contents (per `PasteService.swift`).
+  - Paste-at-cursor falls back (no Accessibility / focus-loss race) — the transcript is left on the clipboard, and the popover status reads "On clipboard".
+- The `Copy` button is the deterministic third path: works in both cases above, lets the user re-copy at will (e.g., after their own pasteboard has cycled through other things), without depending on whether paste-at-cursor succeeded.
+
+## Test plan
+
+- Manual: dictate, lose focus on target window before transcription finishes, verify popover still shows transcript and "Copy" works.
+- Manual: dictate twice in a row; verify "Copy" copies the *latest* transcript, not the previous one.
+- Manual: tap "Copy" repeatedly; verify the "Copied" label correctly reverts and re-flips on the second tap (no stuck state from a cancelled Task).
+- Manual: confirm the button is hidden when no transcript exists.
+- Existing build/test/smoke-bench CI passes (no behavioural change to tests).
+
+## Out of scope (future)
+
+- Multi-transcript history with per-row Copy (deferred to SPEC-014 local history).
+- Right-click context menu on the transcript card with Copy + Save + Send to (also deferred).
+- Per-app smart copy formats (rich text vs plain) — overkill for v1; plain-text only.


### PR DESCRIPTION
## Summary

- Adds a small **Copy** button beside the `dur · rtf` metric in the menu-bar popover's *Last transcript* section.
- Wires to the existing `PasteService.copyToClipboard(_:)` helper at `Sources/OpenQuackKit/Output/PasteService.swift:45` (no new clipboard plumbing).
- Label flips to **Copied** for ~1.5s after a tap; cancel/restart logic so a second tap doesn't get stuck mid-revert.
- One-file code change in `Sources/OpenQuackApp/MenuBarContent.swift` plus a SPEC at `docs/SPECS/SPEC-020-copy-transcript-button.md`.

## Why

Closes the focus-loss gap: when the auto-paste lands on a window that no longer has the cursor (or the user clicked elsewhere mid-dictation), the popover still shows the transcript with `textSelection(.enabled)`, but selecting + copying by hand is fiddly because closing the popover (e.g., switching to Mail) collapses the selection. A button is the deterministic third path.

## Test plan

- [ ] Build green (smoke-bench / swift build / swift test in CI)
- [ ] Manual: dictate, lose focus on target window before transcription finishes, verify popover still shows transcript and **Copy** writes it to the clipboard
- [ ] Manual: dictate twice in a row; verify **Copy** copies the *latest* transcript, not the previous one
- [ ] Manual: tap **Copy** repeatedly; verify the *Copied* label correctly reverts and re-flips on the second tap
- [ ] Manual: confirm the button is hidden when no transcript exists
- [ ] No SettingsView changes; nothing settings-persistent introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)