### PR TITLE
docs(roadmap): flatten milestone structure into a single priority-ordered table

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,112 +1,73 @@
 # Roadmap
 
-Phased milestones with PR-sized atomic tasks. Every task cites a SPEC. Agent contributors should claim a task by opening a draft PR; see [AGENTS.md](../AGENTS.md).
+Atomic tasks — every item cites a SPEC and maps to a PR. Agent contributors should claim a task by opening a draft PR; see [AGENTS.md](../AGENTS.md).
 
-## Status legend
+## Status
 
+- 🟡 **in progress** — draft PR or open issue
 - 🔵 **spec** — `docs/SPECS/<id>.md` exists; ready to claim
-- 🟡 **in progress** — there is a draft PR or open issue
+- ⚪ **idea** — not specced yet
 - 🟢 **done** — merged
-- ⚪ **idea** — not specced yet, scope deliberately vague
 
 ---
-
-## M1 — Foundation _(current)_
-
-Bench framework + first characterisation. Establishes ground truth before product decisions.
 
 | | Task | Spec | Notes |
 |---|---|---|---|
-| 🟢 | SPM scaffolding (Kit + bench + CLI) | — | `Package.swift`, three targets |
-| 🟢 | WhisperKit engine | SPEC-002 | primary; Apple Silicon Metal |
-| 🟢 | Lightning engine (Python subprocess) | SPEC-002 | bench-only baseline |
-| 🟢 | Metrics: WER / CER / RTF / RSS / cold-start | SPEC-002 | `OpenQuackKit/Metrics/` |
-| 🟢 | Corpus: 177 clips (TTS / multilingual / LibriSpeech / noise-aug) | — | `bench/corpus/` |
-| 🟢 | Bench rerun on enriched corpus → BENCHMARKS.md | — | M4/16GB matrix landed |
-| 🟢 | `openquack-cli` (single-file transcribe) | SPEC-002 | quick experiments |
-| 🟢 | Vision + roadmap + AGENTS.md + spec scaffold | — | foundation in place |
-
----
-
-## M2 — Voice → Action MVP
-
-Goal: a working "speak → agent acts" loop on macOS, hotkey to action. Ships an installable but unsigned `.app`.
-
-| | Task | Spec | Effort |
-|---|---|---|---|
-| 🟢 | App shell — SwiftPM target, menu bar, About panel | SPEC-010 | S |
-| 🟢 | Audio capture — AVAudioEngine → 16 kHz mono WAV | SPEC-001 | S |
-| 🟢 | Global hotkey (⌃⇧Space toggle, KeyboardShortcuts pkg) | SPEC-003 | S |
-| 🟢 | Record → WhisperKit `medium` (en) → transcript in popover + clipboard | SPEC-002 | S |
-| 🟢 | Floating recording-state pill (top-centre, click-through) | SPEC-004 | M |
-| 🟢 | CGEvent ⌘V auto-paste at cursor (Accessibility prompt + clipboard fallback) | SPEC-005 | S |
+| 🟡 | Send-feedback menu item — one click from status item to GitHub issue chooser | SPEC-018 | S |
 | 🔵 | Agent session protocol + `PassthroughAgent` + conversation panel | SPEC-006 | M |
 | 🔵 | `ClaudeCodeAgent` — long-lived subprocess, streaming events | SPEC-006 | M |
 | 🔵 | Approval prompt UX (overlay morph + buttons) | SPEC-006 | S |
-| 🟢 | Onboarding flow (Welcome → Mic → Paste → Hotkey → Done) | — | M |
-| 🟢 | Settings scene MVP (General / Models / Shortcut / About) | — | M |
-| 🔵 | Settings — Privacy + Agent panes (lands with SPEC-006 impl) | SPEC-006 | S |
-| 🟢 | Smart text post-processing (capitalise, punct, fillers) | — | S |
-| 🟢 | Live level meter + push-to-talk | SPEC-001 ext | S |
-| 🟢 | VAD auto-stop + sounds + custom dictionary | — | S |
-| 🟢 | App icon (procedural cream-gradient duck) | — | S |
-| 🟢 | DMG + Homebrew cask + README polish | — | S |
-
-**M2 done when:** fresh user installs, completes onboarding, presses hotkey, says *"open a PR for this branch"* in a Claude-Code-configured repo, and a PR appears.
-
----
-
-## M2.5 — LLM transcript polish _(next-priority chunk after v0 launch)_
-
-User-flagged priority on 2026-04-27. Stronger transcript cleanup via a
-small local LLM, off by default but a one-toggle opt-in. Goal: a transcript
-the user can press send on without re-reading. Lays the LLM infra that
-SPEC-006 (agent dispatch) builds on.
-
-| | Task | Spec | Effort |
-|---|---|---|---|
+| 🔵 | Settings — Privacy + Agent panes | SPEC-006 | S; lands with agent impl |
 | 🔵 | `TextPolishEngine` protocol + `OllamaPolishEngine` (HTTP) | SPEC-007 | S |
 | 🔵 | `MLXLMPolishEngine` (in-process via mlx-swift-lm) | SPEC-007 | M |
 | 🔵 | Settings → Polish pane (engine picker, model picker) | SPEC-007 | S |
 | 🔵 | Bench polish WER delta + latency on `openquack-bench` | SPEC-007 | S |
 | 🔵 | Domain-term accuracy bench (e.g. "Claude Code" not "cloud code") | SPEC-007 | S |
 | 🔵 | "Send-confidence" bench: % of utterances clean enough to ship as-is | SPEC-007 | S |
-
-## M3 — Agents + polish
-
-| | Task | Spec | Effort |
-|---|---|---|---|
+| 🔵 | Usage stats pane: words dictated, time saved, audio processed — local-only | SPEC-013 | S |
+| 🔵 | Local audio + transcript history — local-only, retention cap | SPEC-014 | M |
 | ⚪ | `OllamaAgent` (local HTTP) | SPEC-006 ext | S |
 | ⚪ | `MLXLMAgent` (in-process via mlx-swift-lm) | SPEC-006 ext | M |
-| ⚪ | Active-app context: feed the foreground app + focused input field's surrounding text into Whisper's prompt bias and the polish/agent prompt, so domain terms resolve correctly and the agent has the same context the user does (sequenced after M2.5) | new SPEC | M |
-| 🟢 | Stream transcription for long audio (>~30s): chunk while recording so wait time after stop stays flat. Perf-oriented; user never sees partials. | SPEC-012 | L |
-| ⚪ | Investigate streaming for medium-length (15–30s) audio: lower `targetChunkSeconds` and bench WER vs. wall-time tradeoff to see whether the threshold should drop. Surfaced from in-app testing of alpha.9 — a 50s clip felt much faster, the question is whether 20s clips also benefit. | SPEC-012 ext | S |
-| ⚪ | Live partial transcripts in the pill/popover while speaking — UX-facing (lets the user see what's being captured, catch mistakes early). Distinct from the perf streaming above; could share infra. | new SPEC | M |
-| 🔵 | Usage stats pane: words dictated via OpenQuack, time saved (vs. typing baseline), total audio processed. Local-only, opt-in display. | SPEC-013 | S |
-| 🔵 | Local audio + transcript history: keep recent recordings on disk so a crash/failure mid-long-utterance doesn't force the user to repeat 1–2 minutes of speech. Local-only, retention cap, easy purge. Privacy selling point — works offline, nothing leaves the device. | SPEC-014 | M |
-| 🟡 | Send-feedback menu item — one click from status item to GitHub issue chooser. Closes the user → repo feedback loop. | SPEC-018 | S |
+| ⚪ | Active-app context: feed foreground app + focused field text into Whisper prompt bias and polish/agent prompt | — | M |
+| ⚪ | Investigate streaming for medium-length (15–30s) audio: bench WER vs. wall-time at lower `targetChunkSeconds` | SPEC-012 ext | S |
+| ⚪ | Live partial transcripts in pill/popover while speaking | — | M |
+| ⚪ | System-audio capture (meeting mode) | — | ScreenCaptureKit |
+| ⚪ | Multilingual UI strings | — | follow Whisper language menu |
+| ⚪ | Action confirmation UI for high-risk agent calls | — | privacy gate |
+| ⚪ | Per-agent transcript history pane (opt-in, local-only) | — | — |
 | ⚪ | Code signing + notarisation | — | S |
 | ⚪ | Sparkle auto-update | — | S |
 | ⚪ | Demo gif + landing page (GitHub Pages) | — | S |
-
----
-
-## M4 — Beyond MVP
-
-| | Task | Notes |
-|---|---|---|
-| ⚪ | System-audio capture (meeting mode) | ScreenCaptureKit |
-| ⚪ | Multilingual UI strings | follow Whisper language menu |
-| ⚪ | Action confirmation UI for high-risk agent calls | privacy gate |
-| ⚪ | Per-agent transcripts history pane (opt-in) | local-only |
-| ⚪ | Linux / Windows ports | post-2.0 conversation |
+| ⚪ | Linux / Windows ports | — | post-2.0 |
+| 🟢 | Stream transcription for long audio (>~30s) — chunk while recording | SPEC-012 | perf; user never sees partials |
+| 🟢 | App shell — SwiftPM target, menu bar, About panel | SPEC-010 | — |
+| 🟢 | Audio capture — AVAudioEngine → 16 kHz mono WAV | SPEC-001 | — |
+| 🟢 | Global hotkey (⌃⇧Space toggle, KeyboardShortcuts pkg) | SPEC-003 | — |
+| 🟢 | Record → WhisperKit `medium` (en) → transcript in popover + clipboard | SPEC-002 | — |
+| 🟢 | Floating recording-state pill (top-centre, click-through) | SPEC-004 | — |
+| 🟢 | CGEvent ⌘V auto-paste at cursor (Accessibility prompt + clipboard fallback) | SPEC-005 | — |
+| 🟢 | Onboarding flow (Welcome → Mic → Paste → Hotkey → Done) | — | — |
+| 🟢 | Settings scene MVP (General / Models / Shortcut / About) | — | — |
+| 🟢 | Smart text post-processing (capitalise, punct, fillers) | — | — |
+| 🟢 | Live level meter + push-to-talk | SPEC-001 ext | — |
+| 🟢 | VAD auto-stop + sounds + custom dictionary | — | — |
+| 🟢 | App icon (procedural cream-gradient duck) | — | — |
+| 🟢 | DMG + Homebrew cask + README polish | — | — |
+| 🟢 | WhisperKit engine | SPEC-002 | primary; Apple Silicon Metal |
+| 🟢 | Lightning engine (Python subprocess) | SPEC-002 | bench-only baseline |
+| 🟢 | Metrics: WER / CER / RTF / RSS / cold-start | SPEC-002 | `OpenQuackKit/Metrics/` |
+| 🟢 | Corpus: 177 clips (TTS / multilingual / LibriSpeech / noise-aug) | — | `bench/corpus/` |
+| 🟢 | Bench rerun on enriched corpus → BENCHMARKS.md | — | M4/16GB matrix |
+| 🟢 | `openquack-cli` (single-file transcribe) | SPEC-002 | — |
+| 🟢 | SPM scaffolding (Kit + bench + CLI) | — | `Package.swift`, three targets |
+| 🟢 | Vision + roadmap + AGENTS.md + spec scaffold | — | — |
 
 ---
 
 ## How to claim a task
 
 1. Pick a 🔵.
-2. Open an issue using *Agent Task* template; mark yourself as owner.
+2. Open an issue using the *Agent Task* template; mark yourself as owner.
 3. Read the cited SPEC.
 4. Open a draft PR within ~24h naming the task in the title.
 5. Follow [AGENTS.md](../AGENTS.md) for PR shape and required tests.


### PR DESCRIPTION
## Summary

- Removes M1/M2/M2.5/M3/M4 milestone sections
- All tasks now live in one flat table, sorted 🟡 → 🔵 → ⚪ → 🟢 so the most actionable items are immediately visible
- No tasks added, removed, or status-changed — pure structure change

## Why

Milestone groupings assume stable phasing. With shifting priorities and resources, a flat list is easier to reprioritize without restructuring the whole document.

## Test plan

- [ ] Verify all tasks from the original ROADMAP appear in the flat table
- [ ] Confirm "How to claim" and status legend are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)