### PR TITLE
fix(overlay): show indicator on cursor's screen in multi-monitor setups

### DIFF
--- a/Sources/OpenQuackApp/RecordingOverlay.swift
+++ b/Sources/OpenQuackApp/RecordingOverlay.swift
@@ -71,7 +71,9 @@ final class RecordingOverlay {
     }
 
     private func positionTopCentre(panel: NSPanel) {
-        guard let screen = NSScreen.main else { return }
+        let cursor = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(cursor) } ?? NSScreen.main
+        guard let screen else { return }
         let visible = screen.visibleFrame
         let x = visible.midX - panel.frame.width / 2
         let y = visible.maxY - panel.frame.height - Theme.s24

--- a/docs/SPECS/SPEC-004-overlay.md
+++ b/docs/SPECS/SPEC-004-overlay.md
@@ -65,6 +65,7 @@ public final class OverlayController {
 - Level meter (`recording.level`) updates at 30 fps; the overlay subscribes to `AudioRecorder.currentLevel` (SPEC-001).
 - The overlay window does NOT steal focus. Don't call `makeKeyAndOrderFront`; use `orderFront(nil)`.
 - Click-through except on the cancel button area, which acts as cancel.
+- On multi-monitor setups the pill appears on the screen that contains the mouse cursor at show-time, falling back to `NSScreen.main`. This puts the indicator where the user's attention already is when they trigger the hotkey.
 
 ## Open questions
 


### PR DESCRIPTION
## SPEC: SPEC-004 (Recording overlay)
## Milestone: —

### Why
On multi-monitor Macs the "Listening" pill always appeared on the primary display (`NSScreen.main`) regardless of where the cursor was when the hotkey fired. Users had to glance at the wrong screen to confirm recording state (closes #25).

### Change
`RecordingOverlay.positionTopCentre` now picks the screen whose `frame` contains `NSEvent.mouseLocation` and falls back to `NSScreen.main` when no screen strictly contains the cursor (e.g. cursor on the bezel edge between two displays).

`showAnimated()` already calls `positionTopCentre` on each show, so the position is re-evaluated each time recording starts — no additional `NSApplication.didChangeScreenParametersNotification` observer is needed.

Also adds a one-line note to SPEC-004 § Behaviour documenting the positioning rule.

### Tests
- [ ] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build && swift test` green (pre-existing `PreviewsMacros` diagnostic is in the `KeyboardShortcuts` dependency, not in our code)
- [ ] Manual: with two displays and the cursor on the secondary display, press the hotkey → pill appears on the secondary display

### Out of scope
- User-configurable pill position (top / bottom / cursor) — deferred to SPEC-004 M3

🤖 Generated with [Claude Code](https://claude.com/claude-code)