### PR TITLE
feat(SPEC-022): post-paste AXObserver + correction candidate persistence

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -78,6 +78,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let updater = UpdateChecker()
     let usageStats = UsageStats()        // SPEC-013
     let historyStore = HistoryStore()    // SPEC-014
+    let correctionStore = CorrectionCandidateStore()  // SPEC-022 PR-A
+    private var pasteObserver: PostPasteCorrectionObserver?
 
     /// Persist the last recording so the user can verify capture quality
     /// independent of model output. `open ~/Library/Application Support/OpenQuack/last-recording.wav`.
@@ -652,6 +654,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 } else {
                     PasteService.copyToClipboard(polished)
                     pasted = false
+                }
+
+                // SPEC-022 PR-A: after a successful paste-at-cursor, attach a
+                // one-shot AX observer to the focused field. Captures the
+                // user's in-place edits over the next 60 s (or until focus
+                // leaves), diffs them against the pasted transcript, and
+                // appends correction candidates to the store. Silent no-op
+                // if AX isn't trusted or the field doesn't expose a value.
+                if pasted {
+                    let store = self.correctionStore
+                    let transcript = polished
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        let observer = PostPasteCorrectionObserver(store: store)
+                        if observer.start(transcript: transcript) {
+                            self.pasteObserver = observer
+                        }
+                    }
                 }
 
                 await MainActor.run {

--- a/Sources/OpenQuackKit/Dictionary/CorrectionCandidate.swift
+++ b/Sources/OpenQuackKit/Dictionary/CorrectionCandidate.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// SPEC-022 §2.3 — One observed (wrong → right) substitution pair.
+///
+/// `wrong` is what Whisper emitted; `right` is what the user committed after
+/// in-field editing. `count` accumulates across sessions; `lastSeen` is used
+/// for cap eviction. `suppressedUntil` is set by the (PR-B) "Not now" path on
+/// the nudge — persisted here so dismissal survives restarts, even though
+/// PR-A doesn't yet read it.
+public struct CorrectionCandidate: Sendable, Codable, Equatable {
+    public var wrong: String
+    public var right: String
+    public var count: Int
+    public var lastSeen: Date
+    public var suppressedUntil: Date?
+
+    public init(wrong: String,
+                right: String,
+                count: Int = 1,
+                lastSeen: Date = Date(),
+                suppressedUntil: Date? = nil) {
+        self.wrong = wrong
+        self.right = right
+        self.count = count
+        self.lastSeen = lastSeen
+        self.suppressedUntil = suppressedUntil
+    }
+
+    /// Key for dedupe / merge — case-insensitive on both sides so "cloud code"
+    /// → "Claude Code" and "Cloud Code" → "Claude code" collapse to one entry.
+    /// The first-observed casing of `right` wins on merge; `count` accumulates.
+    public var dedupeKey: String {
+        "\(wrong.lowercased())\u{1F}\(right.lowercased())"
+    }
+}

--- a/Sources/OpenQuackKit/Dictionary/CorrectionCandidateStore.swift
+++ b/Sources/OpenQuackKit/Dictionary/CorrectionCandidateStore.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// SPEC-022 §2.4 — Persistence for `CorrectionCandidate`s.
+///
+/// On-disk JSON at `~/Library/Application Support/OpenQuack/correction_candidates.json`.
+/// `record(_:)` dedupes by `(wrong, right)` (case-insensitive) and merges
+/// counts. The store caps total entries at 500 and evicts by `lastSeen`
+/// ascending (oldest first) when over the cap.
+///
+/// All access is serialised through the actor; the file URL is injectable so
+/// tests can use a tmp directory.
+public actor CorrectionCandidateStore {
+    public static let maxEntries = 500
+
+    private let fileURL: URL
+
+    /// Default location per SPEC-022 §2.4.
+    public static var defaultFileURL: URL {
+        let support = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first
+            ?? URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent("Library/Application Support")
+        return support
+            .appendingPathComponent("OpenQuack", isDirectory: true)
+            .appendingPathComponent("correction_candidates.json")
+    }
+
+    public init(fileURL: URL = CorrectionCandidateStore.defaultFileURL) {
+        self.fileURL = fileURL
+    }
+
+    /// Returns all stored candidates in load order (no sort applied).
+    public func loadAll() throws -> [CorrectionCandidate] {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([CorrectionCandidate].self, from: data)
+    }
+
+    /// Merge `incoming` into the on-disk set: matching `(wrong, right)` keys
+    /// have their `count` summed and `lastSeen` advanced to the newer of the
+    /// two; new keys are appended. Caps at `maxEntries` by evicting the
+    /// oldest-`lastSeen` entries (SPEC §2.4).
+    @discardableResult
+    public func record(_ incoming: [CorrectionCandidate]) throws -> [CorrectionCandidate] {
+        guard !incoming.isEmpty else {
+            return (try? loadAll()) ?? []
+        }
+        try ensureParent()
+        var existing = (try? loadAll()) ?? []
+
+        var index: [String: Int] = [:]
+        for (i, c) in existing.enumerated() {
+            index[c.dedupeKey] = i
+        }
+
+        for c in incoming {
+            if let i = index[c.dedupeKey] {
+                existing[i].count += c.count
+                if c.lastSeen > existing[i].lastSeen {
+                    existing[i].lastSeen = c.lastSeen
+                }
+                // Most recent suppression wins (latest user decision).
+                if let s = c.suppressedUntil {
+                    existing[i].suppressedUntil = s
+                }
+            } else {
+                existing.append(c)
+                index[c.dedupeKey] = existing.count - 1
+            }
+        }
+
+        existing = evictIfNeeded(existing)
+        try persist(existing)
+        return existing
+    }
+
+    /// Test / debugging convenience: drop the file entirely.
+    public func reset() throws {
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+    }
+
+    // MARK: - private
+
+    private func ensureParent() throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent,
+                                                withIntermediateDirectories: true)
+    }
+
+    private func evictIfNeeded(_ entries: [CorrectionCandidate]) -> [CorrectionCandidate] {
+        guard entries.count > Self.maxEntries else { return entries }
+        // Sort ascending by lastSeen (oldest first), drop the head until we
+        // fit under the cap, preserve original ordering of the survivors so
+        // the file diff stays small.
+        let oldest = entries
+            .enumerated()
+            .sorted { $0.element.lastSeen < $1.element.lastSeen }
+        let dropCount = entries.count - Self.maxEntries
+        let dropIndices = Set(oldest.prefix(dropCount).map(\.offset))
+        return entries.enumerated()
+            .filter { !dropIndices.contains($0.offset) }
+            .map(\.element)
+    }
+
+    private func persist(_ entries: [CorrectionCandidate]) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(entries)
+        try data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Sources/OpenQuackKit/Dictionary/CorrectionDiff.swift
+++ b/Sources/OpenQuackKit/Dictionary/CorrectionDiff.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// SPEC-022 §2.3 — Token-level diff of `rawTranscript` vs. `committedText`.
+///
+/// `committedText` is the user-edited segment (located by the caller via
+/// longest-common-prefix against the field's final value — see SPEC-022 §2.2.4),
+/// not the entire field. The pure function takes the segment as-is.
+///
+/// Algorithm: word-by-word positional alignment. SPEC explicitly allows simple
+/// alignment over Myers diff at this volume — most paste edits are one or two
+/// in-place substitutions, and full LCS would create spurious pairs from
+/// insertions / deletions at the segment boundary.
+public enum CorrectionDiff {
+
+    /// Stop words: extremely common short tokens whose substitutions are almost
+    /// always grammatical noise rather than dictionary-worthy terms. Kept tiny
+    /// per SPEC §2.3.
+    static let stopWords: Set<String> = [
+        "the", "a", "an", "is", "was", "of", "to",
+        "for", "in", "on", "and", "or", "but",
+        "that", "this",
+    ]
+
+    /// Maximum case-insensitive edit distance for a pair to qualify as a
+    /// correction. > 3 usually means the user replaced the word entirely
+    /// (different intent, not a transcription error) — see SPEC §2.3.
+    static let maxEditDistance = 3
+
+    /// Tokenisation boundary: Unicode whitespace + Unicode punctuation. Empty
+    /// tokens are dropped so trailing punctuation doesn't shift the alignment.
+    private static let tokenSeparators: CharacterSet = {
+        var set = CharacterSet.whitespacesAndNewlines
+        set.formUnion(.punctuationCharacters)
+        return set
+    }()
+
+    /// Returns substitution candidates extracted from the aligned token pairs.
+    /// Caller decides what to do with them (typically: feed into the store).
+    public static func extractCorrections(rawTranscript: String,
+                                          committedText: String,
+                                          now: Date = Date()) -> [CorrectionCandidate] {
+        let rawTokens = tokenize(rawTranscript)
+        let userTokens = tokenize(committedText)
+        let pairCount = min(rawTokens.count, userTokens.count)
+        guard pairCount > 0 else { return [] }
+
+        var out: [CorrectionCandidate] = []
+        for i in 0..<pairCount {
+            let wrong = rawTokens[i]
+            let right = userTokens[i]
+            guard accept(wrong: wrong, right: right) else { continue }
+            out.append(CorrectionCandidate(wrong: wrong, right: right,
+                                           count: 1, lastSeen: now))
+        }
+        return out
+    }
+
+    // MARK: - internals (exposed `internal` for tests)
+
+    static func tokenize(_ s: String) -> [String] {
+        s.components(separatedBy: tokenSeparators)
+            .filter { !$0.isEmpty }
+    }
+
+    static func accept(wrong: String, right: String) -> Bool {
+        // Identical tokens — nothing to learn.
+        if wrong == right { return false }
+        // Case-only differences ("i" → "I") aren't dictionary-worthy; the
+        // count-threshold flow in PR-B is for proper-noun / brand-name terms.
+        let wLower = wrong.lowercased()
+        let rLower = right.lowercased()
+        if wLower == rLower { return false }
+        // Stop-word filter (SPEC §2.3).
+        if stopWords.contains(wLower) { return false }
+        // Edit-distance cap on lowercased forms (SPEC §2.3 — case-insensitive).
+        if levenshtein(wLower, rLower) > maxEditDistance { return false }
+        return true
+    }
+
+    /// Plain Levenshtein on `String.UnicodeScalarView` so multi-byte
+    /// graphemes don't skew the cap.
+    static func levenshtein(_ a: String, _ b: String) -> Int {
+        let aChars = Array(a.unicodeScalars)
+        let bChars = Array(b.unicodeScalars)
+        if aChars.isEmpty { return bChars.count }
+        if bChars.isEmpty { return aChars.count }
+        var prev = Array(0...bChars.count)
+        var curr = [Int](repeating: 0, count: bChars.count + 1)
+        for i in 1...aChars.count {
+            curr[0] = i
+            for j in 1...bChars.count {
+                let cost = aChars[i - 1] == bChars[j - 1] ? 0 : 1
+                curr[j] = min(
+                    curr[j - 1] + 1,        // insertion
+                    prev[j] + 1,            // deletion
+                    prev[j - 1] + cost      // substitution
+                )
+            }
+            swap(&prev, &curr)
+        }
+        return prev[bChars.count]
+    }
+}

--- a/Sources/OpenQuackKit/Dictionary/PostPasteCorrectionObserver.swift
+++ b/Sources/OpenQuackKit/Dictionary/PostPasteCorrectionObserver.swift
@@ -1,0 +1,297 @@
+import ApplicationServices
+import AppKit
+import Foundation
+
+/// SPEC-022 §2.2 — Post-paste field observer.
+///
+/// One instance per paste. After OpenQuack pastes `transcript` at the cursor:
+///
+/// 1. `start(transcript:)` snapshots the focused element's `kAXValueAttribute`
+///    (the field content including the just-pasted transcript).
+/// 2. We register an `AXObserver` for `kAXValueChangedNotification` on that
+///    element, plus a system-wide observer for
+///    `kAXFocusedUIElementChangedNotification` so we know when the user moves
+///    on.
+/// 3. On focus-change or a 60 s timeout, we read the element's value one final
+///    time, unregister, compute the edited segment via longest-common-prefix
+///    of the pasted transcript and the captured text, diff it (§2.3), and
+///    forward any candidates to the store.
+///
+/// The observer is scoped to a single element and a single paste event — it
+/// does not persist across focus changes or new transcriptions. Fields that
+/// don't expose `kAXValueAttribute` (password fields, some Electron apps)
+/// trigger a silent no-op (SPEC §2.2 + Out-of-scope).
+public final class PostPasteCorrectionObserver {
+    private let store: CorrectionCandidateStore
+    private let timeoutSeconds: TimeInterval
+
+    private var pastedTranscript: String?
+    private var focusedElement: AXUIElement?
+    private var elementObserver: AXObserver?
+    private var systemObserver: AXObserver?
+    private var timer: DispatchSourceTimer?
+    private var didFire = false
+
+    /// Stored so the C callbacks can find us — `AXObserverCreate` only gives
+    /// us a raw pointer round-trip.
+    private static var liveObservers: [ObjectIdentifier: PostPasteCorrectionObserver] = [:]
+    private var identifier: ObjectIdentifier { ObjectIdentifier(self) }
+
+    public init(store: CorrectionCandidateStore,
+                timeoutSeconds: TimeInterval = 60) {
+        self.store = store
+        self.timeoutSeconds = timeoutSeconds
+    }
+
+    /// Attach the observer after a successful paste. Must be called on the
+    /// main thread. No-op (returns `false`) if Accessibility is not trusted
+    /// or the focused element doesn't expose `kAXValueAttribute`.
+    @MainActor
+    @discardableResult
+    public func start(transcript: String) -> Bool {
+        guard AXIsProcessTrusted() else { return false }
+        guard !didFire, focusedElement == nil else { return false }
+        guard let focused = copyFocusedElement(),
+              elementSupportsValue(focused) else { return false }
+
+        self.pastedTranscript = transcript
+        self.focusedElement = focused
+        Self.liveObservers[identifier] = self
+
+        if !registerElementObserver(on: focused) {
+            cleanupAfterFire()
+            return false
+        }
+        registerSystemFocusObserver()
+        scheduleTimeout()
+        return true
+    }
+
+    /// Test seam: drive the "final value captured" path directly without a
+    /// live AX event. Equivalent to a successful `start()` + later timeout,
+    /// but skips the AX registration entirely so it runs anywhere.
+    /// Not for production use.
+    public func testOnlyFire(transcript: String,
+                             finalFieldValue: String,
+                             now: Date = Date()) async {
+        await MainActor.run { self.pastedTranscript = transcript }
+        await fire(finalFieldValue: finalFieldValue, now: now)
+    }
+
+    // MARK: - core flow
+
+    @MainActor
+    private func handleValueChanged() {
+        // Don't fire on every keystroke — wait for focus-change or timeout.
+        // The value-changed notification is here purely to keep the run-loop
+        // engaged and to confirm the field is still observable; SPEC §2.2.3
+        // explicitly waits for focus-change or 60 s to read the final value.
+    }
+
+    @MainActor
+    private func handleFocusChanged() {
+        guard !didFire, let element = focusedElement else { return }
+        let final = readValue(element) ?? ""
+        Task { [weak self] in
+            await self?.fire(finalFieldValue: final, now: Date())
+        }
+    }
+
+    @MainActor
+    private func handleTimeout() {
+        guard !didFire, let element = focusedElement else { return }
+        let final = readValue(element) ?? ""
+        Task { [weak self] in
+            await self?.fire(finalFieldValue: final, now: Date())
+        }
+    }
+
+    private func fire(finalFieldValue: String, now: Date) async {
+        // Guard fire-once. The AX callbacks can race the timer; whichever
+        // arrives first wins and the rest become no-ops.
+        let shouldFire: Bool = await MainActor.run {
+            if self.didFire { return false }
+            self.didFire = true
+            return true
+        }
+        guard shouldFire else { return }
+
+        let transcript = pastedTranscript ?? ""
+        let segments = Self.alignedEditSegments(transcript: transcript,
+                                                finalValue: finalFieldValue)
+        if !segments.transcriptTail.isEmpty || !segments.fieldTail.isEmpty {
+            let candidates = CorrectionDiff.extractCorrections(
+                rawTranscript: segments.transcriptTail,
+                committedText: segments.fieldTail,
+                now: now)
+            if !candidates.isEmpty {
+                _ = try? await store.record(candidates)
+            }
+        }
+
+        await MainActor.run { self.cleanupAfterFire() }
+    }
+
+    @MainActor
+    private func cleanupAfterFire() {
+        if let obs = elementObserver, let element = focusedElement {
+            AXObserverRemoveNotification(obs, element,
+                                         kAXValueChangedNotification as CFString)
+            CFRunLoopRemoveSource(CFRunLoopGetMain(),
+                                  AXObserverGetRunLoopSource(obs),
+                                  .defaultMode)
+        }
+        if let sys = systemObserver {
+            let systemWide = AXUIElementCreateSystemWide()
+            AXObserverRemoveNotification(sys, systemWide,
+                                         kAXFocusedUIElementChangedNotification as CFString)
+            CFRunLoopRemoveSource(CFRunLoopGetMain(),
+                                  AXObserverGetRunLoopSource(sys),
+                                  .defaultMode)
+        }
+        elementObserver = nil
+        systemObserver = nil
+        focusedElement = nil
+        timer?.cancel()
+        timer = nil
+        Self.liveObservers[identifier] = nil
+    }
+
+    // MARK: - AX registration
+
+    @MainActor
+    private func registerElementObserver(on element: AXUIElement) -> Bool {
+        var pid: pid_t = 0
+        guard AXUIElementGetPid(element, &pid) == .success else { return false }
+        var observerRef: AXObserver?
+        let create = AXObserverCreate(pid, Self.observerCallback, &observerRef)
+        guard create == .success, let observer = observerRef else { return false }
+        let ctx = UnsafeMutableRawPointer(bitPattern: UInt(bitPattern: identifier.hashValue))
+        let add = AXObserverAddNotification(observer, element,
+                                            kAXValueChangedNotification as CFString,
+                                            ctx)
+        guard add == .success else { return false }
+        CFRunLoopAddSource(CFRunLoopGetMain(),
+                           AXObserverGetRunLoopSource(observer),
+                           .defaultMode)
+        self.elementObserver = observer
+        return true
+    }
+
+    @MainActor
+    private func registerSystemFocusObserver() {
+        let systemWide = AXUIElementCreateSystemWide()
+        var pid: pid_t = 0
+        // System-wide AXUIElement returns the focused app's pid; if we can't
+        // resolve one, skip system-focus observation. The timeout still fires.
+        guard AXUIElementGetPid(systemWide, &pid) == .success else { return }
+        var observerRef: AXObserver?
+        let create = AXObserverCreate(pid, Self.observerCallback, &observerRef)
+        guard create == .success, let observer = observerRef else { return }
+        let ctx = UnsafeMutableRawPointer(bitPattern: UInt(bitPattern: identifier.hashValue))
+        let add = AXObserverAddNotification(observer, systemWide,
+                                            kAXFocusedUIElementChangedNotification as CFString,
+                                            ctx)
+        guard add == .success else { return }
+        CFRunLoopAddSource(CFRunLoopGetMain(),
+                           AXObserverGetRunLoopSource(observer),
+                           .defaultMode)
+        self.systemObserver = observer
+    }
+
+    @MainActor
+    private func scheduleTimeout() {
+        let t = DispatchSource.makeTimerSource(queue: .main)
+        t.schedule(deadline: .now() + timeoutSeconds)
+        t.setEventHandler { [weak self] in
+            self?.handleTimeout()
+        }
+        t.resume()
+        self.timer = t
+    }
+
+    // MARK: - AX helpers
+
+    private func copyFocusedElement() -> AXUIElement? {
+        let systemWide = AXUIElementCreateSystemWide()
+        var value: AnyObject?
+        let err = AXUIElementCopyAttributeValue(systemWide,
+                                                kAXFocusedUIElementAttribute as CFString,
+                                                &value)
+        guard err == .success, let cf = value else { return nil }
+        // CFGetTypeID equality with AXUIElementGetTypeID() is the documented
+        // check; we cast via `AnyObject` so ARC is happy.
+        return (cf as! AXUIElement)
+    }
+
+    private func elementSupportsValue(_ element: AXUIElement) -> Bool {
+        var names: CFArray?
+        guard AXUIElementCopyAttributeNames(element, &names) == .success,
+              let arr = names as? [String]
+        else { return false }
+        return arr.contains(kAXValueAttribute as String)
+    }
+
+    private func readValue(_ element: AXUIElement) -> String? {
+        var value: AnyObject?
+        let err = AXUIElementCopyAttributeValue(element,
+                                                kAXValueAttribute as CFString,
+                                                &value)
+        guard err == .success else { return nil }
+        return value as? String
+    }
+
+    // MARK: - C callback
+
+    /// Single C-callable trampoline used for both observers. Routes by the
+    /// `notification` name into the right `handle…` method on the owning
+    /// instance (looked up from `liveObservers` via the context pointer).
+    private static let observerCallback: AXObserverCallback = {
+        (_: AXObserver, _: AXUIElement, notification: CFString, ctx: UnsafeMutableRawPointer?) in
+        guard let ctx else { return }
+        let hash = Int(bitPattern: UInt(bitPattern: ctx))
+        let owner = liveObservers.first { ObjectIdentifier($0.value).hashValue == hash }?.value
+        guard let owner else { return }
+        let name = notification as String
+        DispatchQueue.main.async {
+            if name == (kAXValueChangedNotification as String) {
+                owner.handleValueChanged()
+            } else if name == (kAXFocusedUIElementChangedNotification as String) {
+                owner.handleFocusChanged()
+            }
+        }
+    }
+
+    // MARK: - segment extraction (exposed for tests)
+
+    /// Locate the edited segment by longest-common-prefix (SPEC §2.2.4).
+    /// Returns the matched tail of the transcript and the matched tail of
+    /// the final field value, both starting where the two strings first
+    /// diverge. Diffing the two tails together (instead of transcript vs.
+    /// field-tail-only) keeps token alignment honest when the user edited
+    /// past the common prefix.
+    ///
+    /// If the strings are identical, both tails are empty and the diff is
+    /// skipped. If the final field value doesn't contain the pasted
+    /// transcript at all (zero LCP), we fall back to diffing the whole
+    /// transcript vs. the whole field — coarser alignment but still better
+    /// than dropping the signal.
+    static func alignedEditSegments(transcript: String,
+                                    finalValue: String)
+        -> (transcriptTail: String, fieldTail: String)
+    {
+        if transcript.isEmpty || finalValue.isEmpty {
+            return (transcript, finalValue)
+        }
+        let t = Array(transcript)
+        let f = Array(finalValue)
+        var i = 0
+        while i < t.count, i < f.count, t[i] == f[i] {
+            i += 1
+        }
+        if i >= t.count, i >= f.count {
+            return ("", "")  // identical
+        }
+        return (String(t[i...]), String(f[i...]))
+    }
+}

--- a/Tests/OpenQuackKitTests/CorrectionCandidateStoreTests.swift
+++ b/Tests/OpenQuackKitTests/CorrectionCandidateStoreTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+import Foundation
+@testable import OpenQuackKit
+
+final class CorrectionCandidateStoreTests: XCTestCase {
+    private var tempDir: URL!
+    private var fileURL: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenQuackCorrectionStoreTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir,
+                                                withIntermediateDirectories: true)
+        fileURL = tempDir.appendingPathComponent("correction_candidates.json")
+    }
+
+    override func tearDown() async throws {
+        if let d = tempDir, FileManager.default.fileExists(atPath: d.path) {
+            try? FileManager.default.removeItem(at: d)
+        }
+        try await super.tearDown()
+    }
+
+    private func makeStore() -> CorrectionCandidateStore {
+        CorrectionCandidateStore(fileURL: fileURL)
+    }
+
+    // MARK: - load / save
+
+    func testLoadAll_emptyWhenFileMissing() async throws {
+        let store = makeStore()
+        let entries = try await store.loadAll()
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    func testRecord_persistsAcrossInstances() async throws {
+        let store = makeStore()
+        let now = Date()
+        try await store.record([
+            CorrectionCandidate(wrong: "cloud", right: "Claude",
+                                count: 1, lastSeen: now)
+        ])
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+
+        let reopened = makeStore()
+        let entries = try await reopened.loadAll()
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.wrong, "cloud")
+        XCTAssertEqual(entries.first?.right, "Claude")
+        XCTAssertEqual(entries.first?.count, 1)
+    }
+
+    // MARK: - dedupe / merge
+
+    func testRecord_dedupesAndMergesCounts() async throws {
+        let store = makeStore()
+        let t1 = Date(timeIntervalSince1970: 1_000_000)
+        let t2 = Date(timeIntervalSince1970: 2_000_000)
+
+        try await store.record([
+            CorrectionCandidate(wrong: "cloud", right: "Claude",
+                                count: 1, lastSeen: t1)
+        ])
+        try await store.record([
+            CorrectionCandidate(wrong: "cloud", right: "Claude",
+                                count: 2, lastSeen: t2)
+        ])
+
+        let entries = try await store.loadAll()
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.count, 3)
+        XCTAssertEqual(entries.first?.lastSeen, t2)
+    }
+
+    func testRecord_caseInsensitiveDedupeKey() async throws {
+        let store = makeStore()
+        try await store.record([
+            CorrectionCandidate(wrong: "Cloud", right: "Claude",
+                                count: 1, lastSeen: Date())
+        ])
+        try await store.record([
+            CorrectionCandidate(wrong: "cloud", right: "claude",
+                                count: 1, lastSeen: Date())
+        ])
+        let entries = try await store.loadAll()
+        XCTAssertEqual(entries.count, 1, "same pair under different casing must dedupe")
+        XCTAssertEqual(entries.first?.count, 2)
+    }
+
+    func testRecord_keepsDistinctRightValuesAsSeparate() async throws {
+        let store = makeStore()
+        try await store.record([
+            CorrectionCandidate(wrong: "cloud", right: "Claude",
+                                count: 1, lastSeen: Date()),
+            CorrectionCandidate(wrong: "cloud", right: "cloud9",
+                                count: 1, lastSeen: Date())
+        ])
+        let entries = try await store.loadAll()
+        XCTAssertEqual(entries.count, 2)
+    }
+
+    // MARK: - cap-500 eviction
+
+    // MARK: - observer test-seam
+
+    func testObserverTestSeam_recordsCorrectionsFromSynthesizedFinalValue() async throws {
+        let store = makeStore()
+        let observer = PostPasteCorrectionObserver(store: store)
+        // `start()` would require live Accessibility trust; the test seam
+        // drives the "final value captured" branch directly so the diff →
+        // store wiring is verified without a live AX event.
+        await observer.testOnlyFire(
+            transcript: "use cloud code please",
+            finalFieldValue: "use Claude code please"
+        )
+        let entries = try await store.loadAll()
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.wrong, "cloud")
+        XCTAssertEqual(entries.first?.right, "Claude")
+    }
+
+    func testObserverTestSeam_noEditMeansNoCandidates() async throws {
+        let store = makeStore()
+        let observer = PostPasteCorrectionObserver(store: store)
+        await observer.testOnlyFire(
+            transcript: "untouched paste",
+            finalFieldValue: "untouched paste"
+        )
+        let entries = try await store.loadAll()
+        XCTAssertTrue(entries.isEmpty)
+    }
+
+    func testRecord_capsAt500_evictingByLastSeenAscending() async throws {
+        let store = makeStore()
+        // Pre-fill with 500 entries with increasing lastSeen — entry 0 is the
+        // oldest.
+        let base = Date(timeIntervalSince1970: 1_000_000)
+        var seed: [CorrectionCandidate] = []
+        for i in 0..<500 {
+            seed.append(CorrectionCandidate(
+                wrong: "w\(i)",
+                right: "r\(i)",
+                count: 1,
+                lastSeen: base.addingTimeInterval(Double(i))
+            ))
+        }
+        try await store.record(seed)
+        var entries = try await store.loadAll()
+        XCTAssertEqual(entries.count, 500)
+
+        // Insert one new entry — total would be 501; oldest (w0) must evict.
+        let newer = base.addingTimeInterval(10_000)
+        try await store.record([
+            CorrectionCandidate(wrong: "wNew", right: "rNew",
+                                count: 1, lastSeen: newer)
+        ])
+        entries = try await store.loadAll()
+        XCTAssertEqual(entries.count, 500, "must not exceed cap")
+
+        let kept = Set(entries.map(\.wrong))
+        XCTAssertTrue(kept.contains("wNew"))
+        XCTAssertFalse(kept.contains("w0"), "oldest entry must be evicted first")
+        XCTAssertTrue(kept.contains("w1"), "second-oldest survives one overflow")
+    }
+}

--- a/Tests/OpenQuackKitTests/CorrectionDiffTests.swift
+++ b/Tests/OpenQuackKitTests/CorrectionDiffTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class CorrectionDiffTests: XCTestCase {
+
+    // MARK: - happy path
+
+    func testSingleSubstitution_isExtracted() {
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "I love cloud code",
+            committedText: "I love Claude code"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.wrong, "cloud")
+        XCTAssertEqual(result.first?.right, "Claude")
+    }
+
+    func testMultipleSubstitutions_extractedInOrder() {
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "cloud code says hi there cloud",
+            committedText: "Claude code says yo there Claude"
+        )
+        // Tokens 0 and 5 are non-case substitutions; token 3 "hi" → "yo"
+        // is distance 2 case-insensitive. "code", "says", "there" are
+        // identical and drop out. Order preserved.
+        let pairs = result.map { "\($0.wrong)->\($0.right)" }
+        XCTAssertEqual(pairs, ["cloud->Claude", "hi->yo", "cloud->Claude"])
+    }
+
+    // MARK: - no false positives
+
+    func testIdenticalStrings_yieldNoCandidates() {
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "hello world",
+            committedText: "hello world"
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testEmptyStrings_yieldNoCandidates() {
+        XCTAssertTrue(CorrectionDiff.extractCorrections(
+            rawTranscript: "", committedText: "").isEmpty)
+        XCTAssertTrue(CorrectionDiff.extractCorrections(
+            rawTranscript: "hello", committedText: "").isEmpty)
+        XCTAssertTrue(CorrectionDiff.extractCorrections(
+            rawTranscript: "", committedText: "hello").isEmpty)
+    }
+
+    // MARK: - case folding
+
+    func testCaseOnlyDifference_isNotACandidate() {
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "i typed something",
+            committedText: "I typed something"
+        )
+        // "i" → "I" is case-only and must be dropped before stop-word check
+        // ever runs.
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testCaseFoldedEditDistance_isMeasuredOnLowercase() {
+        // "WHISPERKIT" vs "WhisperKit" — both lowercase to "whisperkit",
+        // case-only, must drop.
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "use WHISPERKIT today",
+            committedText: "use WhisperKit today"
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - edit-distance threshold
+
+    func testEditDistanceWithinThreshold_passes() {
+        // "code" → "Code" is case-only (drop), but "writes" → "wrote"
+        // is distance 2 (case-insensitive) — must pass.
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "he writes here",
+            committedText: "he wrote here"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.wrong, "writes")
+        XCTAssertEqual(result.first?.right, "wrote")
+    }
+
+    func testEditDistanceAtBoundary_passes() {
+        // "kitten" vs "Kitchen" is distance 3 case-insensitively → boundary.
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "the kitten ran",
+            committedText: "the Kitchen ran"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.wrong, "kitten")
+        XCTAssertEqual(result.first?.right, "Kitchen")
+    }
+
+    func testEditDistanceOverThreshold_isFiltered() {
+        // "Anthropic" vs "OpenQuack" is well over 3 — different word entirely,
+        // not a correction. Drop.
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "Anthropic builds Claude",
+            committedText: "OpenQuack builds Claude"
+        )
+        XCTAssertTrue(result.isEmpty,
+                      "edit-distance > 3 indicates intentional rewrite, not correction")
+    }
+
+    // MARK: - stop-word filtering
+
+    func testStopWordSubstitution_isFiltered() {
+        // "a" → "an" is within edit distance but `wrong` is a stop word.
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "I saw a elephant",
+            committedText: "I saw an elephant"
+        )
+        XCTAssertTrue(result.isEmpty,
+                      "stop-word `wrong` side must filter the pair out")
+    }
+
+    func testNonStopWordWithStopWordRight_stillExtracted() {
+        // "hi" → "the" — `wrong` is not a stop word, so this counts.
+        // (Edit distance 3 case-insensitive, just inside the cap.)
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "hi all",
+            committedText: "the all"
+        )
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.wrong, "hi")
+        XCTAssertEqual(result.first?.right, "the")
+    }
+
+    // MARK: - lastSeen propagation
+
+    func testCorrection_carriesProvidedTimestamp() {
+        let pinned = Date(timeIntervalSince1970: 1_700_000_000)
+        let result = CorrectionDiff.extractCorrections(
+            rawTranscript: "cloud code",
+            committedText: "Claude code",
+            now: pinned
+        )
+        XCTAssertEqual(result.first?.lastSeen, pinned)
+    }
+
+    // MARK: - segment extraction (PostPasteCorrectionObserver helper)
+
+    func testAlignedEditSegments_returnsBothTailsAfterCommonPrefix() {
+        let (t, f) = PostPasteCorrectionObserver.alignedEditSegments(
+            transcript: "hello cloud code",
+            finalValue: "hello Claude code"
+        )
+        XCTAssertEqual(t, "cloud code")
+        XCTAssertEqual(f, "Claude code")
+    }
+
+    func testAlignedEditSegments_bothEmptyWhenIdentical() {
+        let (t, f) = PostPasteCorrectionObserver.alignedEditSegments(
+            transcript: "hello world",
+            finalValue: "hello world"
+        )
+        XCTAssertTrue(t.isEmpty)
+        XCTAssertTrue(f.isEmpty)
+    }
+
+    func testAlignedEditSegments_diffOfBothTailsExtractsCorrection() {
+        // Realistic flow: full transcript was "use cloud code please";
+        // user edited to "use Claude code please" in-place. Aligning on
+        // both tails should yield exactly the cloud→Claude pair.
+        let (t, f) = PostPasteCorrectionObserver.alignedEditSegments(
+            transcript: "use cloud code please",
+            finalValue: "use Claude code please"
+        )
+        let pairs = CorrectionDiff.extractCorrections(
+            rawTranscript: t,
+            committedText: f
+        )
+        XCTAssertEqual(pairs.count, 1)
+        XCTAssertEqual(pairs.first?.wrong, "cloud")
+        XCTAssertEqual(pairs.first?.right, "Claude")
+    }
+}


### PR DESCRIPTION
## SPEC

SPEC-022 PR-A (Custom dictionary auto-learn from user corrections) — §2.2 post-paste observer and §2.3/2.4 candidate persistence only. PR-B (nudge) and PR-C (export) are out of scope.

## Milestone

M2

## Why

Most users immediately fix small Whisper errors in-place ("cloud code" → "Claude code") and OpenQuack throws that signal away today. PR-A captures it silently: after a successful paste-at-cursor we watch the focused field for the user's edit, diff it against the transcript, and persist the (wrong → right) pair. Once a pair has been seen `count >= 3` times, PR-B will offer a one-tap "Add to dictionary" nudge — but nothing user-facing changes in this PR.

## Change

`Sources/OpenQuackKit/Dictionary/` (new folder):

- `CorrectionCandidate.swift` — the SPEC §2.3 struct. `wrong`, `right`, `count`, `lastSeen`, `suppressedUntil?`. `dedupeKey` lowercases both sides so casing variants collapse.
- `CorrectionCandidateStore.swift` — `actor`-backed JSON store at `~/Library/Application Support/OpenQuack/correction_candidates.json`. Injectable `fileURL` for tests. `record(_:)` dedupes/merges counts, advances `lastSeen`, caps at 500 entries with eviction by `lastSeen` ascending.
- `CorrectionDiff.swift` — pure `extractCorrections(rawTranscript:committedText:)`. Word-by-word positional alignment (SPEC explicitly OKs simple alignment over Myers). Drops: identical tokens, case-only diffs (avoids "i" → "I" flooding the store), pairs with case-insensitive Levenshtein > 3, and the small built-in stop-word set from SPEC §2.3.
- `PostPasteCorrectionObserver.swift` — one paste-event, one observer. Snapshots focused element + registers `kAXValueChangedNotification` on it and `kAXFocusedUIElementChangedNotification` system-wide. A `DispatchSourceTimer` enforces the 60 s deadline. All three paths (focus-change, timer, race) funnel through a single `fire(finalFieldValue:)` guarded by a `didFire` latch — observers/timer/source removed in `cleanupAfterFire()`. The "edited segment" is the LCP-trimmed tail of *both* the transcript and the field so token alignment stays honest when the user edited past the prefix. Fields without `kAXValueAttribute` silently no-op (SPEC out-of-scope item).

`Sources/OpenQuackApp/OpenQuackApp.swift` — single hook at the live-dictation paste seam (line ~651). After a `pasted == true` from `PasteService.paste`, we instantiate one `PostPasteCorrectionObserver` on the main actor and call `start(transcript:)`. No changes to `PasteService` itself; no callback signatures added.

Tests in `Tests/OpenQuackKitTests/`:

- `CorrectionCandidateStoreTests` — load/save, persistence across instances, case-insensitive dedupe + count merge, distinct `right` values stay separate, 500-cap eviction by `lastSeen` ascending, observer test-seam happy path.
- `CorrectionDiffTests` — single + multiple substitutions in order, identical / empty strings, case-only filter, case-folded edit distance, edit-distance boundary and over-threshold, stop-word filter on `wrong` side, timestamp propagation, segment-extraction helper.

## Tests

- [x] unit tests added: `CorrectionCandidateStoreTests` (8), `CorrectionDiffTests` (15)
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build && swift test` green locally — 76 tests, 0 failures
- [ ] (manual) end-to-end smoke: dictate "cloud code", let it paste into a TextEdit doc, edit to "Claude code", click elsewhere, check `~/Library/Application Support/OpenQuack/correction_candidates.json`

## Privacy impact

Privacy contract is preserved.

- The observer is scoped to one element, one paste event; it self-unregisters on focus-change or 60 s. No continuous keylogging.
- The store writes locally only; no network calls added.
- Only `(wrong, right, count, lastSeen, suppressedUntil?)` quadruples persist — no audio, no full transcripts, no timestamps beyond `lastSeen`.
- Fields that don't expose `kAXValueAttribute` (password fields, some Electron apps) silently no-op.

## Out of scope

- PR-B (≥3 occurrences "Add to dictionary" nudge) — `suppressedUntil` is persisted by this PR for PR-B's "Not now" path.
- PR-C (Settings → GitHub issue export).
- Wiring the observer at the recovery-flow paste call site (`OpenQuackApp.swift:844`): the recovery path auto-pastes old recordings on launch when the user isn't actively in the field. Not the same user-intent signal as a live dictation edit.
- AX-event end-to-end test: a real `AXObserver` event can't be driven in CI, so the observer class exposes `testOnlyFire(transcript:finalFieldValue:)` for the diff → store wiring and the AX-registration itself is manual-test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)