### PR TITLE
feat(SPEC-023): pure reconcile function for launch-at-login

### DIFF
--- a/Sources/OpenQuackKit/Startup/LaunchAtLogin.swift
+++ b/Sources/OpenQuackKit/Startup/LaunchAtLogin.swift
@@ -1,0 +1,48 @@
+import Foundation
+import ServiceManagement
+
+// SPEC-023 — Launch at login.
+//
+// Pure reconciliation between the user's desired state (persisted in
+// UserDefaults as a `Bool` under "launchAtLogin") and the OS-side state
+// reported by `SMAppService.mainApp.status`. The Settings toggle writes
+// to UserDefaults and triggers the corresponding register/unregister
+// call directly; on app launch, the reconciler aligns the two in case
+// the user toggled the login item off in System Settings → Login Items
+// while OpenQuack wasn't running.
+//
+// The function is intentionally pure so the full state table is unit
+// tested without an `SMAppService` mock. The caller is responsible for
+// invoking `SMAppService.mainApp.register()` / `.unregister()` and for
+// writing `false` back to UserDefaults when `resetToggleOff` is
+// returned. See SPEC-023 §Reconciliation for the action table.
+
+public enum LaunchAtLoginAction: Equatable, Sendable {
+    /// State already matches: do nothing.
+    case noop
+    /// User wants it on and the OS hasn't registered us yet — `register()`.
+    case register
+    /// User wants it off and the OS has us registered — `unregister()`.
+    case unregister
+    /// User wants it on but the OS reports `.requiresApproval` or
+    /// `.notFound`. Write `false` back to UserDefaults so the Settings
+    /// toggle reflects reality, and surface the approval-hint copy.
+    case resetToggleOff
+}
+
+/// Reconcile the persisted "launchAtLogin" toggle with the OS-side status.
+/// Pure; the caller performs the IO.
+public func reconcileLaunchAtLogin(
+    desiredEnabled: Bool,
+    currentStatus: SMAppService.Status
+) -> LaunchAtLoginAction {
+    switch (desiredEnabled, currentStatus) {
+    case (true,  .enabled):         return .noop
+    case (true,  .notRegistered):   return .register
+    case (true,  .requiresApproval),
+         (true,  .notFound):        return .resetToggleOff
+    case (false, .enabled):         return .unregister
+    case (false, _):                return .noop
+    @unknown default:               return .noop
+    }
+}

--- a/Tests/OpenQuackKitTests/LaunchAtLoginTests.swift
+++ b/Tests/OpenQuackKitTests/LaunchAtLoginTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+import ServiceManagement
+@testable import OpenQuackKit
+
+// SPEC-023 — covers the full reconciliation table from §Reconciliation.
+
+final class LaunchAtLoginTests: XCTestCase {
+
+    func testDesiredTrue_enabled_noop() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: true,  currentStatus: .enabled),        .noop)
+    }
+
+    func testDesiredTrue_notRegistered_register() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: true,  currentStatus: .notRegistered),  .register)
+    }
+
+    func testDesiredTrue_requiresApproval_resetToggleOff() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: true,  currentStatus: .requiresApproval), .resetToggleOff)
+    }
+
+    func testDesiredTrue_notFound_resetToggleOff() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: true,  currentStatus: .notFound),       .resetToggleOff)
+    }
+
+    func testDesiredFalse_enabled_unregister() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: false, currentStatus: .enabled),        .unregister)
+    }
+
+    func testDesiredFalse_notRegistered_noop() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: false, currentStatus: .notRegistered),  .noop)
+    }
+
+    func testDesiredFalse_requiresApproval_noop() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: false, currentStatus: .requiresApproval), .noop)
+    }
+
+    func testDesiredFalse_notFound_noop() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: false, currentStatus: .notFound),       .noop)
+    }
+}


### PR DESCRIPTION
## SPEC: SPEC-023 (Launch at login)
## Milestone: —

### Why
Issue #29 ("Add auto launch app on startup") needs an opt-in Settings toggle that registers OpenQuack as a login item via `SMAppService.mainApp`. SPEC-023 (open in #30) defines the contract; this PR lands the pure reconciliation function so the unit test surface is in place before the UI lands.

### Change
- New `Sources/OpenQuackKit/Startup/LaunchAtLogin.swift`:
  - `LaunchAtLoginAction` enum (`noop` / `register` / `unregister` / `resetToggleOff`).
  - `reconcileLaunchAtLogin(desiredEnabled:currentStatus:) -> LaunchAtLoginAction` — pure, encodes the full §Reconciliation table from SPEC-023.
- New `Tests/OpenQuackKitTests/LaunchAtLoginTests.swift` — one test per row of the matrix (8 tests).

The Settings → General toggle, the synchronous `register()` / `unregister()` calls, and the `applicationDidFinishLaunching` reconcile invocation all land in the **follow-up PR** once SPEC-023 (#30) merges. Splitting it here keeps the pure logic separately reviewable and locks in the test surface.

### Tests
- [x] `LaunchAtLoginTests` — 8 cases, full reconciliation table
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build && swift test --filter LaunchAtLoginTests` — 8 passed, 0 failures
- [ ] Manual (follow-up PR): enable toggle → restart Mac → menu-bar icon reappears

### Out of scope
- `SMAppService.mainApp.register()` / `.unregister()` IO calls — follow-up PR
- Settings → General toggle + approval-hint copy — follow-up PR
- `applicationDidFinishLaunching` reconcile call — follow-up PR

Depends on #30 (spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)