### PR TITLE
feat(SPEC-023): launch-at-login Settings toggle + on-launch reconcile

### DIFF
--- a/Sources/OpenQuackApp/LaunchAtLoginController.swift
+++ b/Sources/OpenQuackApp/LaunchAtLoginController.swift
@@ -1,0 +1,79 @@
+import Foundation
+import os.log
+import ServiceManagement
+import OpenQuackKit
+
+// SPEC-023 — App-side integration. Wraps the pure reconcileLaunchAtLogin
+// (in OpenQuackKit) with the SMAppService IO, the UserDefaults rollback
+// when the user has revoked us, and the session-level approval-hint flag
+// that GeneralPane observes.
+//
+// All methods must be called from the main thread. SwiftUI's @MainActor
+// view bodies and AppDelegate.applicationDidFinishLaunching satisfy that.
+final class LaunchAtLoginController: ObservableObject {
+    private static let defaultsKey = "launchAtLogin"
+    private static let logger = Logger(
+        subsystem: "org.openquack.OpenQuack",
+        category: "launchAtLogin"
+    )
+
+    @Published private(set) var showsApprovalHint: Bool = false
+
+    /// Called once from `AppDelegate.applicationDidFinishLaunching`. Aligns
+    /// the persisted toggle with the OS-side login-item state in case the
+    /// user toggled us off in System Settings → Login Items while OpenQuack
+    /// wasn't running.
+    func reconcileOnLaunch() {
+        let desired = UserDefaults.standard.bool(forKey: Self.defaultsKey)
+        perform(
+            action: reconcileLaunchAtLogin(
+                desiredEnabled: desired,
+                currentStatus: SMAppService.mainApp.status
+            ),
+            desiredEnabled: desired
+        )
+    }
+
+    /// Called from the Settings toggle's `.onChange`. Performs
+    /// register/unregister synchronously; rolls UserDefaults back to false
+    /// and sets the hint on failure.
+    func apply(desiredEnabled: Bool) {
+        perform(
+            action: reconcileLaunchAtLogin(
+                desiredEnabled: desiredEnabled,
+                currentStatus: SMAppService.mainApp.status
+            ),
+            desiredEnabled: desiredEnabled
+        )
+    }
+
+    private func perform(action: LaunchAtLoginAction, desiredEnabled: Bool) {
+        switch action {
+        case .register:
+            do {
+                try SMAppService.mainApp.register()
+                showsApprovalHint = false
+            } catch {
+                Self.logger.error("register failed: \(String(describing: error), privacy: .public)")
+                UserDefaults.standard.set(false, forKey: Self.defaultsKey)
+                showsApprovalHint = true
+            }
+        case .unregister:
+            do {
+                try SMAppService.mainApp.unregister()
+            } catch {
+                Self.logger.error("unregister failed: \(String(describing: error), privacy: .public)")
+            }
+        case .resetToggleOff:
+            UserDefaults.standard.set(false, forKey: Self.defaultsKey)
+            showsApprovalHint = true
+        case .noop:
+            // If the user wanted us on and the OS already has us
+            // registered, any previous register failure is no longer
+            // relevant — clear the hint.
+            if desiredEnabled {
+                showsApprovalHint = false
+            }
+        }
+    }
+}

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -76,8 +76,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var streamer: StreamingTranscriber?   // SPEC-012; long-lived after warm
     private var overlay: RecordingOverlay?
     private let updater = UpdateChecker()
-    let usageStats = UsageStats()        // SPEC-013
-    let historyStore = HistoryStore()    // SPEC-014
+    let usageStats = UsageStats()                                  // SPEC-013
+    let historyStore = HistoryStore()                              // SPEC-014
+    let launchAtLoginController = LaunchAtLoginController()        // SPEC-023
 
     /// Persist the last recording so the user can verify capture quality
     /// independent of model output. `open ~/Library/Application Support/OpenQuack/last-recording.wav`.
@@ -163,6 +164,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await history.enforceRetention()
             await self.offerRecoveryIfNeeded()
         }
+
+        // SPEC-023 — align persisted toggle with OS-side login-item state.
+        launchAtLoginController.reconcileOnLaunch()
     }
 
     /// macOS calls this when the user double-clicks the .app while it's
@@ -311,7 +315,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     @objc private func menuShowApp() {
-        SettingsWindowController.show(appState: appState)
+        SettingsWindowController.show(
+            appState: appState,
+            launchAtLoginController: launchAtLoginController
+        )
     }
 
     @MainActor

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -15,10 +15,11 @@ struct SettingsView: View {
     enum Tab: Hashable { case general, shortcut, stats, history, about }
     @State private var selection: Tab = .general
     @ObservedObject var appState: AppState
+    @ObservedObject var launchAtLoginController: LaunchAtLoginController
 
     var body: some View {
         TabView(selection: $selection) {
-            GeneralPane()
+            GeneralPane(launchAtLoginController: launchAtLoginController)
                 .tabItem { Label("General", systemImage: "gearshape") }
                 .tag(Tab.general)
             ShortcutPane()
@@ -50,6 +51,8 @@ private struct GeneralPane: View {
     @AppStorage("vadSilenceSeconds")   private var vadSilenceSeconds: Double = 1.5
     @AppStorage("customWords")         private var customWords: String = ""
     @AppStorage("model")               private var model: String = "medium"
+    @AppStorage("launchAtLogin")       private var launchAtLogin: Bool = false
+    @ObservedObject var launchAtLoginController: LaunchAtLoginController
 
     var body: some View {
         Form {
@@ -140,6 +143,21 @@ private struct GeneralPane: View {
                     .foregroundStyle(.secondary)
             } header: {
                 SectionHeader("Custom dictionary")
+            }
+
+            Section {
+                Toggle("Launch OpenQuack at login", isOn: $launchAtLogin)
+                    .help("Start OpenQuack automatically when you sign in to your Mac, so the menu-bar icon and global hotkey are ready without launching the app manually.")
+                    .onChange(of: launchAtLogin) { newValue in
+                        launchAtLoginController.apply(desiredEnabled: newValue)
+                    }
+                if launchAtLoginController.showsApprovalHint {
+                    Text("macOS blocked OpenQuack from auto-starting. Enable it in System Settings → General → Login Items, then toggle this on again.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                SectionHeader("Startup")
             }
         }
         .formStyle(.grouped)

--- a/Sources/OpenQuackApp/SettingsWindowController.swift
+++ b/Sources/OpenQuackApp/SettingsWindowController.swift
@@ -8,7 +8,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private static var shared: SettingsWindowController?
     private var keyMonitor: Any?
 
-    static func show(appState: AppState) {
+    static func show(appState: AppState, launchAtLoginController: LaunchAtLoginController) {
         if let existing = shared {
             existing.window?.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
@@ -19,7 +19,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         // can re-find it after switching to System Settings or another app.
         NSApp.setActivationPolicy(.regular)
 
-        let view = SettingsView(appState: appState)
+        let view = SettingsView(
+            appState: appState,
+            launchAtLoginController: launchAtLoginController
+        )
         let host = NSHostingController(rootView: view)
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 580, height: 500),

--- a/Sources/OpenQuackKit/Startup/LaunchAtLogin.swift
+++ b/Sources/OpenQuackKit/Startup/LaunchAtLogin.swift
@@ -20,13 +20,17 @@ import ServiceManagement
 public enum LaunchAtLoginAction: Equatable, Sendable {
     /// State already matches: do nothing.
     case noop
-    /// User wants it on and the OS hasn't registered us yet — `register()`.
+    /// User wants it on and the OS doesn't have a BTM record for us yet —
+    /// `register()`. Covers both `.notRegistered` (legacy) and `.notFound`
+    /// (no BTM record exists at this bundle path, i.e. the bootstrap state
+    /// for `SMAppService.mainApp` before any successful register call).
     case register
     /// User wants it off and the OS has us registered — `unregister()`.
     case unregister
-    /// User wants it on but the OS reports `.requiresApproval` or
-    /// `.notFound`. Write `false` back to UserDefaults so the Settings
-    /// toggle reflects reality, and surface the approval-hint copy.
+    /// User wants it on but the OS reports `.requiresApproval` — the BTM
+    /// record exists but the user has actively disabled us in System
+    /// Settings → Login Items. Write `false` back to UserDefaults so the
+    /// Settings toggle reflects reality, and surface the approval-hint copy.
     case resetToggleOff
 }
 
@@ -37,12 +41,16 @@ public func reconcileLaunchAtLogin(
     currentStatus: SMAppService.Status
 ) -> LaunchAtLoginAction {
     switch (desiredEnabled, currentStatus) {
-    case (true,  .enabled):         return .noop
-    case (true,  .notRegistered):   return .register
-    case (true,  .requiresApproval),
-         (true,  .notFound):        return .resetToggleOff
-    case (false, .enabled):         return .unregister
-    case (false, _):                return .noop
-    @unknown default:               return .noop
+    case (true,  .enabled):          return .noop
+    // `.notFound` is the bootstrap state for `SMAppService.mainApp`: BTM
+    // simply has no record at this bundle path yet. Treat it like
+    // `.notRegistered` and try to register — the system will only build
+    // the record after a successful `register()` call.
+    case (true,  .notRegistered),
+         (true,  .notFound):         return .register
+    case (true,  .requiresApproval): return .resetToggleOff
+    case (false, .enabled):          return .unregister
+    case (false, _):                 return .noop
+    @unknown default:                return .noop
     }
 }

--- a/Tests/OpenQuackKitTests/LaunchAtLoginTests.swift
+++ b/Tests/OpenQuackKitTests/LaunchAtLoginTests.swift
@@ -18,8 +18,8 @@ final class LaunchAtLoginTests: XCTestCase {
         XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: true,  currentStatus: .requiresApproval), .resetToggleOff)
     }
 
-    func testDesiredTrue_notFound_resetToggleOff() {
-        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: true,  currentStatus: .notFound),       .resetToggleOff)
+    func testDesiredTrue_notFound_register() {
+        XCTAssertEqual(reconcileLaunchAtLogin(desiredEnabled: true,  currentStatus: .notFound),       .register)
     }
 
     func testDesiredFalse_enabled_unregister() {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@ The product has a working foundation. The current cycle is about removing first-
 | 🔵 | README demo gif + landing-page polish — strong first-impression artifact | SPEC-027 | S |
 | 🟡 | Mandarin auto-detect fix: visible quality bug surfaced by issue #17 | SPEC-021 | PR #20 (bench) draft |
 | 🔵 | `fn` / Globe key as a bindable hotkey — meets a common new-user expectation (#23) | SPEC-003a | PR #28 draft |
-| 🔵 | Launch at login (SMAppService toggle) — basic menu-bar UX (#29) | SPEC-023 | reconcile in main; PR-B wires UI |
+| 🟡 | Launch at login (SMAppService toggle) — basic menu-bar UX (#29) | SPEC-023 | PR #38 draft |
 | ⚪ | Submission tracking for awesome-mac / awesome-llm / awesome-swift lists | — | quiet but durable inbound |
 | ⚪ | Quarterly bench refresh — durable artifact + monthly relaunch hook | — | leverages existing 5×2×177 bench |
 

--- a/docs/SPECS/SPEC-023-launch-at-login.md
+++ b/docs/SPECS/SPEC-023-launch-at-login.md
@@ -75,15 +75,24 @@ func reconcile(desiredEnabled: Bool, currentStatus: SMAppService.Status) -> Laun
 |---------|-------------------------|-------------------|
 | true    | `.enabled`              | `noop`            |
 | true    | `.notRegistered`        | `register`        |
+| true    | `.notFound`             | `register`        |
 | true    | `.requiresApproval`     | `resetToggleOff`  |
-| true    | `.notFound`             | `resetToggleOff`  |
 | false   | `.enabled`              | `unregister`      |
 | false   | anything else           | `noop`            |
 
+`.notFound` is the bootstrap state for `SMAppService.mainApp`: until a
+successful `register()` call builds the BTM record at this bundle path,
+`status` returns `.notFound` (BTM error -95, "record not found"). It must
+be treated like `.notRegistered` — try to register. Otherwise the toggle
+can never get out of `.notFound` because we'd refuse to ever call
+`register()`.
+
 `resetToggleOff` writes `false` back to `UserDefaults` so the Settings UI
 reflects reality on next render, and surfaces a single-line hint under the
-toggle (see "Settings UI" below). We do **not** silently retry registration
-when the user has revoked approval — that's the user's stated preference.
+toggle (see "Settings UI" below). It is reserved for the case where the
+user has *actively* revoked us in System Settings → Login Items
+(`.requiresApproval`) — we do not silently retry registration there,
+that's the user's stated preference.
 
 ### Toggle write path
 


### PR DESCRIPTION
## SPEC

SPEC-023 (Launch at login)

## Milestone

M2

## Why

OpenQuack is a menu-bar app whose value depends on it being always-on — the hotkey only works when the app is running. Today, after every restart the user has to manually launch from `/Applications` before dictation works. For a tool that's supposed to feel like a system feature, that's a recurring papercut and a known reason new users churn after their first reboot. Closes #29.

## Change

App-side integration for SPEC-023 on top of the pure `reconcileLaunchAtLogin` that landed in #33, plus a fix to a `.notFound` bug in that table found during manual verification.

**New file:**

- `Sources/OpenQuackApp/LaunchAtLoginController.swift` — `ObservableObject` wrapping `SMAppService.mainApp.register/unregister`, UserDefaults rollback on register-throw, and a session-level `showsApprovalHint` flag for the UI.

**Modified:**

- `Sources/OpenQuackApp/OpenQuackApp.swift` — `AppDelegate` holds the controller and calls `reconcileOnLaunch()` at the tail of `applicationDidFinishLaunching` so the persisted toggle stays in sync with OS-side BTM state if the user revoked us in System Settings while OpenQuack wasn't running.
- `Sources/OpenQuackApp/SettingsView.swift` — `GeneralPane` gains a "Startup" section with the toggle and (when the OS rejects registration) a hint line directing the user to System Settings → Login Items.
- `Sources/OpenQuackApp/SettingsWindowController.swift` — threads the controller into the SwiftUI view tree.
- `Sources/OpenQuackKit/Startup/LaunchAtLogin.swift` — reconcile table fix: `(true, .notFound) → .register` (was `.resetToggleOff`). Verified via system logs that `.notFound` is the bootstrap state for `SMAppService.mainApp` on a fresh bundle (BTM error -95 \"record not found\"), not a rejection. The old mapping made it impossible to ever escape `.notFound` because `register()` was never being called. `.resetToggleOff` is now reserved for `.requiresApproval` (the actual revoke case).
- `Tests/OpenQuackKitTests/LaunchAtLoginTests.swift` — `testDesiredTrue_notFound_register` updated to match the corrected table.
- `docs/SPECS/SPEC-023-launch-at-login.md` — reconcile table + prose updated.

## Tests

- [x] reconcile-table tests: all 8 rows covered in `OpenQuackKitTests.LaunchAtLoginTests`
- [x] \`swift build && swift test\` green locally (61/0, Xcode 26.5 toolchain)
- [x] manual repro on dev .app build:
  - toggle on → `backgroundtaskmanagementd` logs `registerLaunchItem: result=no error, disposition=[enabled, allowed, visible]`
  - System Settings → Login Items → OpenQuack appears under \"Open at Login\"
  - log out / log back in → menu-bar duck appears automatically within seconds, no Dock bounce, no Settings auto-open
- No bench delta — this change doesn't touch transcription quality or latency.

## Privacy impact

No impact on the privacy contract. SPEC-023 doesn't touch audio capture, transcription, agent dispatch, or output. It writes a local OS-side BTM record (Login Item) so macOS launches the app at user login — local-only system state, no network, no cloud.

## Out of scope

Per SPEC-023 §\"Out of scope\":

- Migration from legacy `LSSharedFileList` — `Package.swift` pins macOS 13+, so `SMAppService` is always available.
- Auto-enabling on first run / install (opt-in by default).
- Telemetry on toggle usage.
- Deep-linking the hint into System Settings via `x-apple.systempreferences:` — nice-to-have, follow-up if users ask.
- Localised strings — own track in SPEC-019.

---

## AI coding brief

**Original request:** roadmap triage → user asked which 🔵 items fit \"do now,\" picked SPEC-023 because the pure `reconcileLaunchAtLogin` had already landed in #33, leaving only App-layer integration. Why: closes issue #29, a recurring first-reboot papercut for a menu-bar app whose value depends on always-on.

**Manual interventions:**

- Pivoted mid-task from a multi-stage subagent-driven workflow (implementer → spec reviewer → code-quality reviewer per task) to direct Opus implementation at user direction — the review ceremony was producing slow churn relative to the small surface area.
- Caught a bug in the existing reconcile table (originally in #33) during manual verification. The table treated `SMAppService.Status.notFound` as a rejection (\"user revoked us\"), but `.notFound` is actually the bootstrap state for `SMAppService.mainApp` on a fresh bundle. Identified by reading `backgroundtaskmanagementd` log entries (`BTMErrorDomain Code=-95 \"record not found\"`). Fixed in a separate commit on this branch so the diff against #33's pure function is clearly scoped.
- Earlier in debugging, I prematurely concluded the OS rejection was due to ad-hoc signing / missing `TeamIdentifier`. User pushed back. Walking back the reasoning with the user revealed I'd taken a speculative leap without log evidence. Re-querying with the right system-side log filter (`subsystem == \"com.apple.backgroundtaskmanagement\"`) immediately produced the actual error code (-95) and the real root cause.

**Retro:** When debugging an OS-level rejection, query the relevant system daemon's log first (filtered by subsystem). The system daemon usually logs the actual error code, which disambiguates \"never registered\" from \"actively rejected\" in one read. Reaching for codesign / signing-policy theories before checking the daemon's own log wastes a debugging cycle.