### PR TITLE
feat(SPEC-023): launch-at-login Settings toggle + AppDelegate reconcile

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -2,6 +2,8 @@ import AppKit
 import AVFoundation
 import SwiftUI
 import Combine
+import os
+import ServiceManagement
 import OpenQuackKit
 
 // SPEC-010 — App shell + dictation lifecycle (SPEC-001 + SPEC-003 wired in).
@@ -78,6 +80,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let updater = UpdateChecker()
     let usageStats = UsageStats()        // SPEC-013
     let historyStore = HistoryStore()    // SPEC-014
+
+    /// SPEC-023 — set true when reconcile returns `.resetToggleOff` (user
+    /// revoked us in System Settings → Login Items while we weren't
+    /// running). Settings → General reads this on appear to surface the
+    /// approval hint. Session-scoped; cleared on next successful register.
+    @MainActor var showsLaunchAtLoginApprovalHint: Bool = false
+
+    private static let launchAtLoginLogger = Logger(
+        subsystem: "org.openquack.OpenQuack",
+        category: "LaunchAtLogin"
+    )
 
     /// Persist the last recording so the user can verify capture quality
     /// independent of model output. `open ~/Library/Application Support/OpenQuack/last-recording.wav`.
@@ -162,6 +175,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             await history.enforceRetention()
             await self.offerRecoveryIfNeeded()
+        }
+
+        // SPEC-023 — align the persisted launchAtLogin toggle with the OS
+        // state. Catches the case where the user revoked us in System
+        // Settings → Login Items while OpenQuack wasn't running.
+        reconcileLaunchAtLoginOnLaunch()
+    }
+
+    /// SPEC-023 §Reconciliation — synchronous on the main actor, runs once
+    /// at launch. `SMAppService` calls are cheap; no Task wrapper needed.
+    @MainActor
+    private func reconcileLaunchAtLoginOnLaunch() {
+        let desired = UserDefaults.standard.bool(forKey: "launchAtLogin")
+        let action = reconcileLaunchAtLogin(
+            desiredEnabled: desired,
+            currentStatus: SMAppService.mainApp.status
+        )
+        switch action {
+        case .noop:
+            return
+        case .register:
+            do {
+                try SMAppService.mainApp.register()
+            } catch {
+                // register can throw on `.requiresApproval`; reverting matches
+                // the SPEC-023 toggle-write contract.
+                UserDefaults.standard.set(false, forKey: "launchAtLogin")
+                showsLaunchAtLoginApprovalHint = true
+                Self.launchAtLoginLogger.error("register() failed on launch: \(error.localizedDescription, privacy: .public)")
+            }
+        case .unregister:
+            do {
+                try SMAppService.mainApp.unregister()
+            } catch {
+                Self.launchAtLoginLogger.error("unregister() failed on launch: \(error.localizedDescription, privacy: .public)")
+            }
+        case .resetToggleOff:
+            UserDefaults.standard.set(false, forKey: "launchAtLogin")
+            showsLaunchAtLoginApprovalHint = true
         }
     }
 

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import AppKit
 import KeyboardShortcuts
+import os
+import ServiceManagement
 import OpenQuackKit
 
 // Settings scene. SwiftUI TabView in an NSWindow (managed by
@@ -50,6 +52,19 @@ private struct GeneralPane: View {
     @AppStorage("vadSilenceSeconds")   private var vadSilenceSeconds: Double = 1.5
     @AppStorage("customWords")         private var customWords: String = ""
     @AppStorage("model")               private var model: String = "medium"
+    @AppStorage("launchAtLogin")       private var launchAtLogin: Bool = false
+
+    // SPEC-023 — session-only hint, seeded from AppDelegate so reconcile
+    // results from app launch propagate the first time Settings opens.
+    @State private var showsApprovalHint: Bool = false
+    // Suppresses the .onChange-triggered SMAppService call when the toggle
+    // is reverted programmatically after a failed register().
+    @State private var isRevertingToggle: Bool = false
+
+    private static let logger = Logger(
+        subsystem: "org.openquack.OpenQuack",
+        category: "LaunchAtLogin"
+    )
 
     var body: some View {
         Form {
@@ -141,10 +156,66 @@ private struct GeneralPane: View {
             } header: {
                 SectionHeader("Custom dictionary")
             }
+
+            // SPEC-023 — Launch at login.
+            Section {
+                Toggle("Launch OpenQuack at login", isOn: $launchAtLogin)
+                    .help("Start OpenQuack automatically when you sign in to your Mac, so the menu-bar icon and global hotkey are ready without launching the app manually.")
+                if showsApprovalHint {
+                    Text("macOS blocked OpenQuack from auto-starting. Enable it in System Settings → General → Login Items, then toggle this on again.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                SectionHeader("Startup")
+            }
         }
         .formStyle(.grouped)
         .padding()
         .creamSettingsBackground()
+        .onAppear {
+            // Pick up the session-flag if reconcile flipped the toggle at
+            // launch (user revoked us in System Settings while away).
+            if let delegate = NSApp.delegate as? AppDelegate,
+               delegate.showsLaunchAtLoginApprovalHint {
+                showsApprovalHint = true
+            }
+        }
+        .onChange(of: launchAtLogin) { newValue in
+            handleLaunchAtLoginChange(newValue)
+        }
+    }
+
+    /// SPEC-023 §Toggle write path. Synchronous SMAppService IO on the
+    /// main actor; on register-throw we revert the toggle and show the hint.
+    @MainActor
+    private func handleLaunchAtLoginChange(_ newValue: Bool) {
+        if isRevertingToggle {
+            isRevertingToggle = false
+            return
+        }
+        if newValue {
+            do {
+                try SMAppService.mainApp.register()
+                showsApprovalHint = false
+                if let delegate = NSApp.delegate as? AppDelegate {
+                    delegate.showsLaunchAtLoginApprovalHint = false
+                }
+            } catch {
+                // register can throw on `.requiresApproval`; reverting matches
+                // the SPEC-023 toggle-write contract.
+                isRevertingToggle = true
+                launchAtLogin = false
+                showsApprovalHint = true
+                Self.logger.error("register() failed: \(error.localizedDescription, privacy: .public)")
+            }
+        } else {
+            do {
+                try SMAppService.mainApp.unregister()
+            } catch {
+                Self.logger.error("unregister() failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## SPEC

SPEC-023 (Launch at login) — PR-B (Settings UI + AppDelegate wiring).
Follow-up to #33 (PR-A: pure reconcile function in OpenQuackKit).

## Milestone

Adoption polish for alpha.11.

## Why

OpenQuack is a menu-bar app whose value depends on always-on availability — the hotkey only works while running. Today every reboot resets that. PR-A landed the pure `reconcileLaunchAtLogin(...)` function; this PR wires the user-visible toggle and the launch-time reconciliation so the OS-side state and the persisted preference stay aligned, including the case where the user revokes us in System Settings → General → Login Items while OpenQuack isn't running.

## Change

**`Sources/OpenQuackApp/SettingsView.swift`**
- New `Startup` section in `GeneralPane`, appended after `Custom dictionary`.
- `@AppStorage("launchAtLogin")` toggle (default `false`, opt-in per SPEC-023 §Goal).
- `.help(...)` copy and approval-hint string verbatim from SPEC-023 §Settings UI.
- `.onChange(of: launchAtLogin)` performs synchronous `SMAppService.mainApp.register()` / `unregister()` on the main actor. On `register()` throw: revert toggle to off, surface hint, log via `Logger`. On `unregister()` throw: log only (goal state already off). An `isRevertingToggle` `@State` flag suppresses the redundant `unregister()` call that would otherwise fire from the programmatic revert.
- `.onAppear` seeds `@State showsApprovalHint` from `AppDelegate.showsLaunchAtLoginApprovalHint` so the hint surfaces the first time Settings opens after a launch-time reconcile flipped the toggle off.

**`Sources/OpenQuackApp/OpenQuackApp.swift`**
- New `reconcileLaunchAtLoginOnLaunch()` called at the end of `applicationDidFinishLaunching` (after onboarding + update poll + history retention). Reads `launchAtLogin` + `SMAppService.mainApp.status`, dispatches the SPEC-023 §Reconciliation action: `.noop`, `.register` (write `false` on throw), `.unregister`, `.resetToggleOff` (write `false` + flip session flag).
- `showsLaunchAtLoginApprovalHint: Bool` lives on `AppDelegate` as the session-flag truth; SettingsView reads it on appear.
- `Logger(subsystem: "org.openquack.OpenQuack", category: "LaunchAtLogin")` for both register/unregister error paths.

`SMAppService.mainApp.register()` / `unregister()` calls live in `OpenQuackApp` only — `OpenQuackKit` stays UI- and IO-free as PR-A established.

## Tests

- [x] `swift build && swift test` green via `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` (61 tests, including the 8 pre-existing `LaunchAtLoginTests` from PR-A covering the full reconcile matrix).
- [x] No new unit tests added: SPEC-023 §Test plan explicitly identifies the reconcile fn as the unit-test seam; SMAppService IO is the manual-repro surface.
- [ ] **Manual (happy path):** toggle on in Settings → confirm OpenQuack appears in System Settings → General → Login Items.
- [ ] **Manual (revoke):** toggle on → revoke in Login Items → relaunch app → toggle flips to off + approval hint appears in Startup section.
- [ ] **Manual (first run):** fresh install → onboarding completes → Startup toggle reads off (opt-in default).

## Privacy impact

None. `SMAppService` is local OS-side state; no network IO, no audio path touched. The privacy contract in `docs/VISION.md` is preserved.

## Out of scope

- Deep-link from the hint to the Login Items pane via `x-apple.systempreferences:` — SPEC-023 §Out of scope; follow-up if users ask.
- Localised strings — SPEC-019 track.
- Telemetry on toggle usage — SPEC-023 §Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)