### PR TITLE
feat(SPEC-026): Sparkle dependency + updater wiring (PR-A)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cbd049855ebc87db58780805c85c98d6178f83718d5f5ef0a295a27b83fad33c",
+  "originHash" : "8a3db3a5e98b5fb27f4568fafb6d080e0ba6a367f25c79186f204bac96bba8f4",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle.git",
+      "state" : {
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,11 @@ let package = Package(
         .package(url: "https://github.com/argmaxinc/argmax-oss-swift.git", from: "0.18.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts.git", from: "2.4.0"),
+        // SPEC-026 — Sparkle 2.x for in-app updates on the DMG path.
+        // Kept off OpenQuackKit (kit stays Sparkle-free); linked only into
+        // OpenQuackApp. `from: "2.6.0"` floats up through 2.x; do not pin a
+        // branch.
+        .package(url: "https://github.com/sparkle-project/Sparkle.git", from: "2.6.0"),
     ],
     targets: [
         .target(
@@ -115,7 +120,10 @@ let package = Package(
         ),
         .executableTarget(
             name: "OpenQuackApp",
-            dependencies: ["OpenQuackKit"],
+            dependencies: [
+                "OpenQuackKit",
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
             path: "Sources/OpenQuackApp",
             resources: [
                 .process("Resources"),

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 import Combine
 import os
 import ServiceManagement
+import Sparkle
 import OpenQuackKit
 
 // SPEC-010 — App shell + dictation lifecycle (SPEC-001 + SPEC-003 wired in).
@@ -77,9 +78,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var transcriber: WhisperKitEngine?
     private var streamer: StreamingTranscriber?   // SPEC-012; long-lived after warm
     private var overlay: RecordingOverlay?
-    private let updater = UpdateChecker()
+    private let updateChecker = UpdateChecker()
     let usageStats = UsageStats()        // SPEC-013
     let historyStore = HistoryStore()    // SPEC-014
+
+    /// SPEC-026 — Sparkle updater. Optional + initialized inside
+    /// `applicationDidFinishLaunching` (after `installMethod` detection)
+    /// so we can configure `automaticallyChecksForUpdates` before the
+    /// updater's first scheduled poll. Declared as `var` rather than
+    /// `lazy` because `SPUStandardUpdaterController` is `@MainActor`
+    /// isolated; a stored-property initializer would need to run on the
+    /// main actor at AppDelegate-init time, which isn't guaranteed.
+    /// Held for the app's lifetime so scheduled checks keep running and
+    /// so PR-B's Settings toggle / "Check now" button have a stable
+    /// handle. NOTE: SUPublicEDKey in the bundled Info.plist is still a
+    /// placeholder; until the user runs `generate_keys` and swaps it,
+    /// Sparkle will refuse to install any downloaded update.
+    private var sparkleUpdater: SPUStandardUpdaterController?
 
     /// SPEC-023 — set true when reconcile returns `.resetToggleOff` (user
     /// revoked us in System Settings → Login Items while we weren't
@@ -115,6 +130,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         appState.installMethod = InstallMethodDetector.detect()
+        installSparkleUpdater()
         installStatusItem()
         installPopover()
         installHotkey()
@@ -250,6 +266,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await pollForUpdate(force: true) }
     }
 
+    /// SPEC-026 — Brew-cask coexistence is the hard rule: two installers
+    /// must never fight over the same `.app` bundle. Sparkle is registered
+    /// for everyone so PR-B's channel toggle keeps working if the user
+    /// later switches install methods, but for `.homebrew` we disable
+    /// scheduled checks so it polls nothing and shows nothing on its own.
+    /// The popover banner (driven by `UpdateChecker` → `pollForUpdate`)
+    /// stays the primary CTA; for brew users it remains the *only* update
+    /// surface. Until the user fills `SUPublicEDKey` in the bundled
+    /// Info.plist, Sparkle will fetch the appcast but refuse to install
+    /// any downloaded update — the wiring is intentionally a no-op in
+    /// PR-A's shipped binary.
+    @MainActor
+    private func installSparkleUpdater() {
+        let controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        switch appState.installMethod {
+        case .homebrew:
+            // Brew owns the bundle. Sparkle stays registered (so PR-B's
+            // channel toggle and "Check now" button still resolve) but
+            // its scheduler is muted.
+            controller.updater.automaticallyChecksForUpdates = false
+        case .manual:
+            // DMG / drag-installed. Let Sparkle's daily scheduler run;
+            // the interval is governed by `SUScheduledCheckInterval` in
+            // the bundled Info.plist.
+            controller.updater.automaticallyChecksForUpdates = true
+        }
+        sparkleUpdater = controller
+    }
+
     private func pollForUpdate(force: Bool = false) async {
         if !force, let last = UserDefaults.standard.object(forKey: "lastUpdateCheck") as? Date,
            Date().timeIntervalSince(last) < 24 * 60 * 60 {
@@ -257,7 +306,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         await MainActor.run { appState.updateStatus = .checking }
         do {
-            let release = try await updater.checkForUpdate(currentVersion: OpenQuackKit.version)
+            let release = try await updateChecker.checkForUpdate(currentVersion: OpenQuackKit.version)
             let now = Date()
             await MainActor.run {
                 if let release {

--- a/Sources/OpenQuackKit/Updates/UpdateChannel.swift
+++ b/Sources/OpenQuackKit/Updates/UpdateChannel.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+// SPEC-026 — Multi-channel appcast selection.
+//
+// Pure mapping from a logical channel to the GitHub-Pages-hosted appcast
+// URL. Lives in OpenQuackKit so the function is unit-testable without a
+// Sparkle import (kit stays Sparkle-free per SPEC-026 §Technical approach).
+// The Settings toggle (PR-B) wires this to `SPUUpdater.feedURL`; PR-A
+// lands the function but doesn't call it yet — the Info.plist still
+// hardcodes `SUFeedURL` to the stable channel.
+
+public enum UpdateChannel: String, Sendable, Equatable, CaseIterable {
+    /// Stable releases only — non-prerelease tags.
+    case stable
+    /// Beta releases. Reserved for the future stable/beta split; the
+    /// Settings UI in PR-B exposes only a binary stable↔alpha toggle.
+    /// The `.beta` case exists so PR-C's release script can emit
+    /// `appcast-beta.xml` against the same mapping later.
+    case beta
+    /// Alpha / prerelease feed — carries every release.
+    case alpha
+}
+
+/// Maps an `UpdateChannel` to its appcast URL on `larryxiao.github.io`.
+/// Force-unwrapping the URLs is safe — they're static literals checked at
+/// compile time by the tests; a typo would fail the unit test immediately.
+public func chooseAppcastURL(channel: UpdateChannel) -> URL {
+    let base = "https://larryxiao.github.io/openquack"
+    let filename: String
+    switch channel {
+    case .stable: filename = "appcast.xml"
+    case .beta:   filename = "appcast-beta.xml"
+    case .alpha:  filename = "appcast-alpha.xml"
+    }
+    return URL(string: "\(base)/\(filename)")!
+}

--- a/Tests/OpenQuackKitTests/UpdateChannelTests.swift
+++ b/Tests/OpenQuackKitTests/UpdateChannelTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OpenQuackKit
+
+// SPEC-026 — covers `chooseAppcastURL` across all three channels.
+// Pure function, no Sparkle mocking (mirrors `LaunchAtLoginTests`).
+
+final class UpdateChannelTests: XCTestCase {
+
+    func testStableMapsToAppcastXML() {
+        XCTAssertEqual(
+            chooseAppcastURL(channel: .stable).absoluteString,
+            "https://larryxiao.github.io/openquack/appcast.xml"
+        )
+    }
+
+    func testBetaMapsToAppcastBetaXML() {
+        XCTAssertEqual(
+            chooseAppcastURL(channel: .beta).absoluteString,
+            "https://larryxiao.github.io/openquack/appcast-beta.xml"
+        )
+    }
+
+    func testAlphaMapsToAppcastAlphaXML() {
+        XCTAssertEqual(
+            chooseAppcastURL(channel: .alpha).absoluteString,
+            "https://larryxiao.github.io/openquack/appcast-alpha.xml"
+        )
+    }
+
+    /// Belt-and-braces: every channel resolves to a non-nil HTTPS URL on
+    /// the same host. Catches the case where someone adds a new case
+    /// without extending the mapping.
+    func testAllChannelsResolveToHTTPSOnSameHost() {
+        for channel in UpdateChannel.allCases {
+            let url = chooseAppcastURL(channel: channel)
+            XCTAssertEqual(url.scheme, "https", "\(channel)")
+            XCTAssertEqual(url.host, "larryxiao.github.io", "\(channel)")
+        }
+    }
+}

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" standalone="yes"?>
+<!--
+    SPEC-026 — Stable-channel appcast for OpenQuack.
+
+    PR-A (this commit) lands an empty channel. No <item> blocks yet:
+    alpha.11 isn't a Sparkle release — Sparkle starts fetching this feed
+    on the next signed release built with SUPublicEDKey populated.
+
+    PR-C adds a release-script step that, for each new signed DMG:
+      1. reads the DMG's byte length
+      2. runs Sparkle's `sign_update` against the maintainer's EdDSA key
+      3. prepends a new <item> to this file
+      4. commits + pushes (GitHub Pages serves /docs)
+
+    Item shape (per Sparkle docs):
+        <item>
+          <title>v2.0.0-alpha.12</title>
+          <sparkle:version>2.0.0.12</sparkle:version>
+          <sparkle:shortVersionString>2.0.0-alpha.12</sparkle:shortVersionString>
+          <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+          <enclosure url="…/OpenQuack-2.0.0-alpha.12.dmg"
+            length="9123456" type="application/octet-stream"
+            sparkle:edSignature="…base64…" />
+        </item>
+
+    `sparkle:version` is the dotted build number Sparkle orders by;
+    `sparkle:shortVersionString` carries the human tag.
+-->
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>OpenQuack — Stable</title>
+        <link>https://larryxiao.github.io/openquack/appcast.xml</link>
+        <description>In-app updates for stable OpenQuack releases (DMG path). Brew users upgrade via `brew upgrade --cask openquack`.</description>
+        <language>en</language>
+    </channel>
+</rss>

--- a/scripts/wrap_app.sh
+++ b/scripts/wrap_app.sh
@@ -74,6 +74,14 @@ done
 cat > "$BUNDLE/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+    SPEC-026 — SUPublicEDKey is intentionally a placeholder. The user
+    runs Sparkle's bundled `generate_keys` once locally; the public half
+    lands here as a follow-up commit, the private half stays in the
+    maintainer's Keychain + a GH Actions secret. Until that swap lands,
+    Sparkle fetches the appcast but refuses to install any update — by
+    design.
+-->
 <plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>            <string>org.openquack.OpenQuack</string>
@@ -92,6 +100,15 @@ cat > "$BUNDLE/Contents/Info.plist" <<PLIST
     <key>NSMicrophoneUsageDescription</key>  <string>OpenQuack transcribes your voice locally to dispatch commands to your AI agent. Audio never leaves the machine.</string>
     <key>NSAppleEventsUsageDescription</key> <string>OpenQuack uses Terminal to run "brew upgrade --cask openquack" when you click Upgrade.</string>
     <key>NSHumanReadableCopyright</key>      <string>MIT — github.com/larryxiao</string>
+
+    <!-- SPEC-026 — Sparkle 2.x auto-update. Stable channel by default;
+         PR-B's Settings toggle will re-point feedURL to the alpha appcast
+         at runtime. -->
+    <key>SUFeedURL</key>                     <string>https://larryxiao.github.io/openquack/appcast.xml</string>
+    <key>SUEnableAutomaticChecks</key>       <true/>
+    <key>SUScheduledCheckInterval</key>      <integer>86400</integer>
+    <key>SUAutomaticallyUpdate</key>         <false/>
+    <key>SUPublicEDKey</key>                 <string>PLACEHOLDER_EDDSA_PUBLIC_KEY_BASE64_REPLACE_ME</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## SPEC

SPEC-026 (Sparkle auto-update) — PR-A of three.

## Milestone

M3

## Why

Existing DMG users have to re-download the DMG every release. SPEC-026
closes that gap with in-app Sparkle updates for the manual path while
keeping the brew flow untouched. This PR lands the dependency, the
plist mechanics, and the AppDelegate wiring so PR-B (Settings UI) and
PR-C (release script) have a stable foundation.

PR-A is intentionally feature-flag-safe: with no `<item>` newer than
the running build in the appcast and a placeholder `SUPublicEDKey`,
nothing changes user-visibly. Sparkle is registered but inert.

## Change

- `Package.swift`: Sparkle `from: "2.6.0"` (resolves to 2.9.1, binary
  artifact). Linked only into `OpenQuackApp` — `OpenQuackKit` stays
  Sparkle-free.
- `Sources/OpenQuackApp/OpenQuackApp.swift`:
  - Rename existing GitHub-Releases poller `updater` → `updateChecker`
    (frees the `updater` name for Sparkle in PR-B's natural call sites).
  - Add `sparkleUpdater: SPUStandardUpdaterController?` initialized
    inside `applicationDidFinishLaunching` after
    `InstallMethodDetector.detect()`. `SPUStandardUpdaterController` is
    `@MainActor`-isolated and the install-method branch needs to run
    before the first scheduled check, so an in-init `var` (not a
    stored-property `let`) is the correct shape.
  - **Hard rule:** `installMethod == .homebrew` sets
    `automaticallyChecksForUpdates = false`. Brew owns the bundle;
    Sparkle stays registered (so PR-B's channel toggle still resolves)
    but its scheduler is muted.
- `scripts/wrap_app.sh`: emit `SUFeedURL`,
  `SUEnableAutomaticChecks=YES`, `SUScheduledCheckInterval=86400`,
  `SUAutomaticallyUpdate=NO`, and a placeholder `SUPublicEDKey`. The
  app has no static Info.plist on disk — `wrap_app.sh` generates it via
  heredoc at bundle-wrap time, so the plist edits live there.
- `Sources/OpenQuackKit/Updates/UpdateChannel.swift`: pure
  `enum UpdateChannel` + `chooseAppcastURL(channel:)`. Lands here so
  PR-B's diff stays scoped to UI; PR-A doesn't call the function yet.
- `docs/appcast.xml`: empty stable-channel stub. PR-C wires the
  release script to prepend `<item>` blocks via `sign_update`.
- `Tests/OpenQuackKitTests/UpdateChannelTests.swift`: one assertion per
  channel + an HTTPS/host invariant.

### Placeholder `SUPublicEDKey` — intentional

`scripts/wrap_app.sh` emits the literal string
`PLACEHOLDER_EDDSA_PUBLIC_KEY_BASE64_REPLACE_ME`. The reviewer should
not swap this in this PR; the maintainer runs Sparkle's bundled
`generate_keys` once locally, drops the public half here as a
follow-up commit, and keeps the private half in their Keychain + a GH
Actions secret. Until that swap, Sparkle fetches the appcast but
refuses to install any download — which is exactly what we want during
the PR-A → PR-B → PR-C rollout.

## Tests

- [x] unit test added: `OpenQuackKitTests.UpdateChannelTests` (4 cases)
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build` green
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` green (74 tests, 0 failures)
- [x] `otool -L .build/debug/openquack | grep -i sparkle` confirms
      `@rpath/Sparkle.framework` linked (2.9.1)

`SPUStandardUpdaterController` lifecycle is **not** unit-tested —
it needs a real `.app` bundle context Swift tests don't provide.
Per SPEC-026 §Test plan, the Sparkle path is manual-validated; PR-C
will exercise the end-to-end signed-update flow.

## Privacy impact

No change. `UpdateChecker`'s polling of `api.github.com/.../releases/latest`
is unchanged. Sparkle adds a daily GET against
`larryxiao.github.io/openquack/appcast.xml` for `.manual` installs and
nothing for `.homebrew` installs. No PII; no audio; no telemetry.

## Out of scope

- Settings UI for the auto-check + prerelease toggles → PR-B
- Release-script integration (sign_update, appcast `<item>` emission)
  → PR-C
- Replacing the in-popover update banner — `UpdateChecker` still
  drives it; Sparkle is the silent secondary install path