### PR TITLE
docs: add Discussions CTA to README + Pages landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ hotkey in Settings → Shortcut. Default ⌃⇧Space.
 
 More options (uninstall, build-from-source, what's downloaded on first run): [`docs/INSTALL.md`](docs/INSTALL.md).
 
+## Got stuck? Want a feature?
+
+Drop a comment in **[Discussions](https://github.com/larryxiao/openquack/discussions/43)** — it's the lowest-friction way to reach me. Bugs, feature ideas, "I'm using it for X" workflow stories, or quick questions about Whisper / model choice / paste behavior in a specific app all welcome. Issues are fine for structured reports too, but no need to format.
+
 ## Acknowledgements
 
 OpenQuack stands on the shoulders of generous open-source work. Huge thanks to:

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,10 @@ brew install --cask openquack
 
 Or [download the DMG](https://github.com/larryxiao/openquack/releases) and drag into Applications. macOS 13+ on Apple Silicon (M1 or newer).
 
+## Got stuck? Want a feature?
+
+Drop a comment in **[Discussions](https://github.com/larryxiao/openquack/discussions/43)** — it's the lowest-friction way to reach me. Bugs, feature ideas, "I'm using it for X" workflow stories, or quick questions about Whisper / model choice all welcome.
+
 ## Documentation
 
 - [Install guide](INSTALL.md)


### PR DESCRIPTION
## Summary

Adds a low-friction "Got stuck? Want a feature?" CTA pointing at the pinned welcome Discussion ([#43](https://github.com/larryxiao/openquack/discussions/43)) on both surfaces (README and docs/index.md).

Sits right after the install instructions so first-time users have a clear path to surface bugs / feature ideas / workflow stories without having to format an Issue.

## Action item for you

Pin Discussion #43 in github.com → Discussions → click the discussion → "Pin discussion" (top-right). GraphQL API doesn't expose the pin mutation, so this is a 30-second manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)