### PR TITLE
feat(SPEC-028): performance summariser + Settings → Stats additions

### DIFF
--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -434,6 +434,9 @@ private struct StatsPane: View {
     @AppStorage("trackUsageStats") private var trackUsageStats: Bool = true
     @AppStorage("typingWPM")       private var typingWPM: Int = 50
     @State private var snapshot: UsageStatsSnapshot?
+    // SPEC-028 — recomputed when the pane appears or `showUsageStats` flips.
+    // Not persisted; recomputing over ≤50 entries is microseconds.
+    @State private var performance: PerformanceSummary?
 
     var body: some View {
         Form {
@@ -451,6 +454,12 @@ private struct StatsPane: View {
                         statRow("Words dictated",        value: snap.wordsDictated.formatted())
                         statRow("Audio processed",       value: Self.formatDuration(snap.audioSeconds))
                         statRow("Dictations",            value: snap.dictationCount.formatted())
+                        // SPEC-028 — personal performance rows. Render between
+                        // "Audio processed" and "Time saved vs. typing" so the
+                        // headline-friendly numbers sit with the rest of the
+                        // aggregates rather than orphaned below.
+                        longestDictationRow
+                        processingSpeedRow
                         statRow("Time saved vs. typing", value: Self.formatDuration(snap.timeSaved(typingWordsPerMinute: typingWPM)))
                         if let since = snap.firstRecordedAt {
                             statRow("Since", value: since.formatted(date: .abbreviated, time: .omitted))
@@ -460,6 +469,16 @@ private struct StatsPane: View {
                     }
                 } header: {
                     SectionHeader("This Mac")
+                }
+
+                // SPEC-028 — length distribution. Only rendered when there's
+                // at least one bucketed entry so an empty pane stays quiet.
+                if let perf = performance, Self.totalBucketCount(perf) > 0 {
+                    Section {
+                        durationHistogram(perf)
+                    } header: {
+                        SectionHeader("Sessions by length")
+                    }
                 }
             }
 
@@ -500,8 +519,19 @@ private struct StatsPane: View {
         (NSApp.delegate as? AppDelegate)?.usageStats
     }
 
+    /// SPEC-028 — mirror the `stats` accessor so the pane reads from the
+    /// same singleton the rest of the app uses.
+    private static var history: HistoryStore? {
+        (NSApp.delegate as? AppDelegate)?.historyStore
+    }
+
     private func refresh() async {
         snapshot = await Self.stats?.snapshot()
+        // SPEC-028 — pull the same 50-entry window the History pane shows
+        // (also the SPEC-014 default retention cap) and recompute. No
+        // caching: the summariser is pure and microseconds.
+        let entries = await Self.history?.list(limit: 50) ?? []
+        performance = PerformanceSummariser.summarise(entries)
     }
 
     private static func formatDuration(_ seconds: TimeInterval) -> String {
@@ -514,11 +544,105 @@ private struct StatsPane: View {
         return "\(s)s"
     }
 
+    /// SPEC-028 — duration formatter for the Longest-dictation row.
+    /// Matches the spec's "6 min 12 s" / "45 s" / "1h 30m" shape (the
+    /// 6 min form uses "m " + "s" to read like prose; the existing
+    /// `formatDuration` writes "6m 12s" for terse aggregate rows).
+    private static func formatLongestDuration(_ seconds: TimeInterval) -> String {
+        let total = max(0, Int(seconds.rounded()))
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 { return "\(h)h \(m)m" }
+        if total >= 60 { return "\(m) min \(s) s" }
+        return "\(s) s"
+    }
+
+    /// SPEC-028 — one-decimal seconds, e.g. "3.4 s".
+    private static func formatProcessSeconds(_ seconds: TimeInterval) -> String {
+        String(format: "%.1f s", seconds)
+    }
+
+    /// SPEC-028 — "3.4×" under 10, "110×" at or above. Integer-round at
+    /// the high end so the headline number reads cleanly.
+    private static func formatRealtimeMultiple(_ rtm: Double) -> String {
+        if rtm >= 10 { return "\(Int(rtm.rounded()))×" }
+        return String(format: "%.1f×", rtm)
+    }
+
     private func statRow(_ label: String, value: String) -> some View {
         HStack {
             Text(label)
             Spacer()
             Text(value).font(.body.monospacedDigit()).foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - SPEC-028 rows + histogram
+
+    /// "Longest dictation  6 min 12 s · processed in 3.4 s · 110× realtime".
+    /// Renders an em-dash when there is no eligible entry. The process-time
+    /// tail is appended only when `processSeconds != nil`, so a mid-transcribe
+    /// or recovery-flow entry still shows its duration honestly.
+    private var longestDictationRow: some View {
+        statRow("Longest dictation", value: longestDictationValue)
+    }
+
+    private var longestDictationValue: String {
+        guard let longest = performance?.longestEntry else { return "—" }
+        var pieces: [String] = [Self.formatLongestDuration(longest.durationSeconds)]
+        if let proc = longest.processSeconds {
+            pieces.append("processed in \(Self.formatProcessSeconds(proc))")
+        }
+        if let rtm = longest.realtimeMultiple {
+            pieces.append("\(Self.formatRealtimeMultiple(rtm)) realtime")
+        }
+        return pieces.joined(separator: " · ")
+    }
+
+    /// "Processing speed  avg 47× realtime". Em-dash when no entries
+    /// have a non-nil RTM yet.
+    private var processingSpeedRow: some View {
+        statRow("Processing speed", value: processingSpeedValue)
+    }
+
+    private var processingSpeedValue: String {
+        guard let avg = performance?.averageRealtimeMultiple else { return "—" }
+        return "avg \(Self.formatRealtimeMultiple(avg)) realtime"
+    }
+
+    private static func totalBucketCount(_ perf: PerformanceSummary) -> Int {
+        perf.bucketCounts.values.reduce(0, +)
+    }
+
+    /// SPEC-028 — bar chart bucketed by `DurationBucket`. A fixed
+    /// `maxBarWidth` (220 pt) avoids `GeometryReader` overhead inside the
+    /// `Form` and keeps the bar lengths visually consistent with the rest
+    /// of the pane. Zero-count rows render a 1pt-floor capsule so the row
+    /// alignment stays stable even when a bucket is empty.
+    private func durationHistogram(_ perf: PerformanceSummary) -> some View {
+        let maxCount = max(1, perf.bucketCounts.values.max() ?? 1)
+        let maxBarWidth: CGFloat = 220
+        return VStack(alignment: .leading, spacing: 6) {
+            ForEach(DurationBucket.allCases, id: \.self) { bucket in
+                let count = perf.bucketCounts[bucket] ?? 0
+                let proportion = CGFloat(count) / CGFloat(maxCount)
+                let width = max(1, maxBarWidth * proportion)
+                HStack(spacing: Theme.s8) {
+                    Text(bucket.rawValue)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(width: 56, alignment: .leading)
+                    Capsule()
+                        .fill(Theme.amber.opacity(0.6))
+                        .frame(width: width, height: 8)
+                    Spacer(minLength: Theme.s8)
+                    Text(count.formatted())
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(minWidth: 28, alignment: .trailing)
+                }
+            }
         }
     }
 

--- a/Sources/OpenQuackKit/History/HistoryEntry+ProcessSeconds.swift
+++ b/Sources/OpenQuackKit/History/HistoryEntry+ProcessSeconds.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// SPEC-028 — per-entry derivations the Stats pane (and any future export
+/// surface) reads to render personal performance numbers. Pure: no IO, no
+/// state — just arithmetic on the three timestamps `HistoryStore` already
+/// records.
+
+extension HistoryEntry {
+    /// Wall-clock seconds from end-of-recording to end-of-transcription.
+    /// Returns nil when the entry is still mid-transcription (no
+    /// `transcribedAt`) or — defensively — when the timestamps imply a
+    /// non-positive elapsed (clock skew, restored-from-backup, the
+    /// recovery flow stamping `transcribedAt` before the recording's
+    /// nominal end). The Stats UI treats nil here as "no row tail."
+    public var processSeconds: TimeInterval? {
+        guard let transcribedAt else { return nil }
+        let recordingEndedAt = recordedAt.addingTimeInterval(durationSeconds)
+        let elapsed = transcribedAt.timeIntervalSince(recordingEndedAt)
+        return elapsed > 0 ? elapsed : nil
+    }
+
+    /// `durationSeconds / processSeconds`. e.g. 300 s of audio processed
+    /// in 3 s → 100. Nil when `processSeconds` is nil or zero.
+    public var realtimeMultiple: Double? {
+        guard let processSeconds, processSeconds > 0 else { return nil }
+        return durationSeconds / processSeconds
+    }
+}

--- a/Sources/OpenQuackKit/Stats/PerformanceSummariser.swift
+++ b/Sources/OpenQuackKit/Stats/PerformanceSummariser.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// SPEC-028 — Personal performance summary derived from `HistoryStore`
+/// entries. Pure: no actor, no IO, recomputed on Settings → Stats open.
+/// The longest dictation, the average realtime multiple, and the length
+/// histogram are the three surfaces that make OpenQuack's long-form +
+/// fast-processing USPs visible as personal numbers, not bench numbers.
+
+/// Duration buckets the long-form claim cares about. RawValues match the
+/// label text rendered in the Stats pane; the boundaries are half-open
+/// `[lower, upper)` so the 30 s / 1 m / 3 m / 10 m cliffs land
+/// unambiguously on the higher bucket.
+public enum DurationBucket: String, CaseIterable, Sendable, Codable {
+    case under30s    = "<30s"
+    case to1min      = "30s–1m"
+    case to3min      = "1–3m"
+    case to10min     = "3–10m"
+    case over10min   = "10m+"
+
+    /// `[lower, upper)` in seconds. `upper == nil` means open-ended.
+    fileprivate var range: (lower: TimeInterval, upper: TimeInterval?) {
+        switch self {
+        case .under30s:  return (0, 30)
+        case .to1min:    return (30, 60)
+        case .to3min:    return (60, 180)
+        case .to10min:   return (180, 600)
+        case .over10min: return (600, nil)
+        }
+    }
+
+    fileprivate static func bucket(forDuration seconds: TimeInterval) -> DurationBucket {
+        // Walk in declared order; first matching range wins. Negatives clamp
+        // into `.under30s` so a malformed entry still buckets somewhere.
+        let d = max(0, seconds)
+        for b in DurationBucket.allCases {
+            let (lo, hi) = b.range
+            if d >= lo, hi == nil || d < hi! { return b }
+        }
+        return .over10min
+    }
+}
+
+/// Aggregate over a history window. Values are `nil` when there is
+/// nothing to summarise (empty window, no transcribed entries).
+public struct PerformanceSummary: Sendable, Codable {
+    /// Entry with the largest `durationSeconds`. Nil iff `entries` was
+    /// empty. The longest entry can still have `processSeconds == nil`
+    /// (mid-transcription / recovery-flow); the UI must guard the tail.
+    public let longestEntry: HistoryEntry?
+    /// Mean of `realtimeMultiple` across entries that have a non-nil
+    /// RTM. Nil when zero entries qualify (every entry untranscribed,
+    /// or empty input).
+    public let averageRealtimeMultiple: Double?
+    /// Counts per bucket; every `DurationBucket` case is present with at
+    /// least a 0 value so the UI can iterate `DurationBucket.allCases`
+    /// without optional dancing.
+    public let bucketCounts: [DurationBucket: Int]
+
+    public init(longestEntry: HistoryEntry?,
+                averageRealtimeMultiple: Double?,
+                bucketCounts: [DurationBucket: Int]) {
+        self.longestEntry = longestEntry
+        self.averageRealtimeMultiple = averageRealtimeMultiple
+        self.bucketCounts = bucketCounts
+    }
+}
+
+/// Pure summariser. Bucketing edges are documented on `DurationBucket`.
+/// Average RTM skips entries with nil RTM (no `transcribedAt` yet,
+/// or zero/negative process time) — only meaningful samples contribute.
+public enum PerformanceSummariser {
+    public static func summarise(_ entries: [HistoryEntry]) -> PerformanceSummary {
+        // Bucket counts — initialise every case to 0 so callers don't
+        // have to handle missing keys.
+        var counts: [DurationBucket: Int] = [:]
+        for b in DurationBucket.allCases { counts[b] = 0 }
+
+        var longest: HistoryEntry?
+        var rtmSum: Double = 0
+        var rtmCount: Int = 0
+
+        for entry in entries {
+            counts[DurationBucket.bucket(forDuration: entry.durationSeconds), default: 0] += 1
+
+            if let current = longest {
+                if entry.durationSeconds > current.durationSeconds {
+                    longest = entry
+                }
+            } else {
+                longest = entry
+            }
+
+            if let rtm = entry.realtimeMultiple {
+                rtmSum += rtm
+                rtmCount += 1
+            }
+        }
+
+        let avgRTM: Double? = rtmCount > 0 ? rtmSum / Double(rtmCount) : nil
+        return PerformanceSummary(longestEntry: longest,
+                                  averageRealtimeMultiple: avgRTM,
+                                  bucketCounts: counts)
+    }
+}

--- a/Tests/OpenQuackKitTests/HistoryEntryProcessSecondsTests.swift
+++ b/Tests/OpenQuackKitTests/HistoryEntryProcessSecondsTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class HistoryEntryProcessSecondsTests: XCTestCase {
+
+    private func makeEntry(durationSeconds: TimeInterval,
+                           transcribedAt: Date?,
+                           recordedAt: Date = Date(timeIntervalSinceReferenceDate: 1_000_000)) -> HistoryEntry {
+        HistoryEntry(id: UUID(),
+                     recordedAt: recordedAt,
+                     transcribedAt: transcribedAt,
+                     durationSeconds: durationSeconds,
+                     transcript: nil,
+                     language: nil,
+                     modelID: nil,
+                     audioURL: nil)
+    }
+
+    // MARK: - processSeconds
+
+    func testProcessSecondsNilWhenTranscribedAtNil() {
+        let entry = makeEntry(durationSeconds: 5, transcribedAt: nil)
+        XCTAssertNil(entry.processSeconds)
+    }
+
+    func testProcessSecondsPositiveCase() throws {
+        let recordedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let duration: TimeInterval = 60
+        // Transcription finishes 3 s after the recording ended.
+        let transcribedAt = recordedAt.addingTimeInterval(duration + 3)
+        let entry = makeEntry(durationSeconds: duration,
+                              transcribedAt: transcribedAt,
+                              recordedAt: recordedAt)
+        let elapsed = try XCTUnwrap(entry.processSeconds)
+        XCTAssertEqual(elapsed, 3, accuracy: 0.001)
+    }
+
+    func testProcessSecondsNilWhenTranscribedAtBeforeRecordingEnd() {
+        // Defensive: clock-skew / recovery-flow can stamp transcribedAt
+        // earlier than recordedAt + durationSeconds. The guard returns nil
+        // rather than a negative elapsed.
+        let recordedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let duration: TimeInterval = 60
+        let transcribedAt = recordedAt.addingTimeInterval(duration - 1)
+        let entry = makeEntry(durationSeconds: duration,
+                              transcribedAt: transcribedAt,
+                              recordedAt: recordedAt)
+        XCTAssertNil(entry.processSeconds)
+    }
+
+    func testProcessSecondsNilWhenTranscribedAtExactlyAtRecordingEnd() {
+        // elapsed == 0 isn't a meaningful "processed in 0 s" claim; treat
+        // as nil so the UI hides the tail rather than show 0.0 s.
+        let recordedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let duration: TimeInterval = 5
+        let transcribedAt = recordedAt.addingTimeInterval(duration)
+        let entry = makeEntry(durationSeconds: duration,
+                              transcribedAt: transcribedAt,
+                              recordedAt: recordedAt)
+        XCTAssertNil(entry.processSeconds)
+    }
+
+    // MARK: - realtimeMultiple
+
+    func testRealtimeMultipleNilWhenProcessSecondsNil() {
+        let entry = makeEntry(durationSeconds: 100, transcribedAt: nil)
+        XCTAssertNil(entry.realtimeMultiple)
+    }
+
+    func testRealtimeMultiplePositiveCase() throws {
+        let recordedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let duration: TimeInterval = 300            // 5 min audio
+        let processSecs: TimeInterval = 3
+        let transcribedAt = recordedAt.addingTimeInterval(duration + processSecs)
+        let entry = makeEntry(durationSeconds: duration,
+                              transcribedAt: transcribedAt,
+                              recordedAt: recordedAt)
+        let rtm = try XCTUnwrap(entry.realtimeMultiple)
+        XCTAssertEqual(rtm, 100, accuracy: 0.001)
+    }
+}

--- a/Tests/OpenQuackKitTests/PerformanceSummariserTests.swift
+++ b/Tests/OpenQuackKitTests/PerformanceSummariserTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class PerformanceSummariserTests: XCTestCase {
+
+    private func makeEntry(durationSeconds: TimeInterval,
+                           transcribedAt: Date? = nil,
+                           recordedAt: Date = Date(timeIntervalSinceReferenceDate: 1_000_000)) -> HistoryEntry {
+        HistoryEntry(id: UUID(),
+                     recordedAt: recordedAt,
+                     transcribedAt: transcribedAt,
+                     durationSeconds: durationSeconds,
+                     transcript: nil,
+                     language: nil,
+                     modelID: nil,
+                     audioURL: nil)
+    }
+
+    /// Build a transcribed entry whose `realtimeMultiple` equals the
+    /// requested multiple — caller controls duration; `processSeconds`
+    /// is derived as `duration / rtm`.
+    private func makeTranscribedEntry(durationSeconds: TimeInterval,
+                                      realtimeMultiple rtm: Double) -> HistoryEntry {
+        let recordedAt = Date(timeIntervalSinceReferenceDate: 0)
+        let processSecs = durationSeconds / rtm
+        let transcribedAt = recordedAt.addingTimeInterval(durationSeconds + processSecs)
+        return makeEntry(durationSeconds: durationSeconds,
+                         transcribedAt: transcribedAt,
+                         recordedAt: recordedAt)
+    }
+
+    // MARK: - empty / single
+
+    func testSummariseEmpty() {
+        let summary = PerformanceSummariser.summarise([])
+        XCTAssertNil(summary.longestEntry)
+        XCTAssertNil(summary.averageRealtimeMultiple)
+        // Every bucket present, all zero.
+        for b in DurationBucket.allCases {
+            XCTAssertEqual(summary.bucketCounts[b], 0, "\(b) expected 0")
+        }
+    }
+
+    func testSummariseSingleEntry() throws {
+        let e = makeTranscribedEntry(durationSeconds: 45, realtimeMultiple: 10)
+        let summary = PerformanceSummariser.summarise([e])
+        XCTAssertEqual(summary.longestEntry?.id, e.id)
+        let avg = try XCTUnwrap(summary.averageRealtimeMultiple)
+        XCTAssertEqual(avg, 10, accuracy: 0.001)
+        XCTAssertEqual(summary.bucketCounts[.to1min], 1)
+        XCTAssertEqual(summary.bucketCounts[.under30s], 0)
+    }
+
+    // MARK: - bucket edges
+
+    /// Each (duration, expected) probes a half-open boundary. 30.0 must
+    /// fall into `30s–1m`, 29.999 into `<30s`, etc.
+    func testBucketEdges_under30s_30s_30s001() {
+        XCTAssertEqual(bucket(for: 0),       .under30s)
+        XCTAssertEqual(bucket(for: 29.999),  .under30s)
+        XCTAssertEqual(bucket(for: 30.0),    .to1min)
+        XCTAssertEqual(bucket(for: 30.001),  .to1min)
+    }
+
+    func testBucketEdges_1m() {
+        XCTAssertEqual(bucket(for: 59.999),  .to1min)
+        XCTAssertEqual(bucket(for: 60.0),    .to3min)
+        XCTAssertEqual(bucket(for: 60.001),  .to3min)
+    }
+
+    func testBucketEdges_3m() {
+        XCTAssertEqual(bucket(for: 179.999), .to3min)
+        XCTAssertEqual(bucket(for: 180.0),   .to10min)
+        XCTAssertEqual(bucket(for: 180.001), .to10min)
+    }
+
+    func testBucketEdges_10m() {
+        XCTAssertEqual(bucket(for: 599.999), .to10min)
+        XCTAssertEqual(bucket(for: 600.0),   .over10min)
+        XCTAssertEqual(bucket(for: 600.001), .over10min)
+        XCTAssertEqual(bucket(for: 9_999),   .over10min)
+    }
+
+    private func bucket(for duration: TimeInterval) -> DurationBucket {
+        let summary = PerformanceSummariser.summarise([makeEntry(durationSeconds: duration)])
+        // Find the single bucket with a non-zero count.
+        let hit = summary.bucketCounts.first { $0.value == 1 }
+        return hit?.key ?? .under30s
+    }
+
+    // MARK: - longest
+
+    func testLongestEntryAcrossMultiple() {
+        let a = makeEntry(durationSeconds: 10)
+        let b = makeEntry(durationSeconds: 500)
+        let c = makeEntry(durationSeconds: 120)
+        let summary = PerformanceSummariser.summarise([a, b, c])
+        XCTAssertEqual(summary.longestEntry?.id, b.id)
+    }
+
+    func testLongestEntryIncludesUntranscribed() {
+        // Untranscribed entry is still eligible — UI must guard the
+        // process-time tail, not the summariser.
+        let mid = makeTranscribedEntry(durationSeconds: 60, realtimeMultiple: 20)
+        let longUntranscribed = makeEntry(durationSeconds: 800, transcribedAt: nil)
+        let summary = PerformanceSummariser.summarise([mid, longUntranscribed])
+        XCTAssertEqual(summary.longestEntry?.id, longUntranscribed.id)
+        XCTAssertNil(summary.longestEntry?.realtimeMultiple)
+    }
+
+    // MARK: - average RTM
+
+    func testAverageRealtimeMultipleSkipsNilRTM() throws {
+        let transcribed = makeTranscribedEntry(durationSeconds: 60, realtimeMultiple: 20)
+        let stillRecording = makeEntry(durationSeconds: 30, transcribedAt: nil)
+        let alsoTranscribed = makeTranscribedEntry(durationSeconds: 120, realtimeMultiple: 40)
+
+        let summary = PerformanceSummariser.summarise([transcribed, stillRecording, alsoTranscribed])
+        let avg = try XCTUnwrap(summary.averageRealtimeMultiple)
+        XCTAssertEqual(avg, 30, accuracy: 0.001)  // (20 + 40) / 2
+    }
+
+    func testAverageRealtimeMultipleNilWhenZeroQualifyingEntries() {
+        let stillRecording = makeEntry(durationSeconds: 30, transcribedAt: nil)
+        let summary = PerformanceSummariser.summarise([stillRecording])
+        XCTAssertNil(summary.averageRealtimeMultiple)
+    }
+}


### PR DESCRIPTION
## SPEC

SPEC-028 — Dictation distribution + personal performance stats.

## Milestone

M3 (Adoption focus).

## Why

OpenQuack's two load-bearing USPs are long-form dictation support and fast post-stop processing (a 5-min clip → 2.8 s after stop = ~12× streaming win). The Stats pane never surfaces those USPs as **personal** numbers. After this PR, Settings → Stats shows the user's longest dictation with its process time + realtime multiple, their average processing speed across history, and a 5-bucket length distribution — three artifacts that prove the headline claims for their own workflow.

## Change

- `Sources/OpenQuackKit/History/HistoryEntry+ProcessSeconds.swift` — new public extension. `processSeconds: TimeInterval?` and `realtimeMultiple: Double?`, with the `transcribedAt > recordedAt + durationSeconds` guard.
- `Sources/OpenQuackKit/Stats/PerformanceSummariser.swift` — new pure summariser. `DurationBucket` enum (rawValues match the spec strings), `PerformanceSummary` (`longestEntry`, `averageRealtimeMultiple`, `bucketCounts`), `PerformanceSummariser.summarise(_:)`.
- `Sources/OpenQuackApp/SettingsView.swift` — Stats pane queries `HistoryStore.list(limit:50)` on `.task { … }` and on `showUsageStats` toggle, recomputes the summary in-process, renders two new rows between **Audio processed** and **Time saved vs. typing** plus the "Sessions by length" histogram below the existing block.
- Tests: `HistoryEntryProcessSecondsTests` (6 cases — nil paths, positive, ≤ recording-end guard) + `PerformanceSummariserTests` (10 cases — empty, single, all four bucket edges, longest-across-entries incl. untranscribed, RTM mean skipping nil).

Histogram is a `VStack` of `HStack` rows: bucket label (fixed width) · `Capsule().fill(Theme.amber.opacity(0.6))` sized proportional to `count / max(1, maxCount)` against a fixed `maxBarWidth = 220` · monospaced count. Zero-count rows render with a 1pt-floor bar so alignment stays stable. No new theme tokens, no chart library, no animations.

## Tests

- [x] unit tests added: `HistoryEntryProcessSecondsTests` (6), `PerformanceSummariserTests` (10)
- [x] `swift build && swift test` green via `DEVELOPER_DIR` override

## Privacy impact

No new persistence, no new network IO, no new disclosure surface. All inputs come from `HistoryStore` (already retention-capped at 50 entries default per SPEC-014) and `UserDefaults`-backed `UsageStats`. Display is gated by the existing `showUsageStats` toggle. Same privacy contract as SPEC-013.

## Out of scope

- Per-app or per-language slicing — flagged in the spec as a follow-up.
- Time-series chart (sessions per day) — distribution histogram only here.
- Persisting `PerformanceSummary` — recompute on Settings open.
- Export-v2 (distribution JSON export) — future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)