### PR TITLE
fix(scripts): wrap_app.sh — bundle Sparkle.framework + drop invalid SUPublicEDKey placeholder

### DIFF
--- a/scripts/wrap_app.sh
+++ b/scripts/wrap_app.sh
@@ -128,7 +128,16 @@ cat > "$BUNDLE/Contents/Info.plist" <<PLIST
     <key>SUEnableAutomaticChecks</key>       <true/>
     <key>SUScheduledCheckInterval</key>      <integer>86400</integer>
     <key>SUAutomaticallyUpdate</key>         <false/>
-    <key>SUPublicEDKey</key>                 <string>PLACEHOLDER_EDDSA_PUBLIC_KEY_BASE64_REPLACE_ME</string>
+    <!-- SUPublicEDKey: REQUIRED for PR-C to enable real update install.
+         Run \`generate_keys\` (Sparkle-bundled), commit the public half
+         back here as <key>SUPublicEDKey</key><string>...44-char base64...</string>;
+         the private half stays in the maintainer's Keychain + a GH
+         Actions secret. Intentionally omitted (rather than a
+         "PLACEHOLDER_..." string) until PR-C lands — Sparkle starts
+         cleanly without it and refuses to install any update, matching
+         the "by design" intent. The previous placeholder string was
+         invalid base64, which made Sparkle bail at startup with
+         "Updater Failed to Start". -->
 </dict>
 </plist>
 PLIST

--- a/scripts/wrap_app.sh
+++ b/scripts/wrap_app.sh
@@ -71,6 +71,26 @@ for bundle in "$BIN_DIR"/*.bundle; do
     cp -R "$bundle" "$BUNDLE/Contents/Resources/"
 done
 
+# Copy SwiftPM-resolved frameworks (e.g. Sparkle.framework, a
+# .binaryTarget xcframework that lands in the release/ dir alongside the
+# binary). They link against `@rpath/<Framework>.framework/...`; the
+# binary's default rpath set by SwiftPM (`@loader_path`) finds them in
+# the release/ dir but breaks once we move the binary into
+# `Contents/MacOS/`. So: copy the framework AND patch the binary's rpath
+# to look in `../Frameworks/`.
+for fw in "$BIN_DIR"/*.framework; do
+    [[ -d "$fw" ]] || continue
+    mkdir -p "$BUNDLE/Contents/Frameworks"
+    cp -R "$fw" "$BUNDLE/Contents/Frameworks/"
+done
+if [[ -d "$BUNDLE/Contents/Frameworks" ]]; then
+    # `|| true` because install_name_tool errors out on repeat invocations
+    # (re-adding an existing rpath). The bundle is rm -rf'd above so this
+    # is the first add, but be defensive against future refactors.
+    install_name_tool -add_rpath @executable_path/../Frameworks \
+        "$BUNDLE/Contents/MacOS/openquack" 2>/dev/null || true
+fi
+
 cat > "$BUNDLE/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
## SPEC

SPEC-026 — Sparkle auto-update (post-PR-A maintenance)

### Why

Two bugs in `scripts/wrap_app.sh` introduced by PR-A (#40) make `v2.0.0-alpha.11` and `v2.0.0-alpha.12` DMGs unusable. Full repro + analysis in #48.

Closes #48.

### Change

- **Commit 1**: copy `*.framework` from the SwiftPM release bin dir into `Contents/Frameworks/`, and `install_name_tool -add_rpath @executable_path/../Frameworks` on the binary so dyld finds it at runtime.
- **Commit 2**: omit `SUPublicEDKey` from the generated `Info.plist` until PR-C lands a real EdDSA pubkey (replaced with an in-place comment).

### Tests

- [x] `xcrun swift build` + `xcrun swift test` green (script-only change; no source touched)
- [x] Manual: `./scripts/wrap_app.sh && open build/OpenQuack.app` launches without dyld crash and without "Updater Failed to Start"
- [x] `plutil -lint build/OpenQuack.app/Contents/Info.plist` — OK
- [x] `ls build/OpenQuack.app/Contents/Frameworks/` shows `Sparkle.framework`; `otool -l ... | grep RPATH` shows `@executable_path/../Frameworks`

No bench delta.

### Out of scope

- **PR-C's real EdDSA key** — still TBD per SPEC-026 timeline
- **CI smoke test** that launches the bundled `.app` post-build — would have caught both bugs; worth a follow-up

---

## AI coding brief

**Original request:** during PR-B (#47, Settings → Updates pane) manual verification, the dev `wrap_app.sh` output crashed at launch. Root cause was in `wrap_app.sh` itself, not PR-B. After confirming the bug reproduced on the published DMG too, split off as a separate fix.

**Manual interventions:** confirmed the dyld crash by running the binary directly — `open` swallows stderr, so the crash looked silent at first. The second bug (`SUPublicEDKey` placeholder) only surfaced after the framework fix made Sparkle actually start; its fatal error had been hidden behind the earlier dyld crash. Multiple bugs can stack on a single broken pipeline — keep peeling.

**Retro:** publishing a release without launching the resulting `.app` once at the end of the pipeline is the gap. A 30-second smoke test in the release workflow (`open build/OpenQuack.app && sleep 5 && kill`) would have caught both of these before they shipped.
