### PR TITLE
feat(SPEC-026): PR-B Settings → Updates pane (brew-aware Sparkle controls)

### DIFF
--- a/Sources/OpenQuackApp/AppDelegate+Sparkle.swift
+++ b/Sources/OpenQuackApp/AppDelegate+Sparkle.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Sparkle
+import OpenQuackKit
+
+// MARK: - SPEC-026 PR-B — Sparkle channel selection via delegate
+
+extension AppDelegate: SPUUpdaterDelegate {
+    /// Called by Sparkle on every update check. Returns the appcast URL
+    /// for the user's currently selected channel.
+    ///
+    /// Implemented via the delegate callback (rather than mutating
+    /// `SPUUpdater.feedURL` directly) because `SPUUpdater.feedURL` is
+    /// read-only in Sparkle 2.x and `-setFeedURL:` is deprecated in
+    /// favor of this callback. See `SPUUpdater.h:278-299`.
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        let channel: UpdateChannel =
+            UserDefaults.standard.bool(forKey: "receivePrereleases")
+                ? .alpha
+                : .stable
+        return chooseAppcastURL(channel: channel).absoluteString
+    }
+}

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -94,7 +94,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// handle. NOTE: SUPublicEDKey in the bundled Info.plist is still a
     /// placeholder; until the user runs `generate_keys` and swaps it,
     /// Sparkle will refuse to install any downloaded update.
-    private var sparkleUpdater: SPUStandardUpdaterController?
+    var sparkleUpdater: SPUStandardUpdaterController?
 
     /// SPEC-023 — set true when reconcile returns `.resetToggleOff` (user
     /// revoked us in System Settings → Login Items while we weren't
@@ -131,6 +131,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
         appState.installMethod = InstallMethodDetector.detect()
         installSparkleUpdater()
+        // SPEC-026 PR-B — seed the prerelease default once. The
+        // delegate's `feedURLString(for:)` reads this key on every
+        // check, so no explicit `feedURL` set is needed at launch.
+        let persistedPrereleases = UserDefaults.standard.object(forKey: "receivePrereleases") as? Bool
+        UserDefaults.standard.set(
+            defaultReceivePrereleases(version: OpenQuackKit.version, persistedValue: persistedPrereleases),
+            forKey: "receivePrereleases"
+        )
         installStatusItem()
         installPopover()
         installHotkey()
@@ -281,7 +289,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func installSparkleUpdater() {
         let controller = SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: self,
             userDriverDelegate: nil
         )
         switch appState.installMethod {

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -20,7 +20,7 @@ struct SettingsView: View {
 
     var body: some View {
         TabView(selection: $selection) {
-            GeneralPane()
+            GeneralPane(appState: appState)
                 .tabItem { Label("General", systemImage: "gearshape") }
                 .tag(Tab.general)
             ShortcutPane()
@@ -43,6 +43,7 @@ struct SettingsView: View {
 // MARK: - General
 
 private struct GeneralPane: View {
+    @ObservedObject var appState: AppState
     @AppStorage("autoPaste")           private var autoPaste: Bool = true
     @AppStorage("polishText")          private var polishText: Bool = true
     @AppStorage("language")            private var language: String = "en"
@@ -53,6 +54,20 @@ private struct GeneralPane: View {
     @AppStorage("customWords")         private var customWords: String = ""
     @AppStorage("model")               private var model: String = "medium"
     @AppStorage("launchAtLogin")       private var launchAtLogin: Bool = false
+
+    // SPEC-026 PR-B — Updates section state.
+    @AppStorage("receivePrereleases") private var receivePrereleases: Bool = false
+    /// Mirror of `SPUUpdater.automaticallyChecksForUpdates`. Sparkle is
+    /// the source of truth (it persists to UserDefaults `SUEnableAutomaticChecks`);
+    /// the mirror seeds `.onAppear` and writes back through the public
+    /// setter on `.onChange` so Sparkle's internal `resetUpdateCycle`
+    /// fires. A direct `@AppStorage` on `SUEnableAutomaticChecks` would
+    /// bypass that setter.
+    @State private var sparkleAutoChecks: Bool = false
+    /// Snapshot of `SPUUpdater.lastUpdateCheckDate`, refreshed `.onAppear`
+    /// and 1.5 s after a Check-now tap. `nil` means "never checked";
+    /// the "Last checked" line is suppressed in that case.
+    @State private var lastChecked: Date?
 
     // SPEC-023 — session-only hint, seeded from AppDelegate so reconcile
     // results from app launch propagate the first time Settings opens.
@@ -171,6 +186,37 @@ private struct GeneralPane: View {
             } header: {
                 SectionHeader("Startup")
             }
+
+            // SPEC-026 PR-B — Updates (Sparkle controls; brew-aware).
+            //
+            // brew install: every Sparkle-side control is functionally a
+            // no-op. Surface that honestly with a single line telling
+            // brew users exactly how to update, with the command typeset
+            // monospaced.
+            Section {
+                if appState.installMethod.isBrew {
+                    Text(brewUpdateInstructions)
+                        .font(.callout)
+                } else {
+                    Toggle("Check for updates automatically", isOn: $sparkleAutoChecks)
+                        .help("Let OpenQuack check for new versions in the background.")
+
+                    if let date = lastChecked {
+                        Text("Last checked: \(date.formatted(.relative(presentation: .named)))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Toggle("Include pre-release builds (alpha/beta)", isOn: $receivePrereleases)
+                        .help("Receive alpha and beta builds in addition to stable releases. Useful if you want fixes before they reach the stable channel.")
+
+                    Button("Check now") {
+                        handleCheckNowTap()
+                    }
+                }
+            } header: {
+                SectionHeader("Updates")
+            }
         }
         .formStyle(.grouped)
         .padding()
@@ -182,9 +228,60 @@ private struct GeneralPane: View {
                delegate.showsLaunchAtLoginApprovalHint {
                 showsApprovalHint = true
             }
+            // SPEC-026 PR-B — seed Sparkle state mirrors.
+            if let updater = (NSApp.delegate as? AppDelegate)?.sparkleUpdater?.updater {
+                sparkleAutoChecks = updater.automaticallyChecksForUpdates
+                lastChecked = updater.lastUpdateCheckDate
+            }
         }
         .onChange(of: launchAtLogin) { newValue in
             handleLaunchAtLoginChange(newValue)
+        }
+        // SPEC-026 PR-B — write the auto-check toggle through Sparkle's
+        // setter so `resetUpdateCycle` fires.
+        .onChange(of: sparkleAutoChecks) { newValue in
+            (NSApp.delegate as? AppDelegate)?.sparkleUpdater?.updater
+                .automaticallyChecksForUpdates = newValue
+        }
+        // SPEC-026 PR-B — flipping the prerelease toggle re-runs a check
+        // immediately so the user sees the result of the new channel
+        // without waiting for the next scheduled one. `@AppStorage`
+        // already persisted the value; the delegate's `feedURLString(for:)`
+        // reads it on the next check and routes to the right appcast.
+        // Goes through `handleCheckNowTap()` (same path as the "Check now"
+        // button) so "Last checked" stays in sync.
+        .onChange(of: receivePrereleases) { _ in
+            handleCheckNowTap()
+        }
+    }
+
+    /// SPEC-026 PR-B — brew-mode hint with the upgrade command typeset
+    /// as monospaced primary text inline.
+    private var brewUpdateInstructions: AttributedString {
+        var s = AttributedString()
+        var prefix = AttributedString("OpenQuack is managed by Homebrew on this Mac. Run ")
+        prefix.foregroundColor = .secondary
+        s += prefix
+        var cmd = AttributedString("brew upgrade --cask openquack")
+        cmd.font = .system(.body, design: .monospaced)
+        cmd.foregroundColor = .primary
+        s += cmd
+        var suffix = AttributedString(" to update.")
+        suffix.foregroundColor = .secondary
+        s += suffix
+        return s
+    }
+
+    /// SPEC-026 PR-B — `Check now` button action. Triggers Sparkle's
+    /// own check + dialog flow; we re-snapshot `lastUpdateCheckDate`
+    /// after a short delay because the check is async.
+    @MainActor
+    private func handleCheckNowTap() {
+        guard let controller = (NSApp.delegate as? AppDelegate)?.sparkleUpdater else { return }
+        controller.checkForUpdates(nil)
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 s
+            lastChecked = controller.updater.lastUpdateCheckDate
         }
     }
 

--- a/Sources/OpenQuackKit/Updates/UpdateChannel.swift
+++ b/Sources/OpenQuackKit/Updates/UpdateChannel.swift
@@ -34,3 +34,21 @@ public func chooseAppcastURL(channel: UpdateChannel) -> URL {
     }
     return URL(string: "\(base)/\(filename)")!
 }
+
+/// SPEC-026 PR-B — Seed default for the `receivePrereleases` toggle on
+/// first launch. ON if the binary is itself a pre-release build (a
+/// `-alpha` or `-beta` tag in the version string); OFF otherwise.
+/// One-shot: once UserDefaults has a value, the user's persisted choice
+/// wins.
+///
+/// `persistedValue` is the current `receivePrereleases` UserDefaults
+/// value, or `nil` if the key has never been written. Passed in
+/// explicitly rather than read inside the function so callers can unit-
+/// test without touching `UserDefaults.standard` global state.
+public func defaultReceivePrereleases(
+    version: String,
+    persistedValue: Bool?
+) -> Bool {
+    if let persisted = persistedValue { return persisted }
+    return version.contains("-alpha") || version.contains("-beta")
+}

--- a/Tests/OpenQuackKitTests/UpdateChannelTests.swift
+++ b/Tests/OpenQuackKitTests/UpdateChannelTests.swift
@@ -37,4 +37,40 @@ final class UpdateChannelTests: XCTestCase {
             XCTAssertEqual(url.host, "larryxiao.github.io", "\(channel)")
         }
     }
+
+    // MARK: - defaultReceivePrereleases (SPEC-026 PR-B)
+
+    func testDefaultReceivePrereleases_alphaBuild_unset_isTrue() {
+        XCTAssertTrue(
+            defaultReceivePrereleases(version: "2.0.0-alpha.12", persistedValue: nil)
+        )
+    }
+
+    func testDefaultReceivePrereleases_betaBuild_unset_isTrue() {
+        XCTAssertTrue(
+            defaultReceivePrereleases(version: "2.0.0-beta.1", persistedValue: nil)
+        )
+    }
+
+    func testDefaultReceivePrereleases_stableBuild_unset_isFalse() {
+        XCTAssertFalse(
+            defaultReceivePrereleases(version: "2.0.0", persistedValue: nil)
+        )
+    }
+
+    /// Persisted choice MUST win over the alpha-build default, otherwise
+    /// users who opted out on an alpha would silently get re-opted-in.
+    func testDefaultReceivePrereleases_alphaBuild_userOptedOut_isFalse() {
+        XCTAssertFalse(
+            defaultReceivePrereleases(version: "2.0.0-alpha.12", persistedValue: false)
+        )
+    }
+
+    /// Persisted choice MUST win over the stable-build default, otherwise
+    /// users who opted in on a stable build would silently get reverted.
+    func testDefaultReceivePrereleases_stableBuild_userOptedIn_isTrue() {
+        XCTAssertTrue(
+            defaultReceivePrereleases(version: "2.0.0", persistedValue: true)
+        )
+    }
 }


### PR DESCRIPTION
## SPEC

SPEC-026 — PR-B (Settings → Updates pane)

## Milestone

M2 (Adoption focus)

### Why

Wires the Sparkle controls PR-A (#40) added into a user-facing Settings section. Closes #47.

**Recommended merge order: #49 first.** PR-B's code compiles + tests cleanly on its own, but the `.app` that ships from `wrap_app.sh` currently can't launch (separate bugs in #48, fix in #49). Merging this PR without #49 means users see a Settings section in a binary they can't open.

### Change

New `Settings → General → "Updates"` section after "Startup":

- **DMG-install users (`.manual`)**: "Check for updates automatically" toggle, "Last checked: …" line, "Include pre-release builds (alpha/beta)" toggle, "Check now" button.

<img width="1160" height="1056" alt="image" src="https://github.com/user-attachments/assets/94c420ed-96c7-490f-b91a-90ec21b096c2" />


- **Homebrew users (`.homebrew`)**: a single line — "OpenQuack is managed by Homebrew on this Mac. Run `brew upgrade --cask openquack` to update." — with the command typeset in monospaced primary text. All three Sparkle-side controls hidden because they're functionally inert under brew: auto-check force-OFF by the brew-cask coexistence rule (PR-A); "Check now" triggers a Sparkle flow whose result isn't actionable (brew users can't install through Sparkle); pre-release preference is unobservable until the user switches install method.

<img width="1160" height="1056" alt="image" src="https://github.com/user-attachments/assets/bce1f63a-b14f-40f9-b66c-6c2cf1f60480" />

Two intentional deviations from SPEC-026 §"Settings UI", both producing the same observable behaviour:

1. **`SPUUpdaterDelegate.feedURLString(for:)` instead of `updater.feedURL = …`.** `SPUUpdater.feedURL` is read-only in Sparkle 2.x and `-setFeedURL:` is deprecated (`SPUUpdater.h:278-299`); the delegate callback is the documented replacement. Our impl reads `@AppStorage("receivePrereleases")` and routes via `chooseAppcastURL(channel:)`. Lives in `Sources/OpenQuackApp/AppDelegate+Sparkle.swift` — mirrors the existing `HistoryEntry+ProcessSeconds.swift` extension-by-file convention.

2. **`@State` mirror for the auto-check toggle instead of `@AppStorage("SUEnableAutomaticChecks")`.** A direct `@AppStorage` on Sparkle's internal UserDefaults key would bypass `SPUUpdater`'s setter and skip its internal `resetUpdateCycle` reschedule. The mirror pattern reads on `.onAppear` and writes through the public setter on `.onChange`.

Both kept narrow — they don't change the SPEC's user-facing contract, only how it's wired internally.

### Tests

- [x] Unit tests added: `OpenQuackKitTests.UpdateChannelTests` — 5 cases for `defaultReceivePrereleases(version:persistedValue:)` (alpha+unset / beta+unset / stable+unset / alpha+opted-out / stable+opted-in)
- [x] `swift build && swift test` green — 95 tests (was 90)
- [x] Manual on `.manual` install: Updates section renders correctly; "Check now" triggers Sparkle dialog; flipping pre-release re-triggers a check; Sparkle log confirms `appcast-alpha.xml` vs `appcast.xml` URL switch
- [x] Manual on `.homebrew` install: brew caption visible, three Sparkle controls hidden, command typeset monospaced
- [ ] End-to-end install flow (download → verify → relaunch): out of scope; PR-C territory

No bench delta — UI + delegate plumbing only.

### Privacy impact

None. The Sparkle appcast fetch already exists (PR-A); this PR just lets the user toggle whether to receive prereleases. No new audio capture, no new network endpoints, no telemetry.

### Out of scope

- **PR-A's plumbing** — already shipped in #40
- **PR-C** (release pipeline: `sign_update`, real EdDSA pubkey, signed appcast items)
- **Replacing the popover banner CTA** — banner stays per SPEC-026 §"Goal" #4
- **Localised strings** — SPEC-019 track

---

## AI coding brief

**Original request:** roadmap triage → claimed SPEC-026 PR-B as the next adoption-focused S-effort task after PR-A merged. Why: the auto-update plumbing was wired but had no UI surface, so users couldn't opt into prereleases or trigger checks manually.

**Manual interventions:**

- SPEC's prescription (`updater.feedURL = chooseAppcastURL(...)`) uses Sparkle 2.x's deprecated `setFeedURL:`. Switched to `feedURLStringForUpdater:` delegate (Sparkle's documented replacement) without changing user-facing behaviour.
- Originally kept the pre-release toggle visible-but-active in brew mode "in case the user later switches install method". First-hand UX testing convinced me that's a weak justification — users almost never switch and the toggle was a trap. Refactored to hide all three controls under brew, leaving only the `brew upgrade --cask openquack` hint typeset as a command.
- During manual verification of PR-B, the dev `.app` crashed on launch. Root cause unrelated to PR-B — a pair of bugs in `wrap_app.sh` from PR-A. Filed as #48 with a fix in #49. PR-B's UI can't be tested end-to-end until that merges; flagged as recommended merge order above.
- Caught an inconsistency where the prerelease toggle's `onChange` called `checkForUpdates(nil)` inline but didn't refresh `lastChecked`, while the "Check now" button did. Routed both call sites through a shared `handleCheckNowTap()` helper.

**Retro:** SPEC-vs-actual-Sparkle-API gaps were the biggest time cost. SPEC-026 was written assuming `updater.feedURL` is writable and that `SUPublicEDKey` validation happens at install time (not init); both wrong, both surfaced only at runtime. When a SPEC names specific third-party API calls, treat those as claims to verify against current docs / headers before implementation, not facts.
