### PR TITLE
fix: load Whisper offline when boot autostart beats WiFi

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -959,6 +959,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Task.detached(priority: .background) {
                 _ = WhisperKitEngine.cleanupOtherModels(keeping: active)
             }
+            Task.detached(priority: .background) {
+                await WhisperKitEngine.refreshModelInBackground(model: active)
+            }
         } catch {
             await MainActor.run {
                 appState.phase = .error("Failed to load Whisper: \(error)")

--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import OpenQuackPlatform
 import WhisperKit
 
 public final class WhisperKitEngine: TranscriptionEngine {
@@ -49,10 +50,23 @@ public final class WhisperKitEngine: TranscriptionEngine {
         // into the new location.
         Self.migrateLegacyDocumentsCache(into: cacheDir)
 
+        // Passing modelFolder + tokenizerFolder when the cache is complete
+        // makes upstream skip its mandatory HuggingFace manifest call,
+        // which fails when the app autostarts before WiFi is up.
+        let hasLocalCache = Self.hasCompleteLocalCache(for: model, downloadBase: cacheDir)
+        let modelFolderArg: String? = hasLocalCache
+            ? Self.localModelFolder(for: model, downloadBase: cacheDir).path
+            : nil
+        let tokenizerFolderArg: URL? = hasLocalCache
+            ? Self.localTokenizerFolder(for: model, downloadBase: cacheDir)
+            : nil
+
         do {
             let config = WhisperKitConfig(
                 model: model,
                 downloadBase: cacheDir,
+                modelFolder: modelFolderArg,
+                tokenizerFolder: tokenizerFolderArg,
                 verbose: false,
                 logLevel: .error,
                 load: true
@@ -61,6 +75,43 @@ public final class WhisperKitEngine: TranscriptionEngine {
         } catch {
             throw EngineError.loadFailed("\(error)")
         }
+    }
+
+    static func localModelFolder(for variant: String, downloadBase: URL? = nil) -> URL {
+        (downloadBase ?? defaultDownloadBase())
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("argmaxinc", isDirectory: true)
+            .appendingPathComponent("whisperkit-coreml", isDirectory: true)
+            .appendingPathComponent("openai_whisper-\(variant)", isDirectory: true)
+    }
+
+    static func localTokenizerFolder(for variant: String, downloadBase: URL? = nil) -> URL {
+        (downloadBase ?? defaultDownloadBase())
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("openai", isDirectory: true)
+            .appendingPathComponent("whisper-\(variant)", isDirectory: true)
+    }
+
+    static func hasCompleteLocalCache(for variant: String, downloadBase: URL? = nil) -> Bool {
+        let fm = FileManager.default
+        let modelFolder = localModelFolder(for: variant, downloadBase: downloadBase)
+        let required = ["AudioEncoder.mlmodelc", "MelSpectrogram.mlmodelc", "TextDecoder.mlmodelc"]
+        let modelsPresent = required.allSatisfy {
+            fm.fileExists(atPath: modelFolder.appendingPathComponent($0).path)
+        }
+        let tokenizer = localTokenizerFolder(for: variant, downloadBase: downloadBase)
+            .appendingPathComponent("tokenizer.json")
+        return modelsPresent && fm.fileExists(atPath: tokenizer.path)
+    }
+
+    public static func refreshModelInBackground(model: String, downloadBase: URL? = nil) async {
+        await NetworkReachability.waitForSatisfied(timeoutSeconds: 300)
+        let cacheDir = downloadBase ?? defaultDownloadBase()
+        _ = try? await WhisperKit.download(
+            variant: model,
+            downloadBase: cacheDir,
+            progressCallback: { _ in }
+        )
     }
 
     /// `~/Library/Application Support/OpenQuack/WhisperKit/`. App-private; no
@@ -196,11 +247,9 @@ public final class WhisperKitEngine: TranscriptionEngine {
         var freed: Int64 = 0
 
         // CoreML weights — argmaxinc/whisperkit-coreml/openai_whisper-<size>.
-        let weightsRoot = cacheDir
-            .appendingPathComponent("models", isDirectory: true)
-            .appendingPathComponent("argmaxinc", isDirectory: true)
-            .appendingPathComponent("whisperkit-coreml", isDirectory: true)
-        let weightsKeep = "openai_whisper-\(keeping)"
+        let keptWeights = localModelFolder(for: keeping, downloadBase: cacheDir)
+        let weightsRoot = keptWeights.deletingLastPathComponent()
+        let weightsKeep = keptWeights.lastPathComponent
         if let entries = try? fm.contentsOfDirectory(atPath: weightsRoot.path) {
             for entry in entries where entry != weightsKeep && !entry.hasPrefix(".") {
                 let url = weightsRoot.appendingPathComponent(entry)
@@ -210,10 +259,9 @@ public final class WhisperKitEngine: TranscriptionEngine {
         }
 
         // Tokenizer/config — openai/whisper-<size> (a few MB each).
-        let tokenizerRoot = cacheDir
-            .appendingPathComponent("models", isDirectory: true)
-            .appendingPathComponent("openai", isDirectory: true)
-        let tokenizerKeep = "whisper-\(keeping)"
+        let keptTokenizer = localTokenizerFolder(for: keeping, downloadBase: cacheDir)
+        let tokenizerRoot = keptTokenizer.deletingLastPathComponent()
+        let tokenizerKeep = keptTokenizer.lastPathComponent
         if let entries = try? fm.contentsOfDirectory(atPath: tokenizerRoot.path) {
             for entry in entries where entry != tokenizerKeep && !entry.hasPrefix(".") {
                 let url = tokenizerRoot.appendingPathComponent(entry)

--- a/Sources/OpenQuackPlatform/NetworkReachability.swift
+++ b/Sources/OpenQuackPlatform/NetworkReachability.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Network
+
+public enum NetworkReachability {
+    /// Suspends until `NWPathMonitor` reports a satisfied path or the timeout
+    /// elapses. Returns immediately if the path is already satisfied on the
+    /// monitor's first callback. Event-driven — no polling.
+    public static func waitForSatisfied(timeoutSeconds: TimeInterval) async {
+        let monitor = NWPathMonitor()
+        let stream = AsyncStream<Void> { continuation in
+            monitor.pathUpdateHandler = { path in
+                if path.status == .satisfied {
+                    continuation.finish()
+                }
+            }
+            continuation.onTermination = { @Sendable _ in
+                monitor.cancel()
+            }
+            monitor.start(queue: .global())
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                continuation.finish()
+            }
+        }
+        for await _ in stream {}
+    }
+}

--- a/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
+++ b/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import Foundation
+@testable import OpenQuackKit
+
+final class WhisperKitEngineCacheTests: XCTestCase {
+    private var base: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenQuackCacheTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDown() async throws {
+        if let b = base, FileManager.default.fileExists(atPath: b.path) {
+            try? FileManager.default.removeItem(at: b)
+        }
+        try await super.tearDown()
+    }
+
+    private func seedCompleteCache(for variant: String) throws {
+        let fm = FileManager.default
+        let model = WhisperKitEngine.localModelFolder(for: variant, downloadBase: base)
+        for name in ["AudioEncoder.mlmodelc", "MelSpectrogram.mlmodelc", "TextDecoder.mlmodelc"] {
+            try fm.createDirectory(at: model.appendingPathComponent(name), withIntermediateDirectories: true)
+        }
+        let tokenizer = WhisperKitEngine.localTokenizerFolder(for: variant, downloadBase: base)
+        try fm.createDirectory(at: tokenizer, withIntermediateDirectories: true)
+        try Data().write(to: tokenizer.appendingPathComponent("tokenizer.json"))
+    }
+
+    func testHasCompleteLocalCache_emptyDirReturnsFalse() {
+        XCTAssertFalse(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))
+    }
+
+    func testHasCompleteLocalCache_fullySeededReturnsTrue() throws {
+        try seedCompleteCache(for: "medium")
+        XCTAssertTrue(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))
+    }
+
+    func testHasCompleteLocalCache_missingAudioEncoderReturnsFalse() throws {
+        try seedCompleteCache(for: "medium")
+        let path = WhisperKitEngine.localModelFolder(for: "medium", downloadBase: base)
+            .appendingPathComponent("AudioEncoder.mlmodelc")
+        try FileManager.default.removeItem(at: path)
+        XCTAssertFalse(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))
+    }
+
+    func testHasCompleteLocalCache_missingTokenizerReturnsFalse() throws {
+        try seedCompleteCache(for: "medium")
+        let path = WhisperKitEngine.localTokenizerFolder(for: "medium", downloadBase: base)
+            .appendingPathComponent("tokenizer.json")
+        try FileManager.default.removeItem(at: path)
+        XCTAssertFalse(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))
+    }
+
+    func testHasCompleteLocalCache_isPerVariant() throws {
+        try seedCompleteCache(for: "medium")
+        XCTAssertTrue(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))
+        XCTAssertFalse(WhisperKitEngine.hasCompleteLocalCache(for: "large-v3", downloadBase: base))
+    }
+
+    func testLocalModelFolder_matchesWhisperKitCacheLayout() {
+        let url = WhisperKitEngine.localModelFolder(for: "medium", downloadBase: base)
+        XCTAssertEqual(
+            url.path,
+            base.appendingPathComponent("models/argmaxinc/whisperkit-coreml/openai_whisper-medium").path
+        )
+    }
+
+    func testLocalTokenizerFolder_matchesWhisperKitCacheLayout() {
+        let url = WhisperKitEngine.localTokenizerFolder(for: "medium", downloadBase: base)
+        XCTAssertEqual(
+            url.path,
+            base.appendingPathComponent("models/openai/whisper-medium").path
+        )
+    }
+
+    func testCleanupOtherModels_keepsActiveAndDeletesSiblings() throws {
+        let fm = FileManager.default
+        let weightsRoot = WhisperKitEngine.localModelFolder(for: "x", downloadBase: base)
+            .deletingLastPathComponent()
+        let tokenizerRoot = WhisperKitEngine.localTokenizerFolder(for: "x", downloadBase: base)
+            .deletingLastPathComponent()
+        for variant in ["medium", "tiny", "large-v3"] {
+            try fm.createDirectory(at: weightsRoot.appendingPathComponent("openai_whisper-\(variant)"),
+                                    withIntermediateDirectories: true)
+            try fm.createDirectory(at: tokenizerRoot.appendingPathComponent("whisper-\(variant)"),
+                                    withIntermediateDirectories: true)
+        }
+
+        _ = WhisperKitEngine.cleanupOtherModels(keeping: "medium", downloadBase: base)
+
+        XCTAssertTrue(fm.fileExists(atPath: weightsRoot.appendingPathComponent("openai_whisper-medium").path))
+        XCTAssertFalse(fm.fileExists(atPath: weightsRoot.appendingPathComponent("openai_whisper-tiny").path))
+        XCTAssertFalse(fm.fileExists(atPath: weightsRoot.appendingPathComponent("openai_whisper-large-v3").path))
+        XCTAssertTrue(fm.fileExists(atPath: tokenizerRoot.appendingPathComponent("whisper-medium").path))
+        XCTAssertFalse(fm.fileExists(atPath: tokenizerRoot.appendingPathComponent("whisper-tiny").path))
+    }
+}


### PR DESCRIPTION
## Why
WhisperKit's `init` always probes HuggingFace for the model manifest, so an SMAppService autostart that beats WiFi negotiation fails even when the model cache is complete on disk. Closes #55.

## Change
- `WhisperKitEngine.init`: pass `modelFolder` + `tokenizerFolder` to `WhisperKitConfig` when the on-disk cache is complete → upstream takes its local-folder branch, no network.
- `WhisperKitEngine.refreshModelInBackground(...)`: after a successful warm, await `NWPathMonitor.satisfied`, then run `WhisperKit.download` for an etag-conditional refresh (new weights land for the next launch).
- New `OpenQuackPlatform/NetworkReachability.swift` — event-driven `waitForSatisfied(timeoutSeconds:)` using `AsyncStream`.
- Refactor `cleanupOtherModels` to use `localModelFolder` / `localTokenizerFolder` as the single source of truth for the cache layout.

## Tests
- [x] `WhisperKitEngineCacheTests` (8 new): `hasCompleteLocalCache` predicate, path helpers, `cleanupOtherModels` sibling deletion.
- [x] `swift build && swift test` green (150 passing).
- [x] Manual: reboot with Launch at Login enabled → no error popover; verified locally.

## AI coding brief
- **Original request**: app's autostart after Mac reboot fails to load Whisper, but manual quit + reopen works. User asked to diagnose with verifiable logs before proposing a fix.
- **Manual interventions**: Initial hypothesis ("WhisperKit always needs network") was rejected by user's case 2/3 evidence; added one-shot `BootDiagnostic` file logger to confirm timing (autostart at boot+35s, WiFi `.satisfied` at boot+83s), then removed before commit. User pushed back on over-commenting, over-extracted helpers, an arbitrary `30s Task.sleep` (replaced with `NWPathMonitor`), and the file's initial location (moved from `OpenQuackKit/` to `OpenQuackPlatform/` to match the foundation-utility layer's convention).
- **Retro**: When the symptom is timing-dependent and the user reports a reproducible matrix of cases, anchor on the evidence the matrix produces (state at each launch) before generalizing. When extracting helpers, justify by current reuse — not by hypothetical future callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)