### PR TITLE
fix(hotkey): swap dictation/kickoff defaults — dictation back to ⌃⇧Space

### DIFF
--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -325,7 +325,7 @@ private struct ShortcutPane: View {
         Form {
             Section {
                 KeyboardShortcuts.Recorder("Hotkey:", name: .toggleRecording)
-                Text("Press once to start dictating, again to stop. ⌃Space is the default and works in most apps.")
+                Text("Press once to start dictating, again to stop. ⌃⇧Space is the default and works in most apps.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } header: {
@@ -334,7 +334,7 @@ private struct ShortcutPane: View {
 
             Section {
                 KeyboardShortcuts.Recorder("Kickoff:", name: .agentKickoff)
-                Text("Voice → fresh background Claude Code session. Press the hotkey, dictate a task, release; the agent runs unattended with **full permission bypass** (any shell command, any file, any app) and you get a macOS notification when it's done. Default ⌃⇧Space; first press shows a consent prompt that spells out what the agent can do — until you accept it, nothing leaves your Mac. Routes through Anthropic.")
+                Text("Voice → fresh background Claude Code session. Press the hotkey, dictate a task, release; the agent runs unattended with **full permission bypass** (any shell command, any file, any app) and you get a macOS notification when it's done. Default ⌃Space; first press shows a consent prompt that spells out what the agent can do — until you accept it, nothing leaves your Mac. Routes through Anthropic.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 ClaudeCodeStatusRow()

--- a/Sources/OpenQuackKit/Hotkey/HotkeyManager.swift
+++ b/Sources/OpenQuackKit/Hotkey/HotkeyManager.swift
@@ -3,21 +3,22 @@ import KeyboardShortcuts
 
 /// SPEC-003 — Global hotkey, backed by sindresorhus/KeyboardShortcuts.
 public extension KeyboardShortcuts.Name {
-    /// SPEC-003 — Dictation hotkey. Default: ⌃Space (simpler combo for
-    /// the more-frequent action). User-overridable via the Settings
-    /// recorder.
+    /// SPEC-003 — Dictation hotkey. Default: ⌃⇧Space. The most-frequent
+    /// action keeps the historical default so existing users' muscle
+    /// memory is preserved across the SPEC-031 release.
     static let toggleRecording = Self(
         "openquack.toggleRecording",
-        default: .init(.space, modifiers: [.control])
+        default: .init(.space, modifiers: [.control, .shift])
     )
 
-    /// SPEC-031 — Agent kickoff hotkey. Default: ⌃⇧Space (the "shift
-    /// up" modifier signals louder/escalated action vs plain
-    /// dictation). User-overridable. Distinct binding from dictation
-    /// so the two paths never collide.
+    /// SPEC-031 — Agent kickoff hotkey. Default: ⌃Space. The simpler
+    /// combo for the lower-frequency / higher-commitment action — the
+    /// user is opting into a multi-step background workflow
+    /// (consent → spawn → notification → attach), and an ergonomic
+    /// launch keeps the cumulative friction tolerable.
     static let agentKickoff = Self(
         "openquack.agentKickoff",
-        default: .init(.space, modifiers: [.control, .shift])
+        default: .init(.space, modifiers: [.control])
     )
 }
 


### PR DESCRIPTION
## SPEC

[SPEC-003](docs/SPECS/SPEC-003-hotkey.md) defaults + [SPEC-031](docs/SPECS/SPEC-031-agent-kickoff.md) defaults.

## Milestone

M2

## Why

Per direction:

> *"switch the shortcut for dictation vs kickoff, kickoff is more involved, and dictation is used more often"*

Restores pre-alpha.14 muscle memory for dictation while keeping kickoff bound to a default (so the feature stays discoverable without a Settings trip).

| | Before this PR (alpha.14) | After this PR |
|---|---|---|
| Dictation | `⌃Space` | `⌃⇧Space` |
| Kickoff | `⌃⇧Space` | `⌃Space` |

## Change

Two-file diff:
- `Sources/OpenQuackKit/Hotkey/HotkeyManager.swift` — swap the `default:` clauses on the two `KeyboardShortcuts.Name` extensions; doc-comments updated to reflect the reasoning.
- `Sources/OpenQuackApp/SettingsView.swift` — Shortcut pane captions reference the new defaults.

`OnboardingFlow.swift`'s onboarding copy already mentioned ⌃⇧Space as the dictation default (it was written before alpha.14 changed the default and never updated), so it lines up correctly with this swap — no edit needed.

## Tests

- [x] 150/150 tests green (`swift build && swift test` with Xcode toolchain)
- [x] No test asserts specific modifier combos for these names, so the swap is a doc + ergonomic change rather than a contract change

## Privacy impact

None — keyboard-shortcut defaults only. The kickoff's bypass-perms + Anthropic-routing behavior is unchanged.

## Out of scope

- Existing users who customized their hotkeys are unaffected — `UserDefaults` wins over the `default:` clause.
- Existing users who were on the alpha.14 default `⌃Space` for dictation will see dictation move to `⌃⇧Space` on next launch (since their UserDefaults only stores explicit customizations).
- Migration prompt for established users — not added; the blast radius is alpha-cohort-small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)