### PR TITLE
fix(SPEC-031): skip kickoff on Whisper blank-audio

### DIFF
--- a/Sources/OpenQuackKit/Agents/AgentKickoffService.swift
+++ b/Sources/OpenQuackKit/Agents/AgentKickoffService.swift
@@ -98,6 +98,10 @@ public enum AgentKickoffService {
     public static func startClaudeKickoff(prompt: String) throws -> KickoffSession {
         let cleaned = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { throw Error.emptyPrompt }
+        // Whisper emits canonical blank-audio markers + classic
+        // hallucinations when there's no actual speech. Don't burn a
+        // claude session on those.
+        guard !looksLikeBlankAudio(cleaned) else { throw Error.emptyPrompt }
         guard !cleaned.contains("\0") else { throw Error.invalidPrompt }
         guard let claudeURL = resolveClaudePath() else { throw Error.claudeCLIMissing }
 
@@ -183,6 +187,64 @@ public enum AgentKickoffService {
     /// `--bg --permission-mode bypassPermissions` requires.
     public static func openDisclaimerTerminal() throws {
         try spawnCommandFile(shellCommand: "claude --dangerously-skip-permissions")
+    }
+
+    // MARK: - Blank-audio detection
+
+    /// True if the transcript looks like Whisper had nothing real to
+    /// say — canonical blank-audio token, parenthesised silence
+    /// markers, the classic "you" / "Thanks for watching" / "Bye"
+    /// hallucinations, or strings with no alphanumeric content at all.
+    ///
+    /// Used by `startClaudeKickoff` to skip spawning a claude session
+    /// on accidental hotkey presses. We err toward false-negatives:
+    /// a legitimate "yes" or "okay" must pass through, so we only
+    /// match Whisper's specific known-blank outputs, not all short
+    /// utterances.
+    static func looksLikeBlankAudio(_ s: String) -> Bool {
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        // No alphanumeric content at all → silence / pure punctuation.
+        if trimmed.range(of: #"[A-Za-z0-9\p{L}]"#, options: .regularExpression) == nil {
+            return true
+        }
+        // Canonical Whisper blank-audio markers + bracketed silence.
+        let lower = trimmed.lowercased()
+        let exactBlankMarkers: Set<String> = [
+            "[blank_audio]",
+            "[ blank_audio ]",
+            "[silence]",
+            "[ silence ]",
+            "(silence)",
+            "( silence )",
+            "[music]",
+            "(music)",
+            "[applause]",
+            "(applause)",
+            "[no audio]",
+            "(no audio)",
+            "[no speech]",
+            "(no speech)",
+        ]
+        if exactBlankMarkers.contains(lower) { return true }
+        // Classic Whisper-on-silence hallucinations (small models
+        // especially). Treat as blank ONLY if they appear in isolation —
+        // a real prompt containing the phrase passes through.
+        let isolatedHallucinations: Set<String> = [
+            "you",
+            "you.",
+            "thank you.",
+            "thanks.",
+            "thanks for watching.",
+            "thanks for watching!",
+            "bye.",
+            "bye!",
+            ".",
+            "...",
+            "…",
+        ]
+        if isolatedHallucinations.contains(lower) { return true }
+        return false
     }
 
     // MARK: - Internal helpers (exposed for tests)

--- a/Tests/OpenQuackKitTests/AgentKickoffServiceTests.swift
+++ b/Tests/OpenQuackKitTests/AgentKickoffServiceTests.swift
@@ -386,6 +386,92 @@ final class AgentKickoffServiceTests: XCTestCase {
         XCTAssertLessThanOrEqual(min, ClaudeVersion(major: 2, minor: 1, patch: 200))
     }
 
+    // MARK: - Blank-audio detection
+
+    func testLooksLikeBlankAudioCanonicalMarkers() {
+        for marker in [
+            "[BLANK_AUDIO]",
+            "[ BLANK_AUDIO ]",
+            "[blank_audio]",
+            "[Silence]",
+            "[silence]",
+            "[ silence ]",
+            "(silence)",
+            "[music]",
+            "(applause)",
+            "[no audio]",
+            "[no speech]",
+        ] {
+            XCTAssertTrue(
+                AgentKickoffService.looksLikeBlankAudio(marker),
+                "expected blank-audio match for: \(marker.debugDescription)"
+            )
+        }
+    }
+
+    func testLooksLikeBlankAudioClassicHallucinations() {
+        // Whisper-on-silence hallucinations seen in the wild (small
+        // models especially).
+        for token in ["you", "You.", "thanks for watching.", "Bye.", "...", "…", "."] {
+            XCTAssertTrue(
+                AgentKickoffService.looksLikeBlankAudio(token),
+                "expected hallucination match for: \(token.debugDescription)"
+            )
+        }
+    }
+
+    func testLooksLikeBlankAudioPunctuationOnly() {
+        XCTAssertTrue(AgentKickoffService.looksLikeBlankAudio("   "))
+        XCTAssertTrue(AgentKickoffService.looksLikeBlankAudio("?!!"))
+        XCTAssertTrue(AgentKickoffService.looksLikeBlankAudio("—"))
+    }
+
+    func testLooksLikeBlankAudioPassesLegitShortUtterances() {
+        // Short but meaningful single-word prompts must pass through —
+        // false-positives here are worse than false-negatives.
+        for prompt in [
+            "yes",
+            "okay",
+            "stop",
+            "set a timer",
+            "what time is it",
+            "compile",
+        ] {
+            XCTAssertFalse(
+                AgentKickoffService.looksLikeBlankAudio(prompt),
+                "must NOT block legit prompt: \(prompt.debugDescription)"
+            )
+        }
+    }
+
+    func testLooksLikeBlankAudioPassesPromptsContainingHallucinationPhrase() {
+        // A real prompt that includes "you" as part of a sentence
+        // should pass — only isolated occurrences are filtered.
+        XCTAssertFalse(
+            AgentKickoffService.looksLikeBlankAudio("can you set me a reminder")
+        )
+        XCTAssertFalse(
+            AgentKickoffService.looksLikeBlankAudio("thanks for watching the build")
+        )
+    }
+
+    func testStartRejectsBlankAudio() {
+        do {
+            _ = try AgentKickoffService.startClaudeKickoff(prompt: "[BLANK_AUDIO]")
+            XCTFail("expected emptyPrompt error for blank-audio marker")
+        } catch let error as AgentKickoffService.Error {
+            // emptyPrompt covers both empty-string + blank-audio.
+            // claudeCLIMissing is acceptable on a test box without
+            // claude installed.
+            XCTAssertTrue(
+                error == .emptyPrompt || error == .claudeCLIMissing,
+                "got \(error)"
+            )
+        } catch {
+            XCTFail("unexpected: \(error)")
+        }
+    }
+
     // MARK: - KickoffSession paths
 
     func testKickoffSessionStateFilePath() {


### PR DESCRIPTION
## SPEC

[SPEC-031](docs/SPECS/SPEC-031-agent-kickoff.md) — UX fix against the live build.

## Milestone

M2

## Why

User-reported gap after alpha.14 hands-on: *"If it's blank audio as the input, I think it's an input from whisper. No need to start the claude code session."*

Pressing the kickoff hotkey without speaking (or by accident) currently still sends `[BLANK_AUDIO]` or a Whisper hallucination as the seed prompt — burns a claude session for nothing.

## Change

**`AgentKickoffService.looksLikeBlankAudio(_:)`** — runs in `startClaudeKickoff` before any claude resolution / Process spawn. Detects:
- Canonical Whisper blank-audio markers (`[BLANK_AUDIO]`, `[silence]`, `(silence)`, `[music]`, `(applause)`, `[no audio]`, `[no speech]`, bracketed/parenthesised variants)
- Classic silence-hallucinations seen in the wild (`you`, `thanks for watching.`, `bye.`, `...`)
- Strings with no alphanumeric content at all (pure punctuation/whitespace)

Throws `.emptyPrompt` on match. AppDelegate's existing dispatch fork already handles this gracefully — clipboard fallback + overlay "Nothing to send — say something first." Errs toward false-negatives: short legit utterances ("yes", "okay", "stop", "set a timer") pass through unchanged.

## Tests

- [x] **6 new** cases (canonical markers, classic hallucinations, punctuation-only, legit short utterances passing, in-context phrases passing, end-to-end via startClaudeKickoff)
- [x] `swift build && swift test` green: **156/156**
- [x] No bench impact — runs outside the transcription hot path

## Privacy impact

None. Blank-audio detection runs locally before any network hop.

## Out of scope

- Blank-audio handling in the **dictation** path — currently still pastes `[BLANK_AUDIO]` if it ever reaches the cursor. Separate concern; flagged as follow-up.
- Custom dictionary seeding — split out to a separate PR per direction. The visible-default approach (changes `@AppStorage` default value so users see + can edit) ships under a separate PR rather than the silent migration that was originally bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)