### PR TITLE
feat: visible default for custom Whisper-bias dictionary

### DIFF
--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -51,7 +51,7 @@ private struct GeneralPane: View {
     @AppStorage("playSounds")          private var playSounds: Bool = true
     @AppStorage("vadAutoStop")         private var vadAutoStop: Bool = false
     @AppStorage("vadSilenceSeconds")   private var vadSilenceSeconds: Double = 1.5
-    @AppStorage("customWords")         private var customWords: String = ""
+    @AppStorage("customWords")         private var customWords: String = CustomDictionaryDefaults.seedList
     @AppStorage("model")               private var model: String = "medium"
     @AppStorage("launchAtLogin")       private var launchAtLogin: Bool = false
 
@@ -162,14 +162,23 @@ private struct GeneralPane: View {
             Section {
                 PlaceholderTextEditor(
                     text: $customWords,
-                    prompt: "e.g.\nOpenQuack\nWhisperKit\nClaude Code",
+                    prompt: CustomDictionaryDefaults.seedList,
                     monospaced: true,
-                    minHeight: 90,
-                    idealHeight: 110
+                    minHeight: 110,
+                    idealHeight: 140
                 )
-                Text("One word or phrase per line. Whisper uses these as a hint when deciding between similar-sounding words — useful for proper nouns, jargon, and project names.")
+                HStack(spacing: 8) {
+                    Text("One word or phrase per line. Whisper uses these as a hint when deciding between similar-sounding words — useful for proper nouns, jargon, and project names.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 12)
+                    Button("Restore suggested") {
+                        customWords = CustomDictionaryDefaults.seedList
+                    }
+                    .buttonStyle(.borderless)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .help("Replaces the editor contents with OpenQuack's default seed list (\(CustomDictionaryDefaults.seedEntries.count) entries focused on macOS / AI-tooling proper nouns Whisper routinely mishears).")
+                }
             } header: {
                 SectionHeader("Custom dictionary")
             }

--- a/Sources/OpenQuackKit/Transcription/CustomDictionary.swift
+++ b/Sources/OpenQuackKit/Transcription/CustomDictionary.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Default Whisper-bias entries for the user's custom dictionary.
+///
+/// New installs get this filled into `UserDefaults["customWords"]`
+/// via the `@AppStorage` default in Settings — visible in the
+/// Custom dictionary editor on first launch, easy to edit / extend.
+/// Existing users (whose UserDefaults key is already set) can pull
+/// it down via the "Restore suggested words" button in Settings.
+///
+/// Curated for OpenQuack's target user group: macOS users with
+/// developer / AI-tooling context. The list focuses on proper
+/// nouns and tokens Whisper routinely mangles (e.g. *Claude* →
+/// "cloud", *OpenQuack* → various contortions) rather than dumping
+/// a generic English word list — Whisper bias has diminishing
+/// returns past ~10-20 entries.
+///
+/// Additions belong here only if they meet *both*:
+///   - The target user group says the word often
+///   - Whisper measurably mishears it (single tokens like
+///     "compile" don't need biasing)
+public enum CustomDictionaryDefaults {
+    /// The seed entries, one per line, in the order they appear in
+    /// the editor. Order doesn't affect Whisper bias weighting (the
+    /// prompt is a bag of strings), but it affects how the list
+    /// reads to the user when they first open Settings.
+    public static let seedEntries: [String] = [
+        "Claude",
+        "Claude Code",
+        "Anthropic",
+        "OpenQuack",
+        "WhisperKit",
+        "macOS",
+        "AppleScript",
+        "Xcode",
+    ]
+
+    /// Newline-joined form for direct insertion into the
+    /// `customWords` UserDefaults key / `@AppStorage` default.
+    public static var seedList: String {
+        seedEntries.joined(separator: "\n")
+    }
+}

--- a/Tests/OpenQuackKitTests/CustomDictionaryDefaultsTests.swift
+++ b/Tests/OpenQuackKitTests/CustomDictionaryDefaultsTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class CustomDictionaryDefaultsTests: XCTestCase {
+    func testSeedListContainsLoadBearingEntries() {
+        // These are the entries we specifically curated for the
+        // target user group. If one is missing, the seed has been
+        // accidentally weakened.
+        let required: [String] = [
+            "Claude",
+            "Claude Code",
+            "Anthropic",
+            "OpenQuack",
+            "WhisperKit",
+            "macOS",
+            "AppleScript",
+            "Xcode",
+        ]
+        for entry in required {
+            XCTAssertTrue(
+                CustomDictionaryDefaults.seedEntries.contains(entry),
+                "seed list missing required entry: \(entry)"
+            )
+        }
+    }
+
+    func testSeedListNewlineJoined() {
+        let joined = CustomDictionaryDefaults.seedList
+        let split = joined.split(separator: "\n").map(String.init)
+        XCTAssertEqual(split, CustomDictionaryDefaults.seedEntries)
+    }
+
+    func testSeedListIsConservativeInSize() {
+        // Whisper bias has diminishing returns past ~10-20 entries.
+        // Guard against drift toward a dumping ground.
+        XCTAssertLessThanOrEqual(
+            CustomDictionaryDefaults.seedEntries.count, 20,
+            "seed list drifting toward a generic word dump — trim it back"
+        )
+    }
+
+    func testSeedEntriesHaveNoLeadingTrailingWhitespace() {
+        for entry in CustomDictionaryDefaults.seedEntries {
+            XCTAssertEqual(
+                entry,
+                entry.trimmingCharacters(in: .whitespacesAndNewlines),
+                "seed entry has stray whitespace: \(entry.debugDescription)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## SPEC

[SPEC-022](docs/SPECS/SPEC-022-custom-dict-autolearn.md) territory — small visible-default addition to the existing custom dictionary surface; no spec change.

## Milestone

M2

## Why

Per direction:

> *"no need for AgentKickoffService.ensureClaudeCodeInCustomDictionary that adds it without user knowing it, simply set a default for the custom dictionary config, based on the target user group, come up with common words and add it, users can see and edit it manually"*

Replaces what was bundled into the original PR #58 (a silent UserDefaults migration). Instead this surfaces the seed list as a **visible default** in Settings → General → Custom dictionary — new installs see it, existing users can pull it down with a button.

## Change

**New `CustomDictionaryDefaults` enum** (`Sources/OpenQuackKit/Transcription/CustomDictionary.swift`):

```swift
public static let seedEntries: [String] = [
    "Claude",
    "Claude Code",
    "Anthropic",
    "OpenQuack",
    "WhisperKit",
    "macOS",
    "AppleScript",
    "Xcode",
]
```

Selection criteria documented inline — additions only if (a) the target user group says the word often AND (b) Whisper measurably mishears it. Tests guard against drift toward a generic word dump.

**SettingsView** (`Sources/OpenQuackApp/SettingsView.swift`):
- `@AppStorage("customWords")` default goes from `""` to `CustomDictionaryDefaults.seedList`. Fresh installs land in Settings with the list visible.
- Section subline gains a **"Restore suggested"** button (bordered, caption-sized) that overwrites the editor with the canonical seed list. Existing users with empty / customized dictionaries can pull it down.
- Placeholder text in the editor falls back to the same seed list (so a cleared field still shows what the suggested default looks like).
- Editor height bumped (110 → 140 ideal) to comfortably show ~8 entries without scroll.

## Tests

- [x] **4 new** cases in `CustomDictionaryDefaultsTests` — required entries present, newline-joined round-trip, conservative size cap (≤20 to guard against drift), no stray whitespace
- [x] `swift build && swift test` green: **154/154**
- [x] No bench impact

## Privacy impact

None. Custom dictionary lives in user-local `UserDefaults`. Visible to the user in Settings.

## Out of scope

- Migration of existing alpha users — they'll see the editor in whatever state they left it in, with the new Restore button as the opt-in
- Per-user-group seed lists (e.g. designers vs. devs vs. writers) — single list for now
- "Auto-learn" — SPEC-022's existing scope, not bundled here

🤖 Generated with [Claude Code](https://claude.com/claude-code)