### PR TITLE
fix(updates): compare versions with SemVer precedence

### DIFF
--- a/Sources/OpenQuackKit/Updates/UpdateChecker.swift
+++ b/Sources/OpenQuackKit/Updates/UpdateChecker.swift
@@ -100,14 +100,68 @@ public actor UpdateChecker {
         return Self.isNewer(remote: info.version, than: currentVersion) ? info : nil
     }
 
-    /// Naive version comparison. Good enough for the alpha cadence
-    /// ("2.0.0-alpha.1" → "2.0.0-alpha.2"). For the future "alpha → release"
-    /// boundary we'll need a proper semver parser; flagged in SPEC-?? once the
-    /// first non-alpha ships.
+    /// SemVer-2.0.0 precedence comparison. Returns true iff `remote` is a
+    /// strictly newer release than `current`.
+    ///
+    /// The old `.numeric` string compare got three cases wrong, all of which
+    /// could pin the update badge "on" forever:
+    ///   • prerelease ordering — "2.0.0-alpha.2" sorted *after* "...alpha.16"
+    ///     lexically, so an older advertised build looked newer.
+    ///   • release vs prerelease — "2.0.0" must outrank "2.0.0-alpha.16"; the
+    ///     prefix compare reported the opposite.
+    ///   • differently-formatted-but-equal versions never compared equal.
     static func isNewer(remote: String, than current: String) -> Bool {
         let r = remote.hasPrefix("v") ? String(remote.dropFirst()) : remote
         let c = current.hasPrefix("v") ? String(current.dropFirst()) : current
-        return r.compare(c, options: .numeric) == .orderedDescending
+        return compareSemver(r, c) == .orderedDescending
+    }
+
+    /// SemVer-2.0.0 precedence (build metadata after `+` is ignored — we emit
+    /// none). Tolerant of short cores like "2.0" (missing parts read as 0).
+    static func compareSemver(_ a: String, _ b: String) -> ComparisonResult {
+        let (coreA, preA) = splitPrerelease(a)
+        let (coreB, preB) = splitPrerelease(b)
+
+        // 1. Core: major.minor.patch, numeric, missing components are 0.
+        let na = coreA.split(separator: ".").map { Int($0) ?? 0 }
+        let nb = coreB.split(separator: ".").map { Int($0) ?? 0 }
+        for i in 0..<max(na.count, nb.count) {
+            let x = i < na.count ? na[i] : 0
+            let y = i < nb.count ? nb[i] : 0
+            if x != y { return x < y ? .orderedAscending : .orderedDescending }
+        }
+
+        // 2. A version with NO prerelease tag outranks one that has it.
+        switch (preA.isEmpty, preB.isEmpty) {
+        case (true, true):  return .orderedSame
+        case (true, false): return .orderedDescending
+        case (false, true): return .orderedAscending
+        case (false, false): break
+        }
+
+        // 3. Compare prerelease identifiers left to right.
+        let idA = preA.split(separator: ".").map(String.init)
+        let idB = preB.split(separator: ".").map(String.init)
+        for i in 0..<max(idA.count, idB.count) {
+            // Fewer identifiers, all else equal, ranks lower.
+            guard i < idA.count else { return .orderedAscending }
+            guard i < idB.count else { return .orderedDescending }
+            let x = idA[i], y = idB[i]
+            if x == y { continue }
+            switch (Int(x), Int(y)) {
+            case let (xi?, yi?): return xi < yi ? .orderedAscending : .orderedDescending
+            case (_?, nil):      return .orderedAscending   // numeric < alphanumeric
+            case (nil, _?):      return .orderedDescending
+            case (nil, nil):     return x < y ? .orderedAscending : .orderedDescending
+            }
+        }
+        return .orderedSame
+    }
+
+    private static func splitPrerelease(_ v: String) -> (core: String, pre: String) {
+        let noBuild = v.split(separator: "+", maxSplits: 1).first.map(String.init) ?? v
+        guard let dash = noBuild.firstIndex(of: "-") else { return (noBuild, "") }
+        return (String(noBuild[..<dash]), String(noBuild[noBuild.index(after: dash)...]))
     }
 
     private static func parseDate(_ s: String) -> Date? {

--- a/Tests/OpenQuackKitTests/UpdateCheckerTests.swift
+++ b/Tests/OpenQuackKitTests/UpdateCheckerTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class UpdateCheckerTests: XCTestCase {
+    // MARK: isNewer — the cases the old .numeric compare got wrong
+
+    func testEqualVersionsAreNotNewer() {
+        // The bug report: installed == latest, yet the badge stayed on.
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "2.0.0-alpha.16", than: "2.0.0-alpha.16"))
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "v2.0.0-alpha.16", than: "2.0.0-alpha.16"))
+    }
+
+    func testPrereleaseOrderingIsNumericNotLexical() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2.0.0-alpha.16", than: "2.0.0-alpha.2"))
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "2.0.0-alpha.2", than: "2.0.0-alpha.16"))
+    }
+
+    func testReleaseOutranksItsPrereleases() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2.0.0", than: "2.0.0-alpha.16"))
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "2.0.0-alpha.16", than: "2.0.0"))
+    }
+
+    func testCoreVersionPrecedence() {
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2.0.1", than: "2.0.0"))
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2.1.0", than: "2.0.9"))
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "2.0.0", than: "2.0.1"))
+    }
+
+    func testStageOrdering() {
+        // alpha < beta < rc < release
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2.0.0-beta.1", than: "2.0.0-alpha.99"))
+        XCTAssertTrue(UpdateChecker.isNewer(remote: "2.0.0-rc.1", than: "2.0.0-beta.5"))
+    }
+
+    func testShortCoreAndBuildMetadata() {
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "2.0", than: "2.0.0"))      // 2.0 == 2.0.0
+        XCTAssertFalse(UpdateChecker.isNewer(remote: "2.0.0+build9", than: "2.0.0")) // metadata ignored
+    }
+}


### PR DESCRIPTION
Fixes #60.

## Problem

`UpdateChecker.isNewer` compared versions with `String.compare(.numeric)`, which the code's own comment flagged as broken at the alpha→release boundary. Any of three cases keeps the in-app `🦆⬆` badge stuck on even when the installed build is already latest:

- prerelease ordering was lexical — `2.0.0-alpha.2` sorted after `…alpha.16`
- a release didn't outrank its prereleases — `2.0.0` read as older than `2.0.0-alpha.16`
- differently-formatted-but-equal versions never compared equal

## Change

- Replace the `.numeric` compare with a SemVer-2.0.0 precedence comparator (`compareSemver`): numeric core (tolerant of short cores like `2.0`), numeric prerelease identifiers, release > prerelease, `+build` metadata ignored.
- Add `Tests/OpenQuackKitTests/UpdateCheckerTests.swift` covering equal-versions, prerelease numeric ordering, release-vs-prerelease, core precedence, stage ordering (alpha<beta<rc), and short-core/build-metadata.

`swift build` + `swift test --filter UpdateCheckerTests` (6/6) pass.

## Out of scope (noted in #60)

The live Sparkle `appcast.xml` is stale at `alpha.12` with a numeric `sparkle:version` that mis-ranks against `2.0.0-alpha.16`. Refreshing the feed + aligning its version scheme is a separate server-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)