### PR TITLE
fix(SPEC-021): enable WhisperKit language detection on the auto path

### DIFF
--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -300,9 +300,24 @@ public final class WhisperKitEngine: TranscriptionEngine {
     ) async throws -> EngineTranscription {
         var options = DecodingOptions()
         options.task = .transcribe
-        options.language = language
         options.verbose = false
         options.withoutTimestamps = true
+
+        // Drive WhisperKit's language handling via the shared policy (SPEC-021).
+        // The offline path is stateless, so `locked` is nil: a pinned language
+        // is forced; otherwise in-decoder detection is enabled. Detection is
+        // gated on `options.detectLanguage`, which defaults to `false` (derives
+        // from `!usePrefillPrompt`, prefill on by default — see
+        // LanguageDecodePolicy and TranscribeTask.swift:312); with it off and
+        // `language == nil` the decoder silently prefilled the English token and
+        // *translated* non-English speech (measured 253% WER / 156% CER on
+        // bench/corpus/multilingual, every clip mislabelled `en`). The detect
+        // reuses the already-computed encoder pass (no extra encode); the pinned
+        // path sets the same `false` it already defaulted to → byte-for-byte
+        // unchanged.
+        let decision = LanguageDecodePolicy.decide(pinned: language)
+        options.language = decision.language
+        options.detectLanguage = decision.detectLanguage
 
         if let words = customWords?.trimmingCharacters(in: .whitespacesAndNewlines), !words.isEmpty {
             // Newline-separated → comma-joined per Whisper convention.

--- a/Sources/OpenQuackPlatform/LanguageDecodePolicy.swift
+++ b/Sources/OpenQuackPlatform/LanguageDecodePolicy.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Pure decision for how to drive WhisperKit's language handling on a single
+/// decode, shared by the offline (`WhisperKitEngine`) and streaming
+/// (`StreamingTranscriber`) paths (SPEC-021).
+///
+/// WhisperKit only runs language detection when **both**
+/// `options.language == nil` **and** `options.detectLanguage == true`; the
+/// latter defaults to `false` (it derives from `!usePrefillPrompt`, and prefill
+/// is on by default). With detection off and no pinned language, the decoder
+/// silently prefills the English token and *translates* non-English speech.
+///
+/// This helper centralises the three-way choice so it can be unit-tested
+/// without loading a model — it is the regression-prone part of the fix:
+///
+/// - **pinned** (user picked a language in Settings): force it, never detect.
+/// - **locked** (streaming: a language already detected on an earlier chunk of
+///   this utterance): reuse it so the utterance can't flip language mid-stream.
+/// - **neither** (auto, first decode): turn detection on.
+public enum LanguageDecodePolicy {
+    public struct Decision: Equatable, Sendable {
+        /// Value for `DecodingOptions.language` (nil ⇒ let the decoder detect).
+        public let language: String?
+        /// Value for `DecodingOptions.detectLanguage`.
+        public let detectLanguage: Bool
+
+        public init(language: String?, detectLanguage: Bool) {
+            self.language = language
+            self.detectLanguage = detectLanguage
+        }
+    }
+
+    /// - Parameters:
+    ///   - pinned: a user-selected language code, or nil for auto.
+    ///   - locked: a language already resolved earlier in the same streaming
+    ///     session, or nil. Ignored when `pinned` is set. Pass nil on the
+    ///     stateless offline path.
+    public static func decide(pinned: String?, locked: String? = nil) -> Decision {
+        if let pinned, !pinned.isEmpty {
+            return Decision(language: pinned, detectLanguage: false)
+        }
+        if let locked, !locked.isEmpty {
+            return Decision(language: locked, detectLanguage: false)
+        }
+        return Decision(language: nil, detectLanguage: true)
+    }
+}

--- a/Sources/OpenQuackStreamBench/OpenQuackStreamBenchCommand.swift
+++ b/Sources/OpenQuackStreamBench/OpenQuackStreamBenchCommand.swift
@@ -26,8 +26,16 @@ struct OpenQuackStreamBenchCommand: AsyncParsableCommand {
     var mode: String = "both"
 
     @Option(name: .customLong("language"),
-            help: "Force language code (en, zh, …). Default: en for the long corpus.")
+            help: "Force language code (en, zh, …), or 'auto' for engine auto-detect. Default: en for the long corpus.")
     var language: String? = "en"
+
+    /// `--language auto` (or empty) → nil, so the engine's auto-detect path
+    /// (SPEC-021 detect-then-lock) is exercised. Any other value is forced.
+    private var resolvedLanguage: String? {
+        guard let language else { return nil }
+        let l = language.trimmingCharacters(in: .whitespaces).lowercased()
+        return (l == "auto" || l.isEmpty) ? nil : language
+    }
 
     @Option(name: .customLong("chunking"),
             help: "Offline only: vad | none. Default vad. (Streaming always silence-cuts.)")
@@ -95,7 +103,7 @@ struct OpenQuackStreamBenchCommand: AsyncParsableCommand {
         if let first = clipURLs.first {
             stderr("◇ warm-up on \(first.lastPathComponent)…")
             _ = try? await transcribeOffline(pipe: pipe, url: first,
-                                              language: language,
+                                              language: resolvedLanguage,
                                               chunkStrategy: chunkStrategy)
             stderr("  ✓ warm")
         }
@@ -112,14 +120,14 @@ struct OpenQuackStreamBenchCommand: AsyncParsableCommand {
 
             if runOffline {
                 let r = try await transcribeOffline(pipe: pipe, url: url,
-                                                     language: language,
+                                                     language: resolvedLanguage,
                                                      chunkStrategy: chunkStrategy)
                 off = ModeResult(text: r.text, postStopWait: r.wall, totalWall: r.wall, chunkCount: nil, ttft: r.ttft)
             }
 
             if runStreaming {
                 let r = try await transcribeStreaming(pipe: pipe, url: url,
-                                                       language: language,
+                                                       language: resolvedLanguage,
                                                        paced: !smoke)
                 stm = ModeResult(text: r.text, postStopWait: r.postStopWait, totalWall: r.totalWall, chunkCount: r.chunkCount, ttft: nil)
             }
@@ -210,7 +218,7 @@ struct OpenQuackStreamBenchCommand: AsyncParsableCommand {
             maxChunkSeconds: maxChunk
         )
         let streamer = StreamingTranscriber(pipe: pipe, config: cfg)
-        await streamer.begin(language: language, customWords: nil)
+        await streamer.begin(language: resolvedLanguage, customWords: nil)
 
         let pacingStart = Date()
         var idx = 0

--- a/Sources/OpenQuackStreaming/StreamingTranscriber.swift
+++ b/Sources/OpenQuackStreaming/StreamingTranscriber.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenQuackPlatform
 import WhisperKit
 
 /// SPEC-012: streaming transcription that chunks audio at silence boundaries
@@ -58,6 +59,11 @@ public actor StreamingTranscriber {
     private var bufferStartSample: Int = 0
     private var beginTime: Date?
     private var language: String?
+    /// On the auto path (`language == nil`), the language detected on the first
+    /// chunk, reused for every subsequent chunk so the whole utterance decodes
+    /// in one consistent language instead of WhisperKit re-detecting (and
+    /// possibly flipping) per chunk (SPEC-021).
+    private var resolvedLanguage: String?
     private var promptTokens: [Int]?
     private var ended: Bool = false
     private var cancelled: Bool = false
@@ -104,6 +110,7 @@ public actor StreamingTranscriber {
         cancelled = false
         beginTime = Date()
         self.language = language
+        self.resolvedLanguage = nil
         self.promptTokens = encodePrompt(customWords: customWords)
     }
 
@@ -156,6 +163,7 @@ public actor StreamingTranscriber {
         buffer.removeAll(keepingCapacity: false)
         chunkOutcomes.removeAll()
         beginTime = nil
+        resolvedLanguage = nil
     }
 
     // MARK: - cut-point logic
@@ -228,16 +236,45 @@ public actor StreamingTranscriber {
     private func transcribeOne(samples: [Float]) async -> ChunkOutcome {
         var options = DecodingOptions()
         options.task = .transcribe
-        options.language = language
         options.verbose = false
         options.withoutTimestamps = true
         if let p = promptTokens, !p.isEmpty {
             options.promptTokens = p
         }
+
+        // Detect-then-lock on the auto path (SPEC-021), via the shared policy.
+        // WhisperKit only detects when `language == nil && detectLanguage`
+        // (the latter defaults false), so without this every chunk silently
+        // prefills English and translates non-English audio. The first auto
+        // chunk detects (reusing its own encoder pass — no extra cost); the
+        // result is locked into `resolvedLanguage` below so later chunks reuse
+        // it and the utterance can't flip language mid-stream. A pinned language
+        // skips detection entirely.
+        //
+        // Limitation: WhisperKit reports `Constants.defaultLanguageCode` ("en")
+        // rather than nil when detection is weak, so we only lock from a chunk
+        // that produced real text (see the `!text.isEmpty` guard below) — a
+        // leading-silence or empty chunk leaves `resolvedLanguage` nil so the
+        // next, content-bearing chunk re-detects instead of pinning "en". The
+        // first emitted chunk is a full ~20s window (`targetChunkSeconds`) where
+        // detection is reliable; pinning a language in Settings removes the risk
+        // entirely. The auto streaming path is not yet benched (no stream-bench
+        // auto option) — tracked in docs/research/accuracy-en-zh-mixed-plan.md.
+        let decision = LanguageDecodePolicy.decide(pinned: language, locked: resolvedLanguage)
+        options.language = decision.language
+        options.detectLanguage = decision.detectLanguage
+
         do {
             let results = try await pipe.transcribe(audioArray: samples, decodeOptions: options)
             let text = results.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-            return ChunkOutcome(text: text, detectedLanguage: results.first?.language, succeeded: true)
+            let detected = results.first?.language
+            // Lock the auto-detected language for the rest of the session, but
+            // only from a chunk that actually transcribed something — an empty
+            // (silence) chunk yields the "en" fallback and must not pin English.
+            if language == nil, resolvedLanguage == nil, !text.isEmpty, let detected {
+                resolvedLanguage = detected
+            }
+            return ChunkOutcome(text: text, detectedLanguage: detected, succeeded: true)
         } catch {
             return ChunkOutcome(text: "", detectedLanguage: nil, succeeded: false)
         }

--- a/Tests/OpenQuackKitTests/LanguageDecodePolicyTests.swift
+++ b/Tests/OpenQuackKitTests/LanguageDecodePolicyTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import OpenQuackPlatform
+
+/// Unit tests for the pinned / locked / auto decision that drives WhisperKit
+/// language handling on both transcription paths (SPEC-021). This is the
+/// regression-prone part of the auto-detect fix; the integration paths that use
+/// it require a loaded model, so the decision itself is covered here in
+/// isolation.
+final class LanguageDecodePolicyTests: XCTestCase {
+    func testPinnedLanguageForcesAndDisablesDetection() {
+        let d = LanguageDecodePolicy.decide(pinned: "zh")
+        XCTAssertEqual(d.language, "zh")
+        XCTAssertFalse(d.detectLanguage)
+    }
+
+    func testPinnedWinsOverLocked() {
+        let d = LanguageDecodePolicy.decide(pinned: "en", locked: "zh")
+        XCTAssertEqual(d.language, "en")
+        XCTAssertFalse(d.detectLanguage)
+    }
+
+    func testLockedReusedWhenNotPinned() {
+        // Streaming: a language detected on an earlier chunk is reused without
+        // re-detecting, so the utterance can't flip language mid-stream.
+        let d = LanguageDecodePolicy.decide(pinned: nil, locked: "zh")
+        XCTAssertEqual(d.language, "zh")
+        XCTAssertFalse(d.detectLanguage)
+    }
+
+    func testNeitherEnablesDetection() {
+        // The core fix: auto + nothing locked ⇒ detection on (the case that was
+        // silently off and caused English translation of non-English speech).
+        let d = LanguageDecodePolicy.decide(pinned: nil, locked: nil)
+        XCTAssertNil(d.language)
+        XCTAssertTrue(d.detectLanguage)
+    }
+
+    func testOfflineDefaultLockedIsNil() {
+        // The offline path calls decide(pinned:) with `locked` defaulting nil.
+        XCTAssertEqual(
+            LanguageDecodePolicy.decide(pinned: nil),
+            LanguageDecodePolicy.decide(pinned: nil, locked: nil)
+        )
+        XCTAssertEqual(
+            LanguageDecodePolicy.decide(pinned: "ja"),
+            LanguageDecodePolicy.decide(pinned: "ja", locked: nil)
+        )
+    }
+
+    func testEmptyStringsTreatedAsAbsent() {
+        // An empty pinned/locked string must not be forced as a language —
+        // WhisperKit would treat "" as a real (invalid) code instead of auto.
+        let d1 = LanguageDecodePolicy.decide(pinned: "")
+        XCTAssertNil(d1.language)
+        XCTAssertTrue(d1.detectLanguage)
+
+        let d2 = LanguageDecodePolicy.decide(pinned: nil, locked: "")
+        XCTAssertNil(d2.language)
+        XCTAssertTrue(d2.detectLanguage)
+    }
+
+    func testOfflineParityWithPriorOneLiner() {
+        // The offline path previously did `detectLanguage = (language == nil)`.
+        // The policy must produce the identical detectLanguage for both cases.
+        XCTAssertFalse(LanguageDecodePolicy.decide(pinned: "en").detectLanguage)
+        XCTAssertTrue(LanguageDecodePolicy.decide(pinned: nil).detectLanguage)
+    }
+}

--- a/docs/research/accuracy-en-zh-mixed-plan.md
+++ b/docs/research/accuracy-en-zh-mixed-plan.md
@@ -1,0 +1,270 @@
+# Accuracy plan — EN / ZH / mixed, holding latency + model size
+
+**Goal:** improve transcription accuracy for English, Chinese, and mixed
+(code-switched) speech while keeping latency low and model size small.
+**Date:** 2026-05-30
+**Status:** L1 (auto-detect fix) **IMPLEMENTED + BENCHED** — see Results. L2–L4
+remain. Every number below is MEASURED on this host; no projected numbers.
+
+**SPEC-021 scope of this change.** This is the engine fix only (the "F-class"
+work in SPEC-021 §PR-2). It does **not** close SPEC-021's other deliverables:
+the categorical failure-mode metrics (`.placeholder`/`.silentTranslation`/
+`.garbled`), the zh_003–008 corpus expansion, or the "≥75% `.ok` rate" acceptance
+criterion — those are bench-infra work tracked as L4 below. The decision logic
+lives in `OpenQuackPlatform/LanguageDecodePolicy.swift` (pure, unit-tested in
+`LanguageDecodePolicyTests`) so both transcription paths share one tested rule.
+
+---
+
+## Correction to repo record (for whoever opens the PR)
+
+**SPEC-021 §"Root cause (hypothesis)" is now factually wrong and should be
+updated.** It hypothesised "Whisper's language token selection during auto-detect
+on short clips is unreliable." The truth, confirmed from WhisperKit 0.18.0
+source: auto-detect was **disabled** in our config (`detectLanguage` defaulted
+`false`), so the decoder never attempted detection — it prefilled English and
+translated. The fix is enabling detection, not working around an unreliable
+detector. SPEC-021's F1/F2/F3 fix candidates are mostly moot (see "dropped F1"
+note). Recommend updating SPEC-021's root-cause section and BENCHMARKS.md's
+"multilingual usage *requires* a language hint" line (auto now works).
+
+---
+
+## Verified ground truth (read directly from source)
+
+Pipeline: `audio → WhisperKit(medium) → raw → TextPolisher.polish → paste`.
+Two decode paths: offline `WhisperKitEngine.transcribe` (<30 s) and streaming
+`StreamingTranscriber` (≥30 s).
+
+1. **Auto-detect is catastrophic and is a user-selectable option.**
+   `SettingsView`: `@AppStorage("language") = "en"` default, with an auto-detect
+   choice the UI itself warns against ("Auto-detect can be unreliable on short
+   utterances"). The fix should make auto *work*, not just warn.
+
+2. **Engine decode options are bare.** `WhisperKitEngine.transcribe` (L296-318):
+   `task=.transcribe`, `language` pass-through, `withoutTimestamps=true`,
+   `promptTokens` from customWords. **No** `supressTokens`, **no** `detectLanguage`
+   handling, **no** threshold/temperature tuning. SPEC-021 fixes unimplemented.
+
+3. **Chinese long-form corrupted at chunk seams.** `StreamingTranscriber`
+   `stitchChunks` (L252-272) joins chunks with `" "` and dedupes by
+   `split(isWhitespace)`. Chinese has no inter-character spaces → every seam
+   injects a spurious ASCII space; boundary-word dedupe never fires for CJK.
+
+4. **`ChineseScript` (Hant↔Hans, ICU) IS wired** — `OpenQuackApp.swift:823,1083`
+   `ChineseScriptConverter.convert(result.text, to: chineseScript)`. (Earlier
+   note that it was dead code was wrong; corrected here.) Default `.auto` = no-op.
+
+5. **ROOT CAUSE CONFIRMED (WhisperKit 0.18.0 source).** The auto-detect failure
+   is not "detection is unreliable" — **detection never runs.**
+   - `TranscribeTask.swift:312`: detection fires only
+     `if textDecoder.isModelMultilingual, options.language == nil, options.detectLanguage`.
+   - `Configurations.swift:226`:
+     `self.detectLanguage = detectLanguage ?? !usePrefillPrompt`, and
+     `usePrefillPrompt` defaults to `true` ⇒ **`detectLanguage` defaults to
+     `false`.**
+   - Our engine builds `DecodingOptions()` with all defaults, so on the auto
+     path (`language == nil`) the guard is false: no detection, the decoder
+     prefills the default English token and silently translates. Exactly the
+     measured result (every clip labelled `en`).
+   - **Fix = one line:** `options.detectLanguage = (options.language == nil)`.
+     The in-decoder detect at `TranscribeTask.swift:313` reuses the already-
+     computed `encoderOutput` (no duplicate encode), so it is cheaper than a
+     separate `pipe.detectLanguage(audioPath:)` pre-pass (which reloads audio +
+     re-encodes). When a language is pinned, the guard stays false and the path
+     is byte-for-byte unchanged → zero overhead.
+
+6. **Bench gaps.** `BenchRunner` calls 2-arg `transcribe` (no customWords) →
+   SPEC-032 `--custom-words` flag absent. No failure-mode metrics (SPEC-021
+   PR-A not landed). Corpus: only `zh_001/zh_002` + ja/ko/es/fr/de×2; no
+   zh_003-008, no EN/ZH code-switch corpus.
+
+---
+
+## MEASURED baseline — `bench/corpus/multilingual`, medium, auto-detect
+
+Run 2026-05-30 on this host (M4, 16 GB reported tag), debug build, no `--language`
+(auto-detect). Reproduces BENCHMARKS.md (253.2% / 156.0%) exactly.
+
+| Clip | ref lang | detected | WER | CER | Preview (note: ENGLISH = silent translation) |
+|---|---|---|---:|---:|---|
+| de_001 | de | en | 100.0% | 74.3% | "Today the weather is really nice." |
+| de_002 | de | en | 122.2% | 66.0% | "I would like a coffee and a piece of cake…" |
+| es_001 | es | en | 100.0% | 78.7% | "Today is a beautiful day to walk…" |
+| es_002 | es | en | 111.1% | 82.2% | "I would like to have a coffee with milk…" |
+| fr_001 | fr | en | 122.2% | 73.8% | "The cat is on the carpet…" |
+| fr_002 | fr | en | 0.0% | 0.0% | "Je voudrais un café…" (correct, by luck) |
+| ja_001 | ja | en | 600.0% | 233.3% | "Today is a very good weather." |
+| ja_002 | ja | en | 700.0% | 173.7% | "The cat always pees in the window." |
+| ko_001 | ko | en | 133.3% | 173.3% | "(speaking in foreign language)" |
+| ko_002 | ko | en | 150.0% | 223.1% | "The weather is really nice today." |
+| zh_001 | zh | en | 350.0% | 380.0% | "Spring is here, the flowers are blooming." |
+| zh_002 | zh | en | 550.0% | 313.3% | "The weather is so nice today, let's go…" |
+| **Aggregate** | | | **253.2%** | **156.0%** | RTF 0.35×, RSS 225 MB, cold 24.4 s |
+
+**Read:** every clip silently translated to English (detected `en`), plus one
+`(speaking in foreign language)` annotation (ko_001) — exactly SPEC-021's modes
+1+2. This is the target to beat with detect-then-decode.
+
+---
+
+## MEASURED results — L1 fix applied (`options.detectLanguage = (language == nil)`)
+
+One line per path. Offline: `WhisperKitEngine.transcribe` sets
+`options.detectLanguage = (language == nil)`. Streaming: `StreamingTranscriber`
+detects on the first auto chunk and locks the result for the rest of the
+session. Same host / model / corpus / debug build as the baseline above.
+
+**Multilingual, auto-detect (the headline win):**
+
+| Metric | Before | After | Δ |
+|---|---:|---:|---|
+| Aggregate WER | 253.2% | **16.7%** | −236 pp |
+| Aggregate CER | 156.0% | **3.7%** | −152 pp |
+| RTF | 0.35× | 0.40× | +0.05× (auto path only) |
+
+Per-clip after: de/es/fr/ja_001/ko/zh_001 all **0.0% WER**, correct language
+token detected (`de`,`es`,`fr`,`ja`,`ko`,`zh` — was `en` for all). Two clips
+(ja_002, zh_002) now decode in-language with CER 31.6% / 13.3% — ordinary ASR
+slips, not translation. (zh_002 emitted Traditional hanzi; the `.auto`
+ChineseScript default leaves it — pinning Simplified in Settings converts it.)
+**16.7% now equals the Lightning engine's multilingual score** → the fix closes
+the entire gap BENCHMARKS.md blamed on "WhisperKit auto-detect being
+unreliable." Detection was never unreliable; it was switched off.
+
+**English regression guards (all MEASURED this session, after = branch):**
+
+| Corpus / path | WER | CER | RTF | Note |
+|---|---:|---:|---:|---|
+| LibriSpeech (real speech), auto | 2.6% | 1.3% | 0.20× | = published BENCHMARKS.md baseline (2.6%/1.3%) → no regression |
+| short TTS, auto (`language==nil`) | 1.3% | 0.7% | 0.34× | tts_005 6.7%, rest 0% — model noise, not the change |
+| short TTS, pinned `--language en` | 1.3% | 0.7% | 0.31× | identical to the auto run above |
+
+English is unchanged. **The pinned path is provably byte-for-byte identical:**
+WhisperKit's `detectLanguage` already defaulted to `false`
+(`detectLanguage ?? !usePrefillPrompt` = `nil ?? !true` = `false`); when a
+language is pinned the policy sets the same `false`. So the default-config path
+that most users run (`@AppStorage("language")` default `"en"`) cannot regress by
+construction. LibriSpeech (the real-speech gold standard) confirms 2.6% → 2.6%.
+Model size unchanged. The **auto** path pays one extra in-decoder detection pass
+— it reuses the existing encoder output (no second encode), so the cost is ~tens
+of ms (visible as short-TTS auto RTF 0.34× vs pinned 0.31×, within run-to-run
+noise on 5 clips). Honest framing: the auto path is slightly slower than pinned,
+the pinned path is unchanged, and accuracy is identical on English either way.
+
+**Custom-words bias survives auto-detect (verified by source reading, not yet
+benched).** With detection on, WhisperKit calls `prefillDecoderInputs` a second
+time after picking the language (`TranscribeTask.swift:326`). That rebuild slices
+`basePrompt = currentTokens[0...startOfTranscriptIndex]` and re-appends
+`options.promptTokens` (`TextDecoder.swift:467-476`); because prompt tokens sit
+*after* the start-of-transcript token, the first prefill's copy is discarded by
+the slice and the custom words are re-applied exactly once — no doubling, no
+loss. This can't be empirically confirmed until `openquack-bench` gains
+`--custom-words` (SPEC-032 crit 4, L4 below), so it ships on source reading.
+
+**Long-form Chinese, offline path, auto-detect (MEASURED).** Synthesised 30.8 s
+Mandarin clip (`say -v Tingting`, 16 kHz mono), `openquack-bench`, medium, no
+`--language`:
+
+| Metric | Value | Note |
+|---|---:|---|
+| Detected language | `zh` | correct (was `en` before the fix) |
+| CER | **12.9%** | the real metric for ZH |
+| WER | 100% | meaningless — Chinese is one whitespace-token; ignore, use CER |
+| RTF | 0.16× | well within budget |
+
+Output: `人工智能正在改变我们的工作方式和生活方式今天的天气真好…`. Inspecting the
+diff, the CER is dominated by **number normalisation**, not recognition errors:
+ref `百分之十五` → `15%`, ref `三点` → `3点`. The actual speech is transcribed
+correctly in Chinese. So long-form Chinese works on the offline path.
+
+**Streaming path (≥30 s) — MEASURED.** This PR adds `openquack-stream-bench
+--language auto` (maps to nil) so the streaming auto path is exercisable; the
+same 30.8 s Mandarin clip, `--mode both --smoke`, 2 chunks. Whitespace-WER is
+meaningless for CJK (reference is one token, so it reads 100% even when perfect),
+so the dispositive signal is the **output text** (full strings in
+`/tmp/oq-stream-auto-{before,after}/report.csv`):
+
+Exact CSV output (verbatim, first clause):
+| | streaming output |
+|---|---|
+| **Before** (pre-fix `StreamingTranscriber`) | `"The artificial intelligence is changing our working and living ways…"` — English translation (stm whitespace-WER 725%) |
+| **After** (fix) | `人工智能正在改变我们的工作方式和生活方式。今天的天气真好,我们出去散步吧。…` — correct Chinese (58%) |
+
+The second chunk correctly **reused** the `zh` locked from chunk 1 (it did not
+re-detect to English or flip), confirming the detect-then-lock mechanism — though
+chunk 2 came back Traditional (`蘋果公司發布…`) while chunk 1 was Simplified, an
+existing ZH-script issue the `.auto` ChineseScript default leaves alone (orthogonal
+to this fix; pinning Simplified in Settings normalises it). Post-stop wait ~4–6 s
+on this 30.8 s clip in smoke mode (no real-time pacing, so not a latency figure).
+The space at the chunk seam (`…材料。 蘋果公司…`) is the **separate L2 issue** —
+`stitchChunks` space-joins CJK chunks; tracked below, not part of this fix.
+Verification method: pre-fix `StreamingTranscriber` checked out from `main`,
+rebuilt against the new bench harness, run with `--language auto`; then the fix
+restored. Both runs used identical bench code, so the delta isolates the engine
+change.
+
+A CER column for stream-bench (to put a number on CJK streaming, not just text)
+remains an L4 follow-up.
+
+**Why this beats a `pipe.detectLanguage()` pre-pass:** the WhisperKit internal
+detect at `TranscribeTask.swift:312` runs inside `decodeWithFallback` on the
+encoder output it already computed (and carries the detected language out via
+`TranscriptionResult.language`, `TranscribeTask.swift:391-396`); a separate
+pre-pass would reload 30 s of audio and re-run the encoder. Same accuracy, half
+the work.
+
+**Dropped from SPEC-021 on purpose:** F1 (suppress the `[` token) — the
+`[SPEAKING …]` placeholders are multi-token, and blanket `[`-suppression would
+corrupt dictated code/brackets (`arr[i]`, `[TODO]`) for the dev audience. The
+annotation failure mode (ko_001 previously emitted the parenthetical
+`(speaking in foreign language)`) is **verified gone** in the after-run —
+ko_001 now scores 0.0% WER with correct Hangul output — because detection picks
+the language token before that fallback can fire. So a separate F3 text-strip is
+not needed for these corpora. If real user logs later show residual placeholders,
+add a *known-vocabulary* strip (preserving real brackets) then.
+
+---
+
+## Levers, ranked by (accuracy gain ÷ latency+size cost)
+
+### L1 — Auto-detect robustness (biggest ZH/mixed win; auto-path-only cost)
+First verify lever 5 above. Then, on the `language == nil` path only:
+- Detect language properly (either `options.detectLanguage = true` if the
+  decoder honours it, or an explicit `pipe.detectLanguage()` pre-pass), then
+  force the detected token. Pinned languages stay free.
+- Targeted strip of `[(SPEAKING|FOREIGN|INAUDIBLE|MUSIC|NOISE|APPLAUSE|…)]`
+  annotations from output — a **known-vocabulary** strip so dictated code/
+  brackets (`arr[i]`, `[TODO]`) survive. (NOT blanket `[`-token suppression —
+  that would corrupt the dev audience's transcripts.)
+- Apply to both paths. **Mixed EN/ZH:** detect+lock dominant language beats the
+  decoder flip-flopping per 30 s window.
+
+### L2 — Chinese chunk stitching (latency-free, long-form ZH)
+`stitchChunks`: when both seam sides are CJK, join with NO space + char-level
+dedupe; keep space-join for Latin.
+
+### L3 — Deterministic CJK post-processing in `TextPolisher` (latency-free)
+Full-width punctuation, strip spurious inter-CJK spaces, optional CJK↔Latin
+pangu spacing for mixed.
+
+### L4 — Bench infra (gate for measuring L1-L3 and the streaming auto path)
+- `openquack-stream-bench`: add `--language auto` (→ nil) so the streaming auto
+  path is benchable, and a **CER column** (today it reports only whitespace-WER,
+  useless for CJK). Without these, the L1 streaming change can't be measured
+  honestly — see the streaming caveat in Results.
+- `openquack-bench`: failure-mode metrics (placeholder/silentTranslation/garbled
+  per SPEC-021), `--custom-words` flag (SPEC-032 crit 4).
+- Corpus: zh_003-008 (SPEC-021) + a small EN/ZH code-switch corpus for mixed.
+  CER primary for ZH.
+
+### Rejected (named, not silently dropped)
+Larger model (size), beam search (latency), network ASR (offline/privacy).
+
+---
+
+## Execution order (each PR cites a SPEC; engine touches carry SPEC-032 table)
+0. Baseline benched ✓ (above).
+1. Verify lever-5 detect mechanism → implement L1 (biggest win).
+2. L2 Chinese stitching. 3. L3 CJK post-processing. 4. L4 bench infra/corpus.
+Re-bench after each; record REAL before/after WER/CER. No projected numbers.


### PR DESCRIPTION
## SPEC

SPEC-021 (Mandarin auto-detect failure) — the engine fix only (the "F-class" work in §PR-2).

## Milestone

M1/M2 boundary.

## Why

The "auto-detect is catastrophic on non-English" behaviour documented in `docs/BENCHMARKS.md` (253% WER on the multilingual corpus) is **not** model unreliability — language detection never runs. WhisperKit gates detection on `DecodingOptions.detectLanguage`, which defaults to `false` (it derives from `!usePrefillPrompt`, and prefill is on by default — see `argmax-oss-swift` `Configurations.swift` init, consumed at `TranscribeTask.swift:312`). Our engine built `DecodingOptions()` with all defaults, so on the auto path (`language == nil`) the decoder silently prefilled the English token and **translated** non-English speech instead of transcribing it. This is the exact failure in issue #17.

## Change

Enable detection on the auto path only, in both transcription paths, via a shared pure helper `OpenQuackPlatform/LanguageDecodePolicy.decide(pinned:locked:)`:

- **pinned** (user picked a language) → force it, detection off
- **locked** (streaming: a language already detected this utterance) → reuse it
- **neither** (auto, first decode) → detection on

- `WhisperKitEngine.transcribe` calls it with `locked = nil` (stateless). The in-decoder detect reuses the already-computed encoder pass — no extra encode.
- `StreamingTranscriber` detects on the first **content-bearing** auto chunk and locks the result (`resolvedLanguage`) so the utterance can't flip language mid-stream; an empty (silence) chunk does not lock, so it can't wrongly pin the `"en"` fallback.
- `openquack-stream-bench` gains `--language auto` (→ nil) so the streaming auto path is benchable.

The decision logic is unit-tested (`LanguageDecodePolicyTests`) since it is the regression-prone part and the integration paths need a loaded model.

**Pinned path is byte-for-byte unchanged:** `detectLanguage` already defaulted to `false`, and a pinned language sets the same `false` — so the default-config path most users run (`@AppStorage("language")` default `"en"`) cannot regress by construction.

## Tests

- [x] unit test added: `LanguageDecodePolicyTests` (7 cases: pinned/locked/auto/empty-string/offline-parity)
- [x] `swift build && swift test` green locally (171 tests, 0 failures)
- [x] bench delta documented (M4-16GB, medium, debug):

| Corpus / path | Before | After |
|---|---|---|
| multilingual auto (12 clips) | **253.2% WER / 156.0% CER** | **16.7% / 3.7%** |
| zh_001 | 350% WER | **0.0%** |
| long-form zh (30.8s, auto) | translated to English | **detects `zh`, CER 12.9%** (mostly `三点`→`3点` number-norm) |
| streaming zh (auto) | "Artificial intelligence is changing…" (English) | **correct Chinese** (chunk 2 reused the `zh` lock) |
| LibriSpeech (20, real EN, after-only) | — | **2.6% WER / 1.3% CER** = published baseline → no regression |
| short TTS (5, auto) | — | 1.3% WER, RTF 0.34× |
| short TTS (5, pinned `--lang en`) | — | 1.3% WER, RTF 0.31× (= auto) |

Every multilingual clip now detects its real language (de/es/fr/ja/ko/zh) instead of `en`. 16.7% matches the previously-published Lightning multilingual figure — the fix closes the whole gap. Whitespace-WER is meaningless for CJK (reference is one token), so CER and the output text are the dispositive signals; full strings are in the run reports.

## Privacy impact

None. No change to audio capture, no network calls, no new data persisted. The `detectLanguage` pass is local CoreML inference on the same encoder output. Privacy contract in `docs/VISION.md` preserved.

## Out of scope

This is the engine fix only. It does **not** close SPEC-021's other deliverables — categorical failure-mode metrics, zh_003–008 corpus expansion, or the "≥75% `.ok`" acceptance criterion. Those, plus L2 (CJK chunk-stitching), L3 (deterministic CJK post-processing), and L4 (stream-bench CER column, `--custom-words`, EN/ZH code-switch corpus) are tracked in `docs/research/accuracy-en-zh-mixed-plan.md`.

**Note for follow-up:** SPEC-021's "Root cause (hypothesis)" section ("detection unreliable") and BENCHMARKS.md's "multilingual requires a language hint" line are now factually wrong (detection was disabled, not unreliable) and should be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
