### PR TITLE
chore: release v2.0.0-alpha.17 (SPEC-021 language-detection fix)

### DIFF
--- a/Casks/openquack.rb
+++ b/Casks/openquack.rb
@@ -1,9 +1,9 @@
 cask "openquack" do
-  version "2.0.0-alpha.16"
+  version "2.0.0-alpha.17"
   # Set per-release by scripts/make_dmg.sh — paste the printed value in
   # before each tag is pushed. `:no_check` is the placeholder while no
   # release has been tagged yet.
-  sha256 "db0838c6c9217662fc171d44b0009a02da4ff5b201a2b7442470e5b36590b972"
+  sha256 "71bab057aca941c8ed426734ae0c9b617c98f5368fab56e10ab47a7b9e9d265b"
 
   url "https://github.com/larryxiao/openquack/releases/download/v#{version}/OpenQuack-#{version}.dmg"
   name "OpenQuack"

--- a/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
+++ b/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
@@ -4,5 +4,5 @@ import Foundation
 /// Carries no UI / KeyboardShortcuts / WhisperKit deps so the bench targets
 /// can build without Xcode-only macro plugins.
 public enum OpenQuackPlatform {
-    public static let version = "2.0.0-alpha.16"
+    public static let version = "2.0.0-alpha.17"
 }


### PR DESCRIPTION
## SPEC

Release chore for SPEC-021 (no new code — version + cask bump only).

## Milestone

M1.

## Why

Cut **v2.0.0-alpha.17** to ship the SPEC-021 language-detection fix (#63) to users. Before the fix, OpenQuack silently translated all non-English dictation to English on auto-detect; now it transcribes correctly.

## Change

- `OpenQuackPlatform.version` → `2.0.0-alpha.17`
- `Casks/openquack.rb` → version + sha256 (`71bab057…`) for the new DMG

## Tests

- [x] `swift build && swift test` green (on #63, the code this releases)
- [x] DMG built via `scripts/make_dmg.sh`, mounts cleanly, app reports `2.0.0-alpha.17`, codesign valid (Apple Development — unsigned for Gatekeeper, same as prior alphas)
- N/A bench delta (no code change in this PR; measured in #63)

## Privacy impact

None — version/cask metadata only.

## Out of scope

Code-signing/notarization (SPEC-025) — this alpha ships unsigned like its predecessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
