### PR TITLE
docs(index): refresh multilingual FAQ for alpha.17

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ macOS Dictation sends audio to Apple's servers by default. OpenQuack runs fully 
 OpenQuack pastes at wherever your cursor is — including the prompt bars of Claude Code, Cursor, Windsurf, or any terminal. Press the hotkey, speak the prompt, press again, and it appears.
 
 **What languages does it support?**
-99 Whisper languages. English is the default; to switch, open Settings → Language. Auto-detect works best on clips longer than 3 seconds and is most reliable when paired with a configured fallback language.
+99 Whisper languages with reliable auto-detect as of [v2.0.0-alpha.17](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.17) — speak Mandarin, Cantonese, Japanese, Korean, French, Spanish, or any of the 99, and OpenQuack identifies and transcribes it correctly without manual selection. Mixed-language dictation (e.g. "*Mon dieu, this PR has 一百 comments*") also works. If you want extra accuracy on very short clips or have a fixed working language, pick it explicitly in Settings → Language.
 
 **Why does the first launch take a long time?**
 The speech model downloads once on first run and is cached permanently in `~/Library/Application Support/OpenQuack/models/`. Every subsequent launch is instant.


### PR DESCRIPTION
## Summary

Updates the `What languages does it support?` FAQ entry on the Pages landing for the SPEC-021 multilingual fix shipped in v2.0.0-alpha.17.

Before: implied auto-detect was unreliable and recommended setting a fallback language as a workaround.

After: states that auto-detect now works reliably across the 99 languages including mixed-language dictation (your "Mon dieu, this PR has 一百 comments" example from the release notes), with explicit language selection positioned as an optional accuracy boost rather than a required workaround.

Pairs with the alpha.17 What's new line you already updated at the top of README.md.

## Test plan

- [ ] Read the new FAQ entry in raw markdown — confirms the framing flip
- [ ] Verify nothing else on docs/index.md still carries the "multilingual is unreliable" caveat
- [ ] Merge → CTA propagates through the Pages site within minutes (Jekyll rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)