### PR TITLE
feat(SPEC-035): mixed-language dictation — system-script normalisation + per-chunk streaming detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Voice dictation for macOS. Nothing leaves your device — audio, text, nothing.
 
 ---
 
-> 📢 **What's new — [v2.0.0-alpha.18](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.18):** Mixed Chinese/English now holds up across a long recording. Start a thought in English and finish it in Chinese — the Chinese comes back as Chinese instead of a botched English translation, normalised to your system's script (Simplified or Traditional). ([past releases](https://github.com/larryxiao/openquack/releases))
+> 📢 **What's new** — full notes on the [Releases page →](https://github.com/larryxiao/openquack/releases)
+>
+> - 🌏 **[v2.0.0-alpha.18](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.18) — code-switch without the chaos.** Start a sentence in English and finish it in 中文: your Chinese now comes back as Chinese across a whole recording, not a garbled English "translation," and it's tidied into your system's script (简体 or 繁體).
+> - 🎧 **[v2.0.0-alpha.17](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.17) — auto-detect that actually detects.** Just talk in any language, no menu-fiddling. Non-English speech stopped getting silently translated to English (253% → 17% WER on the multilingual set).
+> - 🦆 **[v2.0.0-alpha.16](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.16) — updates that get out of your way.** Homebrew upgrades run quietly in the background and relaunch the duck for you — no surprise Terminal window.
 
 ## What it is
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Voice dictation for macOS. Nothing leaves your device — audio, text, nothing.
 
 ---
 
-> 📢 **What's new — [v2.0.0-alpha.17](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.17):** Multilingual auto-detect is now reliable. Say *"bro 这个bug也太离谱了, 鸭鸭我直接躺平了 not today"* and get back exactly that — no language selection needed. ([past releases](https://github.com/larryxiao/openquack/releases))
+> 📢 **What's new — [v2.0.0-alpha.18](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.18):** Mixed Chinese/English now holds up across a long recording. Start a thought in English and finish it in Chinese — the Chinese comes back as Chinese instead of a botched English translation, normalised to your system's script (Simplified or Traditional). ([past releases](https://github.com/larryxiao/openquack/releases))
 
 ## What it is
 

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -38,15 +38,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.string(forKey: "model") ?? "medium"
     }
     private var defaultLanguage: String? {
-        let raw = UserDefaults.standard.string(forKey: "language") ?? "en"
+        let raw = UserDefaults.standard.string(forKey: "language") ?? ""  // default: auto-detect (SPEC-035)
         return raw.isEmpty ? nil : raw  // empty string = auto-detect
     }
     private var customWords: String? {
         UserDefaults.standard.string(forKey: "customWords")
-    }
-    private var chineseScript: ChineseScript {
-        let raw = UserDefaults.standard.string(forKey: "chineseScript") ?? ""
-        return ChineseScript(rawValue: raw) ?? .auto
     }
     private var soundsEnabled: Bool {
         UserDefaults.standard.object(forKey: "playSounds") as? Bool ?? true
@@ -818,9 +814,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     )
                 }
 
-                // Whisper's `zh` output mixes Hant/Hans; honour the user's
-                // script preference before any other text shaping.
-                let scripted = ChineseScriptConverter.convert(result.text, to: chineseScript)
+                // Whisper's `zh` output mixes Hant/Hans; normalise detected
+                // Chinese to the system-language script before any other text
+                // shaping. Gated on `zh` so Japanese/Korean Han is untouched
+                // (SPEC-035).
+                let scripted = ChineseScriptConverter.normalize(
+                    result.text,
+                    language: result.detectedLanguage,
+                    preferredLanguages: Locale.preferredLanguages
+                )
 
                 // Smart formatting on raw Whisper output (capitalisation,
                 // end-punctuation, fillers). Toggle: Settings → General.
@@ -1080,7 +1082,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 language: entry.language,
                 customWords: customWords
             )
-            let scripted = ChineseScriptConverter.convert(result.text, to: chineseScript)
+            let scripted = ChineseScriptConverter.normalize(
+                result.text,
+                language: result.detectedLanguage,
+                preferredLanguages: Locale.preferredLanguages
+            )
             let polishEnabled = UserDefaults.standard.object(forKey: "polishText") as? Bool ?? true
             let polished = polishEnabled ? TextPolisher.polish(scripted) : scripted
             let autoPasteEnabled = UserDefaults.standard.object(forKey: "autoPaste") as? Bool ?? true

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -46,8 +46,7 @@ private struct GeneralPane: View {
     @ObservedObject var appState: AppState
     @AppStorage("autoPaste")           private var autoPaste: Bool = true
     @AppStorage("polishText")          private var polishText: Bool = true
-    @AppStorage("language")            private var language: String = "en"
-    @AppStorage("chineseScript")       private var chineseScript: String = "auto"
+    @AppStorage("language")            private var language: String = ""   // "" = auto-detect (SPEC-035)
     @AppStorage("playSounds")          private var playSounds: Bool = true
     @AppStorage("vadAutoStop")         private var vadAutoStop: Bool = false
     @AppStorage("vadSilenceSeconds")   private var vadSilenceSeconds: Double = 1.5
@@ -123,21 +122,9 @@ private struct GeneralPane: View {
                     Text("Italian (it)").tag("it")
                     Text("Portuguese (pt)").tag("pt")
                 }
-                Text("Auto-detect can be unreliable on short utterances. Set this to your primary language for the most consistent results.")
+                Text("Auto-detect identifies the spoken language for each recording. Pick a specific language only if you always dictate in the same one.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-
-                if language == "zh" {
-                    Picker("Chinese script", selection: $chineseScript) {
-                        Text("Auto (Whisper default — often Traditional)").tag("auto")
-                        Text("Simplified (zh-Hans)").tag("simplified")
-                        Text("Traditional (zh-Hant)").tag("traditional")
-                    }
-                    .help("Whisper's Chinese output mixes Simplified and Traditional. Pick one to force a script.")
-                    Text("Character-level conversion only — region-specific vocabulary (e.g. 软件 vs. 軟體) isn't rewritten.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
             } header: {
                 SectionHeader("Language")
             }

--- a/Sources/OpenQuackKit/Polish/ChineseScript.swift
+++ b/Sources/OpenQuackKit/Polish/ChineseScript.swift
@@ -1,28 +1,90 @@
 import Foundation
 
 /// Whisper's `zh` model emits a mix of Traditional and Simplified hanzi —
-/// often skewing Traditional, even when the speaker is from the mainland.
-/// This converter applies a character-level Hant↔Hans pass via ICU
-/// (`StringTransform("Hant-Hans")`) so the script the user sees matches the
-/// script they expect.
+/// often skewing Traditional, even when the speaker is from the mainland, and
+/// the script can flip between streaming chunks of one utterance. This type
+/// picks the script to normalise toward (Traditional / Simplified) from the
+/// user's macOS language preferences; `ChineseScriptConverter` applies a
+/// character-level Hant↔Hans pass via ICU (`StringTransform`).
 ///
 /// Caveat: ICU is character-level. `軟體` becomes `软体` rather than the
 /// idiomatic mainland `软件`. Word-level conversion (OpenCC) is a future
 /// upgrade; this fixes the script-mismatch case without adding a C++ dep.
 public enum ChineseScript: String, Sendable, CaseIterable {
-    case auto         // leave Whisper output untouched
-    case simplified   // force zh-Hans
-    case traditional  // force zh-Hant
+    case simplified   // zh-Hans
+    case traditional  // zh-Hant
+
+    /// Script implied by the user's macOS language preferences. Reads
+    /// `Locale.preferredLanguages` at the call site; the mapping itself lives
+    /// in `resolve(preferredLanguages:)` so it can be unit-tested.
+    public static var systemDefault: ChineseScript {
+        resolve(preferredLanguages: Locale.preferredLanguages)
+    }
+
+    /// Pure mapping from an ordered BCP-47 preferred-language list to a
+    /// concrete script. Scans for the first Chinese entry (the picker only
+    /// matters for Chinese speakers, so an English-primary user who also lists
+    /// Traditional Chinese should still get Traditional). Defaults to
+    /// Simplified when the list names no Chinese locale.
+    ///
+    /// The region table is authoritative: `Locale.Language(identifier:).script`
+    /// is not reliably populated on region-only forms (`zh-HK`, `zh-TW`)
+    /// without likely-subtag maximisation, so correctness never depends on it —
+    /// an explicit script subtag is honoured when present, otherwise we fall
+    /// back to the region.
+    public static func resolve(preferredLanguages: [String]) -> ChineseScript {
+        for identifier in preferredLanguages {
+            let language = Locale.Language(identifier: identifier)
+            guard language.languageCode?.identifier == "zh" else { continue }
+
+            if let script = language.script?.identifier {
+                return script == "Hant" ? .traditional : .simplified
+            }
+            if let region = language.region?.identifier,
+               ["TW", "HK", "MO"].contains(region) {
+                return .traditional
+            }
+            return .simplified
+        }
+        return .simplified
+    }
 }
 
 public enum ChineseScriptConverter {
-    /// Returns text converted to the target script. `auto` is a no-op and
-    /// non-Chinese text is returned unchanged. Idempotent: applying the
-    /// same target twice yields the same result.
+    /// Languages whose script is Han but *not* Chinese: Japanese kanji and
+    /// Korean hanja share code points with hanzi, so the ICU Hant↔Hans
+    /// transform would silently corrupt them. Output resolved to one of these
+    /// is left byte-for-byte unchanged; everything else is converted.
+    private static let hanButNotChinese: Set<String> = ["ja", "ko"]
+
+    /// Normalise transcription output to the system's Chinese script. The ICU
+    /// transform is a no-op on every non-Han character (Latin, digits,
+    /// punctuation — see `testNonChineseUnchanged`), so we can safely convert
+    /// *any* output that isn't Japanese/Korean: a mixed-language utterance
+    /// transcribed as `en` (e.g. "Hello 軟體") still gets its embedded Chinese
+    /// normalised, while pure English passes through untouched. Only `ja`/`ko`
+    /// are excluded, to protect their kanji/hanja. `nil` (detection unknown)
+    /// converts — there's nothing to corrupt unless the text is actually
+    /// Japanese/Korean, which would have been detected as such.
+    ///
+    /// We deliberately do *not* alter the decode path to force Chinese on a
+    /// mixed utterance; we only reshape the characters Whisper already emitted.
+    /// Pure: the target script is derived from the supplied preferred-languages
+    /// list.
+    public static func normalize(
+        _ text: String,
+        language: String?,
+        preferredLanguages: [String]
+    ) -> String {
+        if let language, hanButNotChinese.contains(language) { return text }
+        return convert(text, to: ChineseScript.resolve(preferredLanguages: preferredLanguages))
+    }
+
+    /// Converts text to the target script via ICU. Non-Chinese characters and
+    /// already-target characters pass through unchanged; idempotent.
     public static func convert(_ text: String, to target: ChineseScript) -> String {
         let transform: StringTransform
         switch target {
-        case .auto:        return text
         case .simplified:  transform = StringTransform(rawValue: "Hant-Hans")
         case .traditional: transform = StringTransform(rawValue: "Hans-Hant")
         }

--- a/Sources/OpenQuackPlatform/LanguageDecodePolicy.swift
+++ b/Sources/OpenQuackPlatform/LanguageDecodePolicy.swift
@@ -44,4 +44,49 @@ public enum LanguageDecodePolicy {
         }
         return Decision(language: nil, detectLanguage: true)
     }
+
+    /// Per-chunk decision for the streaming path (SPEC-035, mixed-language).
+    ///
+    /// The old rule locked the language to the first chunk for the whole
+    /// session, so an utterance that switched language mid-recording (English
+    /// then Chinese) was forced to the first language and the rest was
+    /// mistranscribed. The opposite extreme — re-detect every chunk — re-exposes
+    /// the weak-detection failure that lock was added to fix: WhisperKit returns
+    /// the `"en"` fallback (not nil) when detection is unsure, so a short,
+    /// low-content chunk can silently flip a monolingual recording's tail to the
+    /// wrong language.
+    ///
+    /// The middle ground keys off chunk duration. Interior chunks are always
+    /// ≥ `targetChunkSeconds` (the cutter never emits shorter), long enough for
+    /// reliable language ID, so they **re-detect** — that's what lets the
+    /// language switch at a chunk boundary. Only the trailing partial chunk can
+    /// be short; below `minDetectSeconds` it **inherits** the running language
+    /// instead of risking a misdetect. The first chunk has nothing to inherit,
+    /// so a (rare) short first chunk still detects.
+    ///
+    /// - Parameters:
+    ///   - pinned: user-selected language, or nil for auto.
+    ///   - running: the language detected on the most recent full chunk, or nil.
+    ///   - chunkSeconds: duration of the chunk about to be decoded.
+    ///   - minDetectSeconds: shortest chunk we trust to re-detect.
+    public static func decideStreamingChunk(
+        pinned: String?,
+        running: String?,
+        chunkSeconds: Double,
+        minDetectSeconds: Double
+    ) -> Decision {
+        if let pinned, !pinned.isEmpty {
+            return Decision(language: pinned, detectLanguage: false)
+        }
+        // Full chunk → re-detect, so the language can change mid-recording.
+        if chunkSeconds >= minDetectSeconds {
+            return Decision(language: nil, detectLanguage: true)
+        }
+        // Short tail chunk → inherit rather than risk a weak-detection flip.
+        if let running, !running.isEmpty {
+            return Decision(language: running, detectLanguage: false)
+        }
+        // Nothing to inherit (short first chunk): detect anyway.
+        return Decision(language: nil, detectLanguage: true)
+    }
 }

--- a/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
+++ b/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
@@ -4,5 +4,5 @@ import Foundation
 /// Carries no UI / KeyboardShortcuts / WhisperKit deps so the bench targets
 /// can build without Xcode-only macro plugins.
 public enum OpenQuackPlatform {
-    public static let version = "2.0.0-alpha.17"
+    public static let version = "2.0.0-alpha.18"
 }

--- a/Sources/OpenQuackStreamBench/OpenQuackStreamBenchCommand.swift
+++ b/Sources/OpenQuackStreamBench/OpenQuackStreamBenchCommand.swift
@@ -49,6 +49,10 @@ struct OpenQuackStreamBenchCommand: AsyncParsableCommand {
             help: "Streaming max chunk seconds. Default 28.")
     var maxChunk: Double = 28
 
+    @Option(name: .customLong("min-detect"),
+            help: "Shortest chunk the auto path re-detects on (SPEC-035). Default 10. A very large value (e.g. 9999) reproduces the old lock-to-first-chunk behaviour for A/B.")
+    var minDetect: Double = 10
+
     @Flag(name: .customLong("smoke"),
           help: "Streaming mode without real-time pacing — fastest correctness check; not a latency measurement.")
     var smoke: Bool = false
@@ -215,7 +219,8 @@ struct OpenQuackStreamBenchCommand: AsyncParsableCommand {
         let cfg = StreamingTranscriber.Config(
             streamingThreshold: 0,                // bench drives every clip; gate is the caller's job
             targetChunkSeconds: targetChunk,
-            maxChunkSeconds: maxChunk
+            maxChunkSeconds: maxChunk,
+            minDetectSeconds: minDetect
         )
         let streamer = StreamingTranscriber(pipe: pipe, config: cfg)
         await streamer.begin(language: resolvedLanguage, customWords: nil)

--- a/Sources/OpenQuackStreaming/StreamingTranscriber.swift
+++ b/Sources/OpenQuackStreaming/StreamingTranscriber.swift
@@ -25,19 +25,28 @@ public actor StreamingTranscriber {
         /// Cap on chunks transcribing at once. Default 1: bumping it gives
         /// headroom against RTF spikes at the cost of double peak RAM.
         public var maxInFlightChunks: Int
+        /// Shortest chunk the auto path trusts to re-detect language on
+        /// (SPEC-035). Interior chunks are ≥ `targetChunkSeconds` and always
+        /// re-detect; a trailing chunk shorter than this inherits the running
+        /// language instead of risking a weak-detection flip. Default 10 s —
+        /// comfortably above Whisper's reliable language-ID floor while still
+        /// well under a full chunk, so only genuinely short tails inherit.
+        public var minDetectSeconds: TimeInterval
 
         public init(
             streamingThreshold: TimeInterval = 30,
             targetChunkSeconds: TimeInterval = 20,
             maxChunkSeconds: TimeInterval = 28,
             silenceEnergyThreshold: Float = 0.02,
-            maxInFlightChunks: Int = 1
+            maxInFlightChunks: Int = 1,
+            minDetectSeconds: TimeInterval = 10
         ) {
             self.streamingThreshold = streamingThreshold
             self.targetChunkSeconds = targetChunkSeconds
             self.maxChunkSeconds = maxChunkSeconds
             self.silenceEnergyThreshold = silenceEnergyThreshold
             self.maxInFlightChunks = maxInFlightChunks
+            self.minDetectSeconds = minDetectSeconds
         }
     }
 
@@ -59,11 +68,11 @@ public actor StreamingTranscriber {
     private var bufferStartSample: Int = 0
     private var beginTime: Date?
     private var language: String?
-    /// On the auto path (`language == nil`), the language detected on the first
-    /// chunk, reused for every subsequent chunk so the whole utterance decodes
-    /// in one consistent language instead of WhisperKit re-detecting (and
-    /// possibly flipping) per chunk (SPEC-021).
-    private var resolvedLanguage: String?
+    /// On the auto path (`language == nil`), the language detected on the most
+    /// recent *full* chunk. Full chunks re-detect (so a mid-recording language
+    /// switch is honoured); a short trailing chunk inherits this instead of
+    /// risking a weak-detection flip (SPEC-035, `decideStreamingChunk`).
+    private var runningLanguage: String?
     private var promptTokens: [Int]?
     private var ended: Bool = false
     private var cancelled: Bool = false
@@ -110,7 +119,7 @@ public actor StreamingTranscriber {
         cancelled = false
         beginTime = Date()
         self.language = language
-        self.resolvedLanguage = nil
+        self.runningLanguage = nil
         self.promptTokens = encodePrompt(customWords: customWords)
     }
 
@@ -163,7 +172,7 @@ public actor StreamingTranscriber {
         buffer.removeAll(keepingCapacity: false)
         chunkOutcomes.removeAll()
         beginTime = nil
-        resolvedLanguage = nil
+        runningLanguage = nil
     }
 
     // MARK: - cut-point logic
@@ -242,25 +251,24 @@ public actor StreamingTranscriber {
             options.promptTokens = p
         }
 
-        // Detect-then-lock on the auto path (SPEC-021), via the shared policy.
-        // WhisperKit only detects when `language == nil && detectLanguage`
-        // (the latter defaults false), so without this every chunk silently
-        // prefills English and translates non-English audio. The first auto
-        // chunk detects (reusing its own encoder pass — no extra cost); the
-        // result is locked into `resolvedLanguage` below so later chunks reuse
-        // it and the utterance can't flip language mid-stream. A pinned language
-        // skips detection entirely.
-        //
-        // Limitation: WhisperKit reports `Constants.defaultLanguageCode` ("en")
-        // rather than nil when detection is weak, so we only lock from a chunk
-        // that produced real text (see the `!text.isEmpty` guard below) — a
-        // leading-silence or empty chunk leaves `resolvedLanguage` nil so the
-        // next, content-bearing chunk re-detects instead of pinning "en". The
-        // first emitted chunk is a full ~20s window (`targetChunkSeconds`) where
-        // detection is reliable; pinning a language in Settings removes the risk
-        // entirely. The auto streaming path is not yet benched (no stream-bench
-        // auto option) — tracked in docs/research/accuracy-en-zh-mixed-plan.md.
-        let decision = LanguageDecodePolicy.decide(pinned: language, locked: resolvedLanguage)
+        // Per-chunk language decision on the auto path (SPEC-035). WhisperKit
+        // only detects when `language == nil && detectLanguage` (the latter
+        // defaults false), so without this every chunk silently prefills English
+        // and translates non-English audio (SPEC-021). Rather than lock the whole
+        // session to the first chunk — which forces a mid-recording language
+        // switch back to the original language — each *full* chunk re-detects,
+        // and only a short trailing chunk inherits the running language (it can
+        // be too short for reliable detection, and WhisperKit returns the "en"
+        // fallback when unsure). A pinned language skips detection entirely. See
+        // `decideStreamingChunk` for the rationale and SPEC-035 §Streaming for
+        // the before/after bench.
+        let chunkSeconds = Double(samples.count) / Double(sampleRate)
+        let decision = LanguageDecodePolicy.decideStreamingChunk(
+            pinned: language,
+            running: runningLanguage,
+            chunkSeconds: chunkSeconds,
+            minDetectSeconds: config.minDetectSeconds
+        )
         options.language = decision.language
         options.detectLanguage = decision.detectLanguage
 
@@ -268,11 +276,12 @@ public actor StreamingTranscriber {
             let results = try await pipe.transcribe(audioArray: samples, decodeOptions: options)
             let text = results.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
             let detected = results.first?.language
-            // Lock the auto-detected language for the rest of the session, but
-            // only from a chunk that actually transcribed something — an empty
-            // (silence) chunk yields the "en" fallback and must not pin English.
-            if language == nil, resolvedLanguage == nil, !text.isEmpty, let detected {
-                resolvedLanguage = detected
+            // Update the running language only from a chunk that actually
+            // re-detected (a full chunk) and produced text — a short inherited
+            // chunk must not overwrite it, and an empty (silence) chunk yields
+            // the "en" fallback and must not pin English.
+            if language == nil, decision.detectLanguage, !text.isEmpty, let detected {
+                runningLanguage = detected
             }
             return ChunkOutcome(text: text, detectedLanguage: detected, succeeded: true)
         } catch {

--- a/Tests/OpenQuackKitTests/ChineseScriptTests.swift
+++ b/Tests/OpenQuackKitTests/ChineseScriptTests.swift
@@ -2,10 +2,7 @@ import XCTest
 @testable import OpenQuackKit
 
 final class ChineseScriptTests: XCTestCase {
-    func testAutoIsNoOp() {
-        let mixed = "今天的軟體更新有点慢"
-        XCTAssertEqual(ChineseScriptConverter.convert(mixed, to: .auto), mixed)
-    }
+    // MARK: convert (ICU transform)
 
     func testTraditionalToSimplified() {
         let trad = "繁體中文軟體與計算機技術"
@@ -21,10 +18,7 @@ final class ChineseScriptTests: XCTestCase {
 
     func testIdempotentSimplified() {
         let already = "已经是简体的句子"
-        XCTAssertEqual(
-            ChineseScriptConverter.convert(already, to: .simplified),
-            already
-        )
+        XCTAssertEqual(ChineseScriptConverter.convert(already, to: .simplified), already)
     }
 
     func testNonChineseUnchanged() {
@@ -36,5 +30,93 @@ final class ChineseScriptTests: XCTestCase {
     func testEmptyString() {
         XCTAssertEqual(ChineseScriptConverter.convert("", to: .simplified), "")
         XCTAssertEqual(ChineseScriptConverter.convert("", to: .traditional), "")
+    }
+
+    // MARK: resolve (system-language → script). Machine-independent: the
+    // input list is supplied, not read from the host locale.
+
+    func testResolveTraditionalLocales() {
+        for id in ["zh-Hant", "zh-Hant-TW", "zh-TW", "zh-HK", "zh-MO"] {
+            XCTAssertEqual(
+                ChineseScript.resolve(preferredLanguages: [id]), .traditional,
+                "\(id) should resolve Traditional"
+            )
+        }
+    }
+
+    func testResolveSimplifiedLocales() {
+        for id in ["zh-Hans", "zh-Hans-CN", "zh-CN", "zh-SG", "zh"] {
+            XCTAssertEqual(
+                ChineseScript.resolve(preferredLanguages: [id]), .simplified,
+                "\(id) should resolve Simplified"
+            )
+        }
+    }
+
+    func testResolveDefaultsSimplifiedForNonChineseOrEmpty() {
+        XCTAssertEqual(ChineseScript.resolve(preferredLanguages: ["en-US"]), .simplified)
+        XCTAssertEqual(ChineseScript.resolve(preferredLanguages: []), .simplified)
+    }
+
+    func testResolveFirstChineseEntryWins() {
+        XCTAssertEqual(
+            ChineseScript.resolve(preferredLanguages: ["en-US", "zh-Hant-TW"]), .traditional
+        )
+        XCTAssertEqual(
+            ChineseScript.resolve(preferredLanguages: ["en-US", "zh-Hans-CN"]), .simplified
+        )
+    }
+
+    // MARK: normalize (language-gated entry point used by the app)
+
+    func testNormalizeConvertsDetectedChinese() {
+        // System prefers Traditional → mixed/Simplified zh output is forced Traditional.
+        XCTAssertEqual(
+            ChineseScriptConverter.normalize("软件", language: "zh", preferredLanguages: ["zh-Hant-TW"]),
+            "軟件"
+        )
+        // System prefers Simplified → Traditional zh output is forced Simplified.
+        XCTAssertEqual(
+            ChineseScriptConverter.normalize("軟體", language: "zh", preferredLanguages: ["zh-Hans-CN"]),
+            "软体"
+        )
+    }
+
+    func testNormalizeProtectsJapaneseKorean() {
+        // Japanese kanji / Korean hanja share code points with hanzi; the gate
+        // must spare them even when the system locale is Chinese. "繁體" would
+        // become "繁体" if the transform ran — it must not.
+        let han = "繁體"
+        XCTAssertEqual(ChineseScriptConverter.normalize(han, language: "ja", preferredLanguages: ["zh-Hans-CN"]), han)
+        XCTAssertEqual(ChineseScriptConverter.normalize(han, language: "ko", preferredLanguages: ["zh-Hans-CN"]), han)
+    }
+
+    func testNormalizeConvertsEnglishAndUnknownStreams() {
+        // Mixed-language handling: a stream transcribed as `en` (or with
+        // detection unknown) may still carry Chinese characters — those get
+        // normalised to the system script. Pure English/Latin passes through
+        // because the ICU transform is a no-op on non-Han characters.
+        XCTAssertEqual(
+            ChineseScriptConverter.normalize("繁體", language: "en", preferredLanguages: ["zh-Hans-CN"]),
+            "繁体"
+        )
+        XCTAssertEqual(
+            ChineseScriptConverter.normalize("繁體", language: nil, preferredLanguages: ["zh-Hans-CN"]),
+            "繁体"
+        )
+        XCTAssertEqual(
+            ChineseScriptConverter.normalize("Hello, world!", language: "en", preferredLanguages: ["zh-Hans-CN"]),
+            "Hello, world!"
+        )
+    }
+
+    func testNormalizeMixedLatinAndChinese() {
+        // The motivating case: English-detected utterance with an embedded
+        // Traditional phrase, system prefers Simplified → English untouched,
+        // Chinese normalised in place.
+        XCTAssertEqual(
+            ChineseScriptConverter.normalize("I use 軟體 daily", language: "en", preferredLanguages: ["zh-Hans-CN"]),
+            "I use 软体 daily"
+        )
     }
 }

--- a/Tests/OpenQuackKitTests/LanguageDecodePolicyTests.swift
+++ b/Tests/OpenQuackKitTests/LanguageDecodePolicyTests.swift
@@ -65,4 +65,60 @@ final class LanguageDecodePolicyTests: XCTestCase {
         XCTAssertFalse(LanguageDecodePolicy.decide(pinned: "en").detectLanguage)
         XCTAssertTrue(LanguageDecodePolicy.decide(pinned: nil).detectLanguage)
     }
+
+    // MARK: - decideStreamingChunk (SPEC-035 mixed-language)
+
+    func testStreamingPinnedForcesEvenOnShortChunk() {
+        // A user-pinned language always wins, regardless of chunk size / running.
+        let d = LanguageDecodePolicy.decideStreamingChunk(
+            pinned: "en", running: "zh", chunkSeconds: 2, minDetectSeconds: 10
+        )
+        XCTAssertEqual(d.language, "en")
+        XCTAssertFalse(d.detectLanguage)
+    }
+
+    func testStreamingFullChunkReDetectsDespiteRunning() {
+        // The un-locking: a full chunk re-detects even when a language is already
+        // running, so the language can switch at a chunk boundary.
+        let d = LanguageDecodePolicy.decideStreamingChunk(
+            pinned: nil, running: "en", chunkSeconds: 20, minDetectSeconds: 10
+        )
+        XCTAssertNil(d.language)
+        XCTAssertTrue(d.detectLanguage)
+    }
+
+    func testStreamingShortChunkInheritsRunning() {
+        // A short trailing chunk inherits the running language rather than risk a
+        // weak-detection flip to the "en" fallback.
+        let d = LanguageDecodePolicy.decideStreamingChunk(
+            pinned: nil, running: "zh", chunkSeconds: 3, minDetectSeconds: 10
+        )
+        XCTAssertEqual(d.language, "zh")
+        XCTAssertFalse(d.detectLanguage)
+    }
+
+    func testStreamingShortChunkWithNoRunningDetects() {
+        // Nothing to inherit (e.g. a short first chunk) → detect anyway.
+        let d = LanguageDecodePolicy.decideStreamingChunk(
+            pinned: nil, running: nil, chunkSeconds: 3, minDetectSeconds: 10
+        )
+        XCTAssertNil(d.language)
+        XCTAssertTrue(d.detectLanguage)
+    }
+
+    func testStreamingEmptyRunningTreatedAsAbsent() {
+        let d = LanguageDecodePolicy.decideStreamingChunk(
+            pinned: "", running: "", chunkSeconds: 3, minDetectSeconds: 10
+        )
+        XCTAssertNil(d.language)
+        XCTAssertTrue(d.detectLanguage)
+    }
+
+    func testStreamingThresholdIsInclusive() {
+        // chunkSeconds == minDetectSeconds re-detects (the boundary is reliable).
+        let d = LanguageDecodePolicy.decideStreamingChunk(
+            pinned: nil, running: "en", chunkSeconds: 10, minDetectSeconds: 10
+        )
+        XCTAssertTrue(d.detectLanguage)
+    }
 }

--- a/docs/SPECS/README.md
+++ b/docs/SPECS/README.md
@@ -55,10 +55,11 @@ column tracks *implementation* state, which is what the roadmap drives against:
 | [SPEC-031](SPEC-031-agent-kickoff.md) | Agent kickoff (one-shot voice-to-action) | shipped | M2 |
 | [SPEC-031a](SPEC-031a-voice-reply.md) | Voice reply to live agent sessions | draft | M2 |
 | [SPEC-032](SPEC-032-engine-prompt-token-cache.md) | Engine prompt-token cache (offline path parity) | draft | M1 |
+| [SPEC-035](SPEC-035-chinese-script-system-default.md) | Auto-normalise Chinese script + mixed-language streaming detection | shipped | M3 |
 
-> Next free spec IDs: **SPEC-033, SPEC-034** (reserved for the two open docs PRs
-> #41 Pages analytics → 033 and #42 install-count → 034, pending renumber). IDs
-> are global and monotonic — never reuse 028/029/031/032.
+> Next free spec ID: **SPEC-036**. SPEC-033 / SPEC-034 stay reserved for the two
+> open docs PRs (#41 Pages analytics → 033, #42 install-count → 034, pending
+> renumber). IDs are global and monotonic — never reuse 028/029/031/032/035.
 
 ## Spec lifecycle
 

--- a/docs/SPECS/SPEC-035-chinese-script-system-default.md
+++ b/docs/SPECS/SPEC-035-chinese-script-system-default.md
@@ -1,0 +1,193 @@
+# SPEC-035 — Auto-normalise Chinese script to the system language
+
+**Status:** ratified — implemented 2026-06-02 (shipping in v2.0.0-alpha.18)
+**Owner:** `Sources/OpenQuackKit/Polish/ChineseScript.swift`,
+`OpenQuackPlatform/LanguageDecodePolicy.swift`,
+`OpenQuackStreaming/StreamingTranscriber.swift`, + `OpenQuackApp`
+**Last updated:** 2026-06-02
+
+## Goal
+
+Whisper's `zh` model emits a mix of Traditional and Simplified hanzi —
+often skewing Traditional even for a mainland speaker, and the script can
+flip between streaming chunks of one utterance. Today the only fix is a
+manual Settings picker (`ChineseScript` = auto / simplified / traditional)
+that defaults to `auto` (no-op), so most users see inconsistent script and
+never discover the control.
+
+This spec makes script normalisation **automatic and configuration-free**:
+when the transcription language is Chinese, the output is normalised to the
+script implied by the user's macOS language preferences (Traditional for a
+Traditional-Chinese system, Simplified otherwise — including non-Chinese
+systems). No picker; it just happens.
+
+## Behaviour
+
+1. **Language is auto-detected** (the default). Post-SPEC-021 the auto path
+   reliably labels Chinese as `zh`. A user who pins a language in Settings
+   still works — the rule keys off the *resolved* language, pinned or
+   detected.
+2. **Convert the characters, don't touch the transcription.** The conversion
+   is an ICU character-level `Hant↔Hans` transform, applied to whatever Whisper
+   already emitted — we never alter the decode path to force a language. The
+   transform is a no-op on every non-Han character (Latin, digits, punctuation),
+   so it is safe to run on *any* output **except** Japanese (`ja`) and Korean
+   (`ko`): their kanji/hanja share code points with hanzi and would be corrupted.
+   The normaliser therefore skips only `ja`/`ko`; `zh`, `en`, `nil`, and mixed
+   output all pass through the transform, with non-Chinese characters untouched.
+
+   This is what handles **mixed language**: an utterance transcribed as `en`
+   that carries embedded Chinese (e.g. "I use 軟體 daily") still gets its hanzi
+   normalised to the system script, while the English is left exactly as-is.
+
+   **Verified (2026-05-31, `medium`, offline auto-detect, M4-16GB).** An
+   English-dominant ~8 s clip with an embedded Mandarin phrase transcribed as
+   `language=en` with the Chinese emitted *as hanzi* inline (not translated):
+   `…It goes like this. 你好世界,今天天气很好。 Isn't that…`. Feeding that exact
+   string through the converter for a Traditional system flips `天气→天氣`
+   while the English stays byte-for-byte identical; a Simplified system leaves
+   it. The old `== "zh"` gate skipped this `en`-labelled output entirely. (The
+   decoder does **not** always translate embedded Chinese away — so the
+   mixed-language win is real on the offline path. The streaming path needs the
+   companion change in *Streaming* below to decode the switch as Chinese in the
+   first place.)
+3. **Target script = system language, default Simplified.** Resolved from
+   `Locale.preferredLanguages`, scanning for the first Chinese entry:
+   - explicit `Hant` script subtag, or region ∈ {TW, HK, MO} → **Traditional**
+   - explicit `Hans` subtag, region ∈ {CN, SG}, or bare `zh` → **Simplified**
+   - no Chinese entry in the system preferences → **Simplified**
+
+   The region table is the source of truth: `Locale.Language(identifier:)`
+   does not reliably populate `.script` on region-only forms like `zh-HK`
+   without likely-subtag maximisation, so we never depend on it.
+
+## Non-goals
+
+- **Word-level conversion.** ICU is character-level: Traditional `軟體`
+  becomes `软体`, not the idiomatic mainland `软件`. Word-level (OpenCC) is a
+  future upgrade; out of scope here (no C++ dep).
+- **A script picker / per-locale override.** Removed for simplicity. If
+  Traditional-on-a-Simplified-system demand shows up, revisit.
+- **Cantonese vs Mandarin.** Whisper labels both `zh`; no separate handling.
+- **Japanese/Korean Han under a mislabelled decode.** The skip-list keys off the
+  *detected* language, so genuine kanji/hanja that surface under a non-`ja`/`ko`
+  label (e.g. a Japanese name in an utterance detected `en`) would be converted.
+  Accepted: that requires both a detection miss and embedded CJK, and the
+  alternative (never convert outside `zh`) loses the mixed-language win.
+- **In-clip switching on the offline (<30 s) path.** The offline decode runs
+  one language detection for the whole clip, so a short utterance that switches
+  language mid-sentence is decoded under a single language. Whichever side the
+  detector picks is transcribed faithfully (and embedded characters of the other
+  language often survive — see the Behaviour §2 example); forcing a second
+  decode is out of scope. The *streaming* path (≥30 s) does re-detect per chunk —
+  see *Streaming* below.
+
+## Streaming: per-chunk language detection
+
+The streaming path (≥30 s) used to detect the language on the first chunk and
+**lock** it for the whole recording (SPEC-021). That kept a monolingual
+utterance from flipping language mid-stream, but it also meant an utterance that
+genuinely switched language — start in English, finish in Chinese — was forced
+to the first language: the Chinese tail came back as an English *translation*,
+with no hanzi to normalise.
+
+Per-chunk re-detection is the fix, but the naive version (re-detect every chunk)
+re-opens the failure the lock was added for: WhisperKit returns the `"en"`
+fallback — not `nil` — when detection is weak, so a short, low-content chunk can
+silently flip a monolingual recording's tail to the wrong language.
+
+**Middle ground (keyed off chunk duration).** The cutter never emits an interior
+chunk shorter than `targetChunkSeconds` (20 s), which is plenty for reliable
+language ID — so **full chunks re-detect** (that's what lets the language switch
+at a boundary), and only the trailing partial chunk, if it is below
+`minDetectSeconds` (default 10 s), **inherits** the running language instead of
+risking a misdetect. The first chunk has nothing to inherit, so a rare short
+first chunk still detects. The whole decision is the pure, unit-tested
+`LanguageDecodePolicy.decideStreamingChunk`; a pinned language skips detection
+entirely as before.
+
+**Bench (2026-06-02, `medium`, streaming auto, smoke, M4-16GB).** A/B via
+`openquack-stream-bench --min-detect 10` (new) vs `9999` (reproduces the lock),
+same clips, same process:
+
+| Clip | Old (lock) | New (per-chunk) |
+|---|---|---|
+| `en_long` 49 s monolingual EN | WER 3.7% | WER 3.7%, **byte-identical output** |
+| `zh_long` 37 s monolingual ZH | hanzi | hanzi, **byte-identical output** |
+| `codeswitch` 53 s EN→ZH | Chinese tail **translated to English** (no hanzi) | Chinese tail decoded as **hanzi** (`…最近我还在尝试用它来朗读和整理我的读书笔记…`) |
+
+No regression on either monolingual case; the code-switch tail goes from an
+English mistranslation to correct Chinese, which the normaliser above then puts
+in the system script. (Smoke mode has no real-time pacing, so its post-stop wait
+is not a latency figure — SPEC-012 owns that.)
+
+**Known limitation.** A switch confined to the final < `minDetectSeconds` (10 s)
+of audio lands in the short trailing chunk, which inherits rather than detects,
+so that brief tail is missed. Catching it would mean trusting detection on very
+short chunks — the exact regression the lock guarded against — so the tradeoff is
+deliberate. A switch that occupies a full chunk (the normal case for a real
+language change) is caught.
+
+## Interaction with the default language mode
+
+For the feature to apply out of the box, the default transcription language
+moves from pinned-`en` to **auto-detect** (`""`). This is really SPEC-021's
+domain (the detection mechanism), folded in here for one coherent change.
+
+The legacy Settings caption ("Auto-detect can be unreliable on short
+utterances…") predates the SPEC-021 alpha.17 fix (caption 2026-04-27; fix
+2026-05-31) and is stale. **Gate the default flip on a bench:** run
+`openquack-bench --models tiny --corpus bench/corpus/short` with
+`--language en` vs auto and compare EN WER. SPEC-021 validated the
+non-English failure modes, not EN short-clip misdetection specifically, so
+this is the gap worth measuring.
+
+- EN WER unchanged → flip the default **and** update the stale caption.
+- EN WER regresses → keep the pinned-`en` default; normalisation still
+  applies whenever the user is on auto-detect or pins `zh`. Report the delta.
+
+**Bench result (2026-05-31, `medium` on `bench/corpus/short`, M4-16GB):**
+auto-detect is byte-for-byte identical to pinned-`en` — WER
+`{0, 0, 0, 0, 0.067}` on both runs, and auto-detect labels every clip `en`.
+No EN regression → default flipped to auto-detect (`""`) and the stale
+caption replaced. (`medium` is the app's default model, so this is the
+representative comparison; `tiny` was not cached.)
+
+## Acceptance criteria
+
+- **Pure resolver, unit-tested matrix.** `ChineseScript.resolve(preferredLanguages:)`
+  maps the full matrix deterministically (machine-independent):
+  `zh-Hant`, `zh-Hant-TW`, `zh-TW`, `zh-HK`, `zh-MO` → `.traditional`;
+  `zh-Hans`, `zh-CN`, `zh-SG`, bare `zh`, `en-US`, `[]` → `.simplified`;
+  `["en-US","zh-Hant-TW"]` → `.traditional` (first Chinese entry wins).
+- **Gating, unit-tested.** `normalize(_:language:preferredLanguages:)`:
+  `ja` / `ko` return the input byte-for-byte unchanged even when it contains
+  Han characters (kanji/hanja protection); `zh`, `en`, `nil`, and mixed
+  Latin+Chinese strings convert the Chinese characters to the resolved script
+  while leaving non-Han characters untouched.
+- **No config surface.** The `chineseScript` UserDefault and its Settings
+  picker are removed; `swift build && swift test` green.
+- **Streaming decision, unit-tested.** `LanguageDecodePolicy.decideStreamingChunk`:
+  a full chunk (≥ `minDetectSeconds`) re-detects even when a language is already
+  running; a short chunk inherits the running language; a short chunk with
+  nothing to inherit detects; a pinned language always forces. The offline
+  `decide(pinned:locked:)` path is unchanged (its tests stay green).
+- **Streaming bench.** A/B `--min-detect 10` vs `9999` on a monolingual EN
+  clip, a monolingual ZH clip, and an EN→ZH code-switch clip: no monolingual
+  regression, code-switch tail decodes as hanzi (see *Streaming* above).
+- **Manual:** on auto-detect, dictate a mixed Simplified/Traditional Chinese
+  utterance; the pasted text is uniformly in the system-implied script.
+- **Manual (mixed language):** dictate an English sentence with an embedded
+  Chinese phrase; the English is unchanged and the Chinese is in the
+  system-implied script (provided Whisper transcribed it as hanzi — see
+  Non-goals).
+- **(Default flip) Bench:** EN WER delta on `bench/corpus/short`, `en` vs
+  auto, documented in the PR before the flip lands.
+
+## References
+
+- SPEC-021 — Mandarin auto-detect fix (the detection mechanism this builds on).
+- `Sources/OpenQuackKit/Transcription/TranscriptionEngine.swift` —
+  `EngineTranscription.detectedLanguage` (the resolved-language signal).
+- ICU `StringTransform` `Hant-Hans` / `Hans-Hant`.
+- AGENTS.md — atomic PR + bench-on-language-path rules apply.


### PR DESCRIPTION
## SPEC

SPEC-035 (Auto-normalise Chinese script + mixed-language streaming detection).

## Milestone

M3.

## Why

Bilingual users hit two failures with Chinese/English dictation. (1) A mostly-English
sentence with an embedded Chinese phrase is labelled `en`, so its hanzi were never
normalised to the user's system script — they'd get mixed Traditional/Simplified.
(2) On a long recording that *switches* language (start English, finish Chinese),
the streaming path locked the language to the first chunk (SPEC-021), so the Chinese
tail came back as a botched English translation instead of Chinese.

## Change

- **Script gate (`ChineseScript.normalize`).** The ICU `Hant↔Hans` transform is a
  no-op on non-Han characters, so it now runs on *any* output except Japanese (`ja`)
  / Korean (`ko`) — whose kanji/hanja it would corrupt — instead of only when the
  whole utterance is `zh`. Embedded Chinese in an `en` utterance is now normalised;
  English passes through untouched.
- **Streaming per-chunk detection (`LanguageDecodePolicy.decideStreamingChunk` +
  `StreamingTranscriber`).** Replaces lock-to-first-chunk. Full chunks
  (≥ `minDetectSeconds`, default 10s — interior chunks are always ≥ the 20s target)
  re-detect, so the language can switch at a boundary; only a short trailing chunk
  inherits the running language, preserving the weak-detection safety the lock gave.
  The offline `decide(pinned:locked:)` path is unchanged.
- **Bench tooling.** `openquack-stream-bench --min-detect` (10 = new, 9999 =
  reproduces the lock) to A/B in one build.
- Default language already flips to auto-detect; `chineseScript` picker removed
  (prior SPEC-035 work in this branch).

See `docs/SPECS/SPEC-035-chinese-script-system-default.md` for the full rationale,
the §Streaming section, and the bench.

## Tests

- [x] unit test added/updated: `ChineseScriptTests` (gate: ja/ko protected, en/nil/mixed
      convert), `LanguageDecodePolicyTests` (`decideStreamingChunk`: full re-detects,
      short inherits, pinned forces, threshold inclusive)
- [x] `swift build && swift test` green locally (178 tests; built via full Xcode toolchain —
      CommandLineTools lacks the SwiftUI `#Preview` macro plugin a dependency uses)
- [x] bench delta documented (streaming, `medium`, auto, M4-16GB, smoke):
      `--min-detect 9999` (lock) vs `10` (new) on EN/ZH/code-switch clips —
      monolingual EN/ZH **byte-identical** (EN WER 3.7%→3.7%); code-switch tail goes
      from English mistranslation → hanzi (`…最近我还在尝试用它来朗读和整理我的读书笔记…`).
      Full table in SPEC-035 §Streaming.

## Privacy impact

None. The change is language-detection logic + a character transform, all on-device.
No audio capture, network, or output-path change; the `docs/VISION.md` privacy
contract is preserved.

## Out of scope

- In-clip language switching on the **offline** (<30s) path (single decode, one
  detection) and a switch confined to the final **<10s** of a streaming recording
  (lands in the inherited short tail) — both documented as known limitations.
- Word-level (OpenCC) conversion; Cantonese vs Mandarin.
- Notarisation (SPEC-025) — release stays ad-hoc/locally-signed as today.