### PR TITLE
chore: release v2.0.0-alpha.19 — reliable brew self-upgrade relaunch

### DIFF
--- a/Casks/openquack.rb
+++ b/Casks/openquack.rb
@@ -1,9 +1,9 @@
 cask "openquack" do
-  version "2.0.0-alpha.18"
+  version "2.0.0-alpha.19"
   # Set per-release by scripts/make_dmg.sh — paste the printed value in
   # before each tag is pushed. `:no_check` is the placeholder while no
   # release has been tagged yet.
-  sha256 "e1ef5cd027ee697f77ee1837c9967f76f8a446fc765c91b8eb5b8299ed5c4c2a"
+  sha256 "201b1873434ab912ffbdfc15da935b3bb8f70e72b4667a01f4103a09cd446111"
 
   url "https://github.com/larryxiao/openquack/releases/download/v#{version}/OpenQuack-#{version}.dmg"
   name "OpenQuack"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Voice dictation for macOS. Nothing leaves your device — audio, text, nothing.
 
 > 📢 **What's new** — full notes on the [Releases page →](https://github.com/larryxiao/openquack/releases)
 >
+> - 🔁 **[v2.0.0-alpha.19](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.19) — self-upgrades that land on their feet.** A Homebrew update now reliably relaunches OpenQuack when it finishes, instead of occasionally quitting and leaving the duck closed.
 > - 🌏 **[v2.0.0-alpha.18](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.18) — code-switch without the chaos.** Start a sentence in English and finish it in 中文: your Chinese now comes back as Chinese across a whole recording, not a garbled English "translation," and it's tidied into your system's script (简体 or 繁體).
 > - 🎧 **[v2.0.0-alpha.17](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.17) — auto-detect that actually detects.** Just talk in any language, no menu-fiddling. Non-English speech stopped getting silently translated to English (253% → 17% WER on the multilingual set).
-> - 🦆 **[v2.0.0-alpha.16](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.16) — updates that get out of your way.** Homebrew upgrades run quietly in the background and relaunch the duck for you — no surprise Terminal window.
 
 ## What it is
 

--- a/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
+++ b/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
@@ -4,5 +4,5 @@ import Foundation
 /// Carries no UI / KeyboardShortcuts / WhisperKit deps so the bench targets
 /// can build without Xcode-only macro plugins.
 public enum OpenQuackPlatform {
-    public static let version = "2.0.0-alpha.18"
+    public static let version = "2.0.0-alpha.19"
 }


### PR DESCRIPTION
## SPEC

SPEC-011 (Update flow), SPEC-026 (Sparkle channels). Release of #70.

## Milestone

Adoption focus — update reliability.

## Why

Cut alpha.19 so the auto-update fix (#70) reaches users. The previous in-app **Upgrade** on Homebrew installs could quit OpenQuack and leave it closed.

## Change

- version `2.0.0-alpha.18` → `2.0.0-alpha.19`
- cask `version` + `sha256` for the alpha.19 DMG (`201b187…46111`)
- README "What's new" banner entry

No source logic changes beyond #70 (already merged); this is the version/cask/banner bump that constitutes the release.

## Tests

- [x] `swift build && swift test` green locally (184 tests; release build via `make_dmg.sh`)
- [x] DMG builds + signs (`OpenQuack-2.0.0-alpha.19.dmg`, plist `plutil -lint` OK)
- [ ] unit test added/updated: n/a (release bump)

## Privacy impact

None. Version/cask/doc only.

## Out of scope

- Notarisation (SPEC-025) — alpha.19 ships Apple-Development-signed like prior alphas.
- Populating the alpha appcast with signed Sparkle items (PR-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)