### PR TITLE
chore: roll stable release back to v2.0.0-alpha.18

### DIFF
--- a/Casks/openquack.rb
+++ b/Casks/openquack.rb
@@ -1,9 +1,9 @@
 cask "openquack" do
-  version "2.0.0-alpha.19"
+  version "2.0.0-alpha.18"
   # Set per-release by scripts/make_dmg.sh — paste the printed value in
   # before each tag is pushed. `:no_check` is the placeholder while no
   # release has been tagged yet.
-  sha256 "201b1873434ab912ffbdfc15da935b3bb8f70e72b4667a01f4103a09cd446111"
+  sha256 "e1ef5cd027ee697f77ee1837c9967f76f8a446fc765c91b8eb5b8299ed5c4c2a"
 
   url "https://github.com/larryxiao/openquack/releases/download/v#{version}/OpenQuack-#{version}.dmg"
   name "OpenQuack"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Voice dictation for macOS. Nothing leaves your device — audio, text, nothing.
 
 > 📢 **What's new** — full notes on the [Releases page →](https://github.com/larryxiao/openquack/releases)
 >
-> - 🔁 **[v2.0.0-alpha.19](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.19) — self-upgrades that land on their feet.** A Homebrew update now reliably relaunches OpenQuack when it finishes, instead of occasionally quitting and leaving the duck closed.
 > - 🌏 **[v2.0.0-alpha.18](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.18) — code-switch without the chaos.** Start a sentence in English and finish it in 中文: your Chinese now comes back as Chinese across a whole recording, not a garbled English "translation," and it's tidied into your system's script (简体 or 繁體).
 > - 🎧 **[v2.0.0-alpha.17](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.17) — auto-detect that actually detects.** Just talk in any language, no menu-fiddling. Non-English speech stopped getting silently translated to English (253% → 17% WER on the multilingual set).
+> - 🦆 **[v2.0.0-alpha.16](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.16) — updates that get out of your way.** Homebrew upgrades run quietly in the background and relaunch the duck for you — no surprise Terminal window.
 
 ## What it is
 


### PR DESCRIPTION
## SPEC

SPEC-011 (Update flow / distribution). Withdraws the alpha.19 release (#71) as stable.

## Milestone

Adoption focus — update reliability.

## Why

Issues reported with alpha.19. Pin the stable/brew install path back to alpha.18 while they're investigated, so new installs and `brew upgrade` stop pulling 19.

## Change

- `Casks/openquack.rb`: `version` + `sha256` → alpha.18 (the alpha.18 release + DMG are intact).
- `README.md`: drop the alpha.19 "What's new" entry.
- GitHub "Latest" already flipped to alpha.18 out-of-band (alpha.19 marked prerelease); `releases/latest` now returns alpha.18, so brew `livecheck` and the in-app `UpdateChecker` point at 18.

**Kept:** the #70 auto-update fix stays in `main`. **Not reverted:** the code version string (`OpenQuackPlatform.version`) stays `alpha.19` — reverting it would collide with the already-shipped alpha.18 binary, which lacks #70. Fix-forward will be alpha.20 (or a re-cut 19).

## Tests

- [x] `releases/latest` API returns v2.0.0-alpha.18 (verified)
- [x] cask sha matches the alpha.18 DMG asset
- [ ] unit test: n/a (distribution rollback)

## Privacy impact

None.

## Out of scope

- Investigating the actual alpha.19 issues (separate).
- Deleting the alpha.19 release/tag (kept as prerelease for diagnosis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)