### PR TITLE
feat(SPEC-036): recording diagnostics, health & Settings health view

### DIFF
--- a/Sources/OpenQuackApp/AppState.swift
+++ b/Sources/OpenQuackApp/AppState.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import OpenQuackKit
+import OpenQuackPlatform
 
 public final class AppState: ObservableObject {
     public enum Phase: Equatable {
@@ -45,6 +46,21 @@ public final class AppState: ObservableObject {
         currentLevel = 0
         levelHistory = Array(repeating: 0, count: Self.barCount)
     }
+
+    /// SPEC-036 — record a finished recording's health summary, newest-first,
+    /// trimming to `recentRecordingsCap`. Call on the main actor (it drives
+    /// `@Published`).
+    public func pushRecentRecording(_ summary: DiagnosticsReport.LastRecording) {
+        recentRecordings.insert(summary, at: 0)
+        if recentRecordings.count > Self.recentRecordingsCap {
+            recentRecordings.removeLast(recentRecordings.count - Self.recentRecordingsCap)
+        }
+    }
+
+    /// SPEC-036 — count of this session's recordings flagged incomplete-capture.
+    public var incompleteCaptureCount: Int {
+        recentRecordings.filter { $0.health.isIncomplete }.count
+    }
     @Published public var lastTranscript: String?
     @Published public var lastAudioSeconds: Double?
     @Published public var lastWallSeconds: Double?
@@ -61,6 +77,12 @@ public final class AppState: ObservableObject {
     /// e.g. "Recording interrupted by an audio device change". Takes priority
     /// over the transcript preview when set; cleared at the next recording.
     @Published public var lastNotice: String?
+    /// SPEC-036 — newest-first ring of recent recording-health summaries,
+    /// surfaced (opt-in) in Settings → Stats → "Recording health". Local-only;
+    /// session-scoped, capped at `recentRecordingsCap`. Mutate via
+    /// `pushRecentRecording(_:)` so the cap/order stay in one place.
+    @Published public var recentRecordings: [DiagnosticsReport.LastRecording] = []
+    public static let recentRecordingsCap = 10
     @Published public var accessibilityTrusted: Bool = false
     @Published public var modelLabel: String = "medium"
     /// Lifecycle of an update check — drives both the menu-bar 🦆⬆

--- a/Sources/OpenQuackApp/AppState.swift
+++ b/Sources/OpenQuackApp/AppState.swift
@@ -57,6 +57,10 @@ public final class AppState: ObservableObject {
     /// SPEC-031 — short error label for failed kickoffs, shown in the
     /// "ready" overlay state.
     @Published public var lastKickoffError: String?
+    /// SPEC-036 — a transient notice shown in the "ready" overlay subline,
+    /// e.g. "Recording interrupted by an audio device change". Takes priority
+    /// over the transcript preview when set; cleared at the next recording.
+    @Published public var lastNotice: String?
     @Published public var accessibilityTrusted: Bool = false
     @Published public var modelLabel: String = "medium"
     /// Lifecycle of an update check — drives both the menu-bar 🦆⬆

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -872,6 +872,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     interrupted: recordingInterrupted
                 )
                 lastRecordingDiag = diag
+                // SPEC-036 — also push to the session ring AppState exposes to
+                // Settings → Stats → "Recording health" (opt-in display).
+                await MainActor.run { appState.pushRecentRecording(diag) }
                 let rtfText = DiagnosticsReport.rtf(transcribe: result.wallSeconds, audio: result.audioSeconds)
                     .map { String(format: "%.2f", $0) } ?? "-"
                 Diagnostics.shared.log(
@@ -1135,9 +1138,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the user can attach it to a GitHub issue. No network IO; contains
     /// durations, counts, RTF, a detected-language code, and event labels —
     /// never transcript text. Returns the file URL (nil on write failure).
+    /// Internal (not `private`) so Settings → Stats → "Recording health" can
+    /// drive the reveal flow via the `(NSApp.delegate as? AppDelegate)` handle,
+    /// mirroring how StatsPane reaches `usageStats` (SPEC-036).
     @MainActor
     @discardableResult
-    private func writeDiagnosticsFileAndReveal() -> URL? {
+    func writeDiagnosticsFileAndReveal() -> URL? {
         let report = DiagnosticsReport.render(
             appVersion: OpenQuackKit.version,
             osVersion: ProcessInfo.processInfo.operatingSystemVersionString,

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -7,6 +7,7 @@ import ServiceManagement
 import Sparkle
 import UserNotifications
 import OpenQuackKit
+import OpenQuackPlatform
 
 // SPEC-010 — App shell + dictation lifecycle (SPEC-001 + SPEC-003 wired in).
 //
@@ -68,6 +69,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastVoiceAt: Date?
     private static let voiceThreshold: Float = 0.06
     private static let vadMinDuration: Double = 0.8
+
+    /// SPEC-036 — set when the current recording was force-stopped by an audio
+    /// device/route change (vs. a user stop / VAD). Reset at each `startRecording`.
+    private var recordingInterrupted = false
+    /// SPEC-036 — summary of the most recent recording for the bug-report dump.
+    private var lastRecordingDiag: DiagnosticsReport.LastRecording?
 
     private let appState = AppState()
     private let recorder = AudioRecorder()
@@ -132,6 +139,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // SPEC-033 — read sentinel before any code that could crash, then arm
+        // it for this session. Value stays true if we crash; cleared on clean exit.
+        let priorSessionCrashed = checkAndMarkCrashSentinel()
+
         NSApp.setActivationPolicy(.accessory)
         appState.installMethod = InstallMethodDetector.detect()
         installSparkleUpdater()
@@ -172,6 +183,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // SPEC-036 — when the audio engine reconfigures mid-recording (device /
+        // route change — Bluetooth, device switch, sample-rate change), the tap
+        // stops and the UI would otherwise freeze. Auto-stop-and-transcribe so
+        // the user gets the partial result with a clear notice instead. Fires on
+        // the main queue.
+        recorder.interruptionHandler = { [weak self] in
+            guard let self else { return }
+            guard case .recording = self.appState.phase else { return }
+            self.recordingInterrupted = true
+            self.appState.lastNotice = "Recording interrupted by an audio device change"
+            Diagnostics.shared.log(.recording, .warn, "interruption → auto-stopping mid-recording")
+            self.stopAndTranscribe()
+        }
+
         // Refresh permission state on launch and every 5 s while running so
         // the popover banner reflects reality even if the user grants AX
         // through System Settings without coming back to the app first.
@@ -206,9 +231,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await pollForUpdate() }
 
         // SPEC-014 — sweep retention + offer crash-recovery on launch.
+        // SPEC-033 — offer bug report if sentinel indicates unclean prior exit.
         let history = historyStore
         Task { @MainActor in
             await history.enforceRetention()
+            if priorSessionCrashed { await self.offerCrashBugReport() }
             await self.offerRecoveryIfNeeded()
         }
 
@@ -438,6 +465,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func menuSendFeedback() {
         // SPEC-018. Opens the GitHub issue chooser; user picks bug report
         // or feature request from there. No app-side network IO.
+        // SPEC-036 — also drop a diagnostics file in Finder to attach.
+        writeDiagnosticsFileAndReveal()
         guard let url = URL(string: "https://github.com/larryxiao/openquack/issues/new/choose") else {
             return
         }
@@ -692,6 +721,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     appState.phase = .recording
                     appState.elapsedSeconds = 0
                     appState.resetLevels()
+                    appState.lastNotice = nil          // SPEC-036
+                    recordingInterrupted = false       // SPEC-036
                     lastVoiceAt = nil
                     startElapsedTimer()
                     playSound("Tink")
@@ -794,9 +825,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // sees every frame; cancel() is fine to call after teardown
                 // (any frames still queued become a no-op once cancelled).
                 let result: EngineTranscription
+                // SPEC-036 — streaming-only stats for the diagnostics summary.
+                let pathLabel: String
+                var chunkCount: Int?
+                var chunkFailures: Int?
                 if audioDuration >= Self.streamingThreshold, let streamer {
                     await tearDownFramesPump()
                     let r = try await streamer.finish()
+                    chunkCount = r.chunkCount
+                    chunkFailures = r.chunkFailures
+                    pathLabel = "streaming"
                     result = EngineTranscription(
                         text: r.text,
                         detectedLanguage: r.detectedLanguage,
@@ -807,12 +845,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 } else {
                     await tearDownFramesPump()
                     if let streamer { await streamer.cancel() }
+                    pathLabel = "offline"
                     result = try await engine.transcribe(
                         audioFile: url,
                         language: defaultLanguage,
                         customWords: customWords
                     )
                 }
+
+                // SPEC-036 — recording-health + transcription summary. `captured`
+                // survives `recorder.stop()` (reset only on the next start), so it
+                // reflects this recording. A large wall-vs-captured shortfall is
+                // the freeze signature (the tap stopped mid-recording).
+                let captured = recorder.capturedSeconds
+                let health = RecordingHealth.assess(wallSeconds: audioDuration, capturedSeconds: captured)
+                let diag = DiagnosticsReport.LastRecording(
+                    wallSeconds: audioDuration,
+                    capturedSeconds: captured,
+                    health: health,
+                    path: pathLabel,
+                    chunkCount: chunkCount,
+                    chunkFailures: chunkFailures,
+                    transcribeWallSeconds: result.wallSeconds,
+                    audioSeconds: result.audioSeconds,
+                    detectedLanguage: result.detectedLanguage,
+                    interrupted: recordingInterrupted
+                )
+                lastRecordingDiag = diag
+                let rtfText = DiagnosticsReport.rtf(transcribe: result.wallSeconds, audio: result.audioSeconds)
+                    .map { String(format: "%.2f", $0) } ?? "-"
+                Diagnostics.shared.log(
+                    .transcription,
+                    health.isIncomplete ? .error : .info,
+                    "stop: wall \(String(format: "%.1f", audioDuration))s captured \(String(format: "%.1f", captured))s"
+                    + " \(pathLabel) rtf=\(rtfText) lang=\(result.detectedLanguage ?? "-")"
+                    + (health.isIncomplete ? " ⚠ INCOMPLETE" : "")
+                    + (recordingInterrupted ? " (interrupted)" : "")
+                )
 
                 // Whisper's `zh` output mixes Hant/Hans; normalise detected
                 // Chinese to the system-language script before any other text
@@ -1038,6 +1107,78 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return (samples, format.sampleRate)
     }
 
+    // MARK: - SPEC-033: crash-sentinel bug-report prompt
+
+    /// Reads the crash sentinel and immediately re-arms it for this session.
+    /// Returns true if the prior session didn't exit cleanly.
+    @MainActor
+    private func checkAndMarkCrashSentinel() -> Bool {
+        let didCrash = UserDefaults.standard.bool(forKey: "crashSentinel")
+        UserDefaults.standard.set(true, forKey: "crashSentinel")
+        return didCrash
+    }
+
+    @MainActor
+    private func offerCrashBugReport() async {
+        let alert = NSAlert()
+        alert.messageText = "OpenQuack didn't exit cleanly last time."
+        alert.informativeText = "This is usually a crash or force-quit. Filing a report helps us fix it. We'll open a diagnostics file in Finder you can drag into the issue."
+        alert.addButton(withTitle: "Report Bug")
+        alert.addButton(withTitle: "Dismiss")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        writeDiagnosticsFileAndReveal()   // SPEC-036
+        guard let url = URL(string: "https://github.com/larryxiao/openquack/issues/new?template=bug_report.yml") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// SPEC-036 — write a plain-text diagnostics file and reveal it in Finder so
+    /// the user can attach it to a GitHub issue. No network IO; contains
+    /// durations, counts, RTF, a detected-language code, and event labels —
+    /// never transcript text. Returns the file URL (nil on write failure).
+    @MainActor
+    @discardableResult
+    private func writeDiagnosticsFileAndReveal() -> URL? {
+        let report = DiagnosticsReport.render(
+            appVersion: OpenQuackKit.version,
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            chip: Self.chipString(),
+            model: appState.modelLabel,
+            lastRecording: lastRecordingDiag,
+            events: Diagnostics.shared.recentEvents(),
+            generatedAt: Date()
+        )
+        let dir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("Logs/OpenQuack", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("diagnostics-\(Self.fileTimestamp()).txt")
+        do {
+            try report.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            Diagnostics.shared.log(.app, .error, "diagnostics write failed: \(error)")
+            return nil
+        }
+        Diagnostics.shared.log(.app, .info, "wrote diagnostics to \(url.lastPathComponent)")
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+        return url
+    }
+
+    /// CPU brand string (e.g. "Apple M4") for the diagnostics header.
+    private static func chipString() -> String {
+        var size = 0
+        sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
+        guard size > 0 else { return "unknown CPU" }
+        var buf = [CChar](repeating: 0, count: size)
+        sysctlbyname("machdep.cpu.brand_string", &buf, &size, nil, 0)
+        return String(cString: buf)
+    }
+
+    private static func fileTimestamp() -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyyMMdd-HHmmss"
+        return f.string(from: Date())
+    }
+
     /// On launch, surface any recordings that didn't complete transcription.
     /// Spec calls for a non-modal popover anchored to the menu-bar icon;
     /// alpha.5 ships an NSAlert as the simpler MVP. Replace in a follow-up.
@@ -1109,6 +1250,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // kill the sessions; user can re-enter them via `claude
         // agents` or `claude attach <id>` next time they want to.
         agentSessions.stopTrackingAll()
+        // SPEC-033 — clean exit: disarm the crash sentinel.
+        UserDefaults.standard.set(false, forKey: "crashSentinel")
     }
 }
 

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -139,7 +139,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // SPEC-033 — read sentinel before any code that could crash, then arm
+        // SPEC-039 — read sentinel before any code that could crash, then arm
         // it for this session. Value stays true if we crash; cleared on clean exit.
         let priorSessionCrashed = checkAndMarkCrashSentinel()
 
@@ -231,7 +231,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await pollForUpdate() }
 
         // SPEC-014 — sweep retention + offer crash-recovery on launch.
-        // SPEC-033 — offer bug report if sentinel indicates unclean prior exit.
+        // SPEC-039 — offer bug report if sentinel indicates unclean prior exit.
         let history = historyStore
         Task { @MainActor in
             await history.enforceRetention()
@@ -1110,7 +1110,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return (samples, format.sampleRate)
     }
 
-    // MARK: - SPEC-033: crash-sentinel bug-report prompt
+    // MARK: - SPEC-039: crash-sentinel bug-report prompt
 
     /// Reads the crash sentinel and immediately re-arms it for this session.
     /// Returns true if the prior session didn't exit cleanly.
@@ -1256,7 +1256,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // kill the sessions; user can re-enter them via `claude
         // agents` or `claude attach <id>` next time they want to.
         agentSessions.stopTrackingAll()
-        // SPEC-033 — clean exit: disarm the crash sentinel.
+        // SPEC-039 — clean exit: disarm the crash sentinel.
         UserDefaults.standard.set(false, forKey: "crashSentinel")
     }
 }

--- a/Sources/OpenQuackApp/RecordingOverlay.swift
+++ b/Sources/OpenQuackApp/RecordingOverlay.swift
@@ -223,6 +223,8 @@ struct OverlayPill: View {
         case .transcribing:
             return "On your Mac"
         case .ready:
+            // SPEC-036 — surface an interruption notice over the usual subline.
+            if let notice = state.lastNotice { return notice }
             if state.recordingMode == .agentKickoff, !state.lastKickoffSucceeded {
                 return state.lastKickoffError ?? "Transcript copied to clipboard"
             }

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -4,6 +4,7 @@ import KeyboardShortcuts
 import os
 import ServiceManagement
 import OpenQuackKit
+import OpenQuackPlatform
 
 // Settings scene. SwiftUI TabView in an NSWindow (managed by
 // SettingsWindowController). Storage via @AppStorage on UserDefaults.
@@ -26,7 +27,7 @@ struct SettingsView: View {
             ShortcutPane()
                 .tabItem { Label("Shortcut", systemImage: "command") }
                 .tag(Tab.shortcut)
-            StatsPane()
+            StatsPane(appState: appState)
                 .tabItem { Label("Stats", systemImage: "chart.bar") }
                 .tag(Tab.stats)
             HistoryPane()
@@ -633,6 +634,7 @@ private struct AboutPane: View {
 // MARK: - Stats (SPEC-013)
 
 private struct StatsPane: View {
+    @ObservedObject var appState: AppState
     @AppStorage("showUsageStats")  private var showUsageStats: Bool = false
     @AppStorage("trackUsageStats") private var trackUsageStats: Bool = true
     @AppStorage("typingWPM")       private var typingWPM: Int = 50
@@ -683,6 +685,11 @@ private struct StatsPane: View {
                         SectionHeader("Sessions by length")
                     }
                 }
+
+                // SPEC-036 — local-only recording-health diagnostics. Same
+                // privacy stance as the rest of this pane: gathered on this Mac,
+                // nothing leaves it. Gated behind the existing display toggle.
+                recordingHealthSection
             }
 
             Section {
@@ -847,6 +854,101 @@ private struct StatsPane: View {
                 }
             }
         }
+    }
+
+    // MARK: - SPEC-036 recording health
+
+    /// Local-only recording-health subsection: a session incomplete-capture
+    /// count, the newest recordings (wall / captured / RTF / path / lang with a
+    /// warning marker when the tap stopped early), an optional compact list of
+    /// warn/error diagnostic events, and a button into the existing reveal flow.
+    @ViewBuilder
+    private var recordingHealthSection: some View {
+        Section {
+            if appState.recentRecordings.isEmpty {
+                Text("No recordings yet this session.")
+                    .font(.caption).foregroundStyle(.secondary)
+            } else {
+                let incomplete = appState.incompleteCaptureCount
+                if incomplete > 0 {
+                    HStack(spacing: Theme.s8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("\(incomplete) of \(appState.recentRecordings.count) recording\(appState.recentRecordings.count == 1 ? "" : "s") this session ended early (capture stopped mid-recording).")
+                            .font(.caption)
+                    }
+                } else {
+                    Text("All \(appState.recentRecordings.count) recording\(appState.recentRecordings.count == 1 ? "" : "s") this session captured cleanly.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
+                ForEach(appState.recentRecordings.indices, id: \.self) { i in
+                    recordingHealthRow(appState.recentRecordings[i])
+                }
+            }
+
+            let warnings = Self.recentWarnings()
+            if !warnings.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(warnings.indices, id: \.self) { i in
+                        let e = warnings[i]
+                        Text("\(e.level.marker) [\(e.category.rawValue)] \(e.message)")
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+            }
+
+            HStack {
+                Button("Reveal diagnostics file") {
+                    (NSApp.delegate as? AppDelegate)?.writeDiagnosticsFileAndReveal()
+                }
+                .buttonStyle(.oqNeutral)
+                Spacer()
+            }
+            Text("Recording health is gathered on this Mac — durations, counts, and a detected-language code, never your transcript. Nothing leaves your Mac.")
+                .font(.caption).foregroundStyle(.secondary)
+        } header: {
+            SectionHeader("Recording health")
+        }
+    }
+
+    /// One recording row: "wall / captured · RTF · path · lang", warning-marked
+    /// when capture fell short.
+    private func recordingHealthRow(_ r: DiagnosticsReport.LastRecording) -> some View {
+        let incomplete = r.health.isIncomplete
+        var tail: [String] = []
+        if let rtf = DiagnosticsReport.rtf(transcribe: r.transcribeWallSeconds, audio: r.audioSeconds) {
+            tail.append(String(format: "RTF %.2f", rtf))
+        }
+        tail.append(r.path)
+        if let lang = r.detectedLanguage { tail.append("lang=\(lang)") }
+        return HStack(alignment: .firstTextBaseline, spacing: Theme.s8) {
+            Image(systemName: incomplete ? "exclamationmark.triangle.fill" : "checkmark.circle")
+                .foregroundStyle(incomplete ? Color.orange : .secondary)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(format: "wall %.1fs / captured %.1fs", r.wallSeconds, r.capturedSeconds))
+                    .font(.caption.monospacedDigit())
+                Text(tail.joined(separator: " · "))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Compact warn/error tail from the diagnostics ring (newest-first, capped).
+    /// `recentEvents()` returns oldest-first.
+    private static func recentWarnings(limit: Int = 5) -> [DiagEvent] {
+        Diagnostics.shared.recentEvents()
+            .filter { $0.level == .warn || $0.level == .error }
+            .suffix(limit)
+            .reversed()
     }
 
     private func exportSnapshot() {

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import OpenQuackPlatform
 
 public enum RecorderError: Error, CustomStringConvertible {
     case permissionDenied
@@ -44,6 +45,19 @@ public final class AudioRecorder {
     private var _startTime: Date?
     private var _isRecording = false
 
+    /// SPEC-036 — total audio frames the tap actually delivered this session,
+    /// and the input rate they were captured at. Compared against wall-clock
+    /// `elapsedSeconds` to detect a tap that stopped mid-recording (the freeze
+    /// signature). Lives in its own reference so the audio-thread tap can bump
+    /// it without capturing `self`.
+    private let frameCounter = FrameCounter()
+    private var _capturedSampleRate: Double = 16000
+
+    /// SPEC-036 — observer for `AVAudioEngineConfigurationChange` (device/route
+    /// change). Removed before our own `engine.stop()` so teardown doesn't
+    /// re-enter it.
+    private var configObserver: NSObjectProtocol?
+
     /// Called on the main queue with each buffer's RMS level (0…1, gently
     /// scaled for UI). Set this before calling `start` to drive a level meter.
     public var levelHandler: ((Float) -> Void)?
@@ -55,7 +69,30 @@ public final class AudioRecorder {
     /// callers leave it nil and pay nothing.
     public var framesHandler: (([Float], Double) -> Void)?
 
+    /// SPEC-036 — invoked on the main queue when `AVAudioEngine` reconfigures
+    /// mid-capture (the usual cause of a frozen recording). The app uses it to
+    /// auto-stop-and-transcribe instead of leaving the UI frozen. Set before
+    /// `start()`.
+    public var interruptionHandler: (() -> Void)?
+
     public init() {}
+
+    /// Thread-safe frame tally bumped from the audio thread.
+    private final class FrameCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var frames: Int64 = 0
+        func add(_ n: Int) { lock.lock(); frames += Int64(n); lock.unlock() }
+        func reset() { lock.lock(); frames = 0; lock.unlock() }
+        var value: Int64 { lock.lock(); defer { lock.unlock() }; return frames }
+    }
+
+    /// SPEC-036 — seconds of audio the tap actually delivered this session.
+    /// Survives `stop()` (reset only on the next `start()`) so the post-stop
+    /// transcription path can compare it against wall-clock duration.
+    public var capturedSeconds: TimeInterval {
+        guard _capturedSampleRate > 0 else { return 0 }
+        return Double(frameCounter.value) / _capturedSampleRate
+    }
 
     public var isRecording: Bool {
         lock.lock(); defer { lock.unlock() }
@@ -145,13 +182,21 @@ public final class AudioRecorder {
         let framesHandler = self.framesHandler
         let inputSampleRate = inputFormat.sampleRate
 
+        // SPEC-036 — fresh tally for this session; capture the rate so
+        // `capturedSeconds` reads correctly after stop().
+        frameCounter.reset()
+        _capturedSampleRate = inputSampleRate
+        let frameCounter = self.frameCounter
+
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+            // SPEC-036 — count delivered frames before anything that can fail, so
+            // capturedSeconds reflects what the tap actually produced.
+            frameCounter.add(Int(buffer.frameLength))
+
             do {
                 try file.write(from: buffer)
             } catch {
-                FileHandle.standardError.write(
-                    "[AudioRecorder] write error: \(error)\n".data(using: .utf8) ?? Data()
-                )
+                Diagnostics.shared.log(.recording, .error, "tap write failed: \(error)")
             }
 
             // Emit a UI-friendly level if anyone is subscribed.
@@ -177,7 +222,36 @@ public final class AudioRecorder {
             try engine.start()
         } catch {
             inputNode.removeTap(onBus: 0)
+            Diagnostics.shared.log(.recording, .error, "engine start failed: \(error)")
             throw RecorderError.engineFailed("\(error)")
+        }
+
+        // SPEC-036 — notice device/route changes that silently stop the tap.
+        // The engine posts this when the input/output format changes underneath
+        // it (Bluetooth connect/disconnect, device switch, sample-rate change,
+        // sleep/wake); without a handler the tap stops, the meter freezes, and
+        // only a partial transcript comes back. Bound to this engine instance so
+        // we don't catch unrelated graphs.
+        configObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main
+        ) { [weak self] _ in
+            // This notification ALSO fires for benign changes that leave input
+            // capture intact — default *output* device change, Bluetooth codec
+            // renegotiation, sample-rate settle. Auto-stopping on those would cut
+            // a long dictation short on a harmless route change, a worse
+            // regression than the freeze we're guarding against. So only treat it
+            // as an interruption when the engine has actually stopped. Fails safe:
+            // a genuine stop that still briefly reports running falls back to the
+            // old freeze, which `capturedSeconds` + the logged event still surface.
+            let stopped = !(engine.isRunning)
+            Diagnostics.shared.log(
+                .recording, stopped ? .warn : .info,
+                "AVAudioEngineConfigurationChange mid-capture (engine \(stopped ? "STOPPED" : "still running"))"
+            )
+            guard stopped else { return }
+            self?.interruptionHandler?()
         }
 
         self.engine = engine
@@ -185,6 +259,7 @@ public final class AudioRecorder {
         self._outputURL = url
         self._startTime = Date()
         self._isRecording = true
+        Diagnostics.shared.log(.recording, .info, String(format: "start: input %.0f Hz, %d ch", inputSampleRate, Int(inputFormat.channelCount)))
         return url
     }
 
@@ -193,6 +268,10 @@ public final class AudioRecorder {
         lock.lock(); defer { lock.unlock() }
         guard _isRecording else { return nil }
 
+        // SPEC-036 — drop the config-change observer first: `engine.stop()`
+        // itself posts a configuration change, which would otherwise re-enter
+        // the interruption handler during our own teardown.
+        removeConfigObserverLocked()
         engine?.inputNode.removeTap(onBus: 0)
         engine?.stop()
         engine = nil
@@ -200,9 +279,19 @@ public final class AudioRecorder {
         _startTime = nil
         _isRecording = false
 
+        Diagnostics.shared.log(.recording, .info, String(format: "stop: captured %.1fs", capturedSeconds))
+
         let url = _outputURL
         _outputURL = nil
         return url
+    }
+
+    /// Tear down the config-change observer. Caller holds `lock`.
+    private func removeConfigObserverLocked() {
+        if let obs = configObserver {
+            NotificationCenter.default.removeObserver(obs)
+            configObserver = nil
+        }
     }
 
     /// Stop and discard the WAV.

--- a/Sources/OpenQuackPlatform/Diagnostics.swift
+++ b/Sources/OpenQuackPlatform/Diagnostics.swift
@@ -1,0 +1,100 @@
+import Foundation
+import os
+
+/// SPEC-036 — central diagnostics.
+///
+/// Two sinks for every event:
+///   1. `os.Logger` (unified log) — persistent + queryable via Console.app or
+///      `log show --predicate 'subsystem == "org.openquack.OpenQuack"'`.
+///   2. a bounded in-memory ring — so the bug-report flow can dump recent events
+///      to an attachable `.txt`; users filing a bug won't run `log show`.
+///
+/// Lives in `OpenQuackPlatform` so both `AudioRecorder` (OpenQuackKit) and
+/// `StreamingTranscriber` (OpenQuackStreaming) can log through one place.
+public enum DiagCategory: String, Sendable, CaseIterable {
+    case recording
+    case streaming
+    case transcription
+    case app
+}
+
+/// Severity, kept independent of `OSLogType` so the renderer and tests don't
+/// pull in `os`.
+public enum DiagLevel: String, Sendable {
+    case info
+    case warn
+    case error
+
+    var osLogType: OSLogType {
+        switch self {
+        case .info:  return .info
+        case .warn:  return .error   // unified log has no "warn"; .error surfaces it
+        case .error: return .fault
+        }
+    }
+
+    /// Single-char marker for the text dump.
+    public var marker: String {
+        switch self {
+        case .info:  return " "
+        case .warn:  return "⚠"
+        case .error: return "✗"
+        }
+    }
+}
+
+public struct DiagEvent: Sendable, Equatable {
+    public let time: Date
+    public let category: DiagCategory
+    public let level: DiagLevel
+    public let message: String
+
+    public init(time: Date, category: DiagCategory, level: DiagLevel, message: String) {
+        self.time = time
+        self.category = category
+        self.level = level
+        self.message = message
+    }
+}
+
+public final class Diagnostics: @unchecked Sendable {
+    public static let shared = Diagnostics()
+
+    private static let subsystem = "org.openquack.OpenQuack"
+    private let loggers: [DiagCategory: Logger]
+    private let lock = NSLock()
+    private var ring: [DiagEvent] = []
+
+    /// Cap on retained events. ~300 covers many minutes of lifecycle + per-chunk
+    /// events (chunks are ~20 s apart) without unbounded growth.
+    public let capacity: Int
+
+    public init(capacity: Int = 300) {
+        self.capacity = capacity
+        var m: [DiagCategory: Logger] = [:]
+        for c in DiagCategory.allCases {
+            m[c] = Logger(subsystem: Self.subsystem, category: c.rawValue)
+        }
+        loggers = m
+    }
+
+    public func log(_ category: DiagCategory, _ level: DiagLevel = .info, _ message: String) {
+        loggers[category]?.log(level: level.osLogType, "\(message, privacy: .public)")
+        let e = DiagEvent(time: Date(), category: category, level: level, message: message)
+        lock.lock()
+        ring.append(e)
+        if ring.count > capacity { ring.removeFirst(ring.count - capacity) }
+        lock.unlock()
+    }
+
+    /// Snapshot of retained events, oldest-first.
+    public func recentEvents() -> [DiagEvent] {
+        lock.lock(); defer { lock.unlock() }
+        return ring
+    }
+
+    /// Test/maintenance hook.
+    public func clear() {
+        lock.lock(); ring.removeAll(keepingCapacity: true); lock.unlock()
+    }
+}

--- a/Sources/OpenQuackPlatform/DiagnosticsReport.swift
+++ b/Sources/OpenQuackPlatform/DiagnosticsReport.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// SPEC-036 — pure renderer for the attachable diagnostics `.txt`.
+///
+/// Kept free of IO (file writing, `ProcessInfo`, `Date()` "now") so it can be
+/// unit-tested deterministically; the app gathers the live values and writes the
+/// returned string to `~/Library/Logs/OpenQuack/`.
+public enum DiagnosticsReport {
+    /// Summary of the most recent recording + transcription.
+    public struct LastRecording: Sendable, Equatable {
+        public let wallSeconds: Double
+        public let capturedSeconds: Double
+        public let health: RecordingHealth
+        /// "streaming" or "offline".
+        public let path: String
+        public let chunkCount: Int?
+        public let chunkFailures: Int?
+        public let transcribeWallSeconds: Double?
+        public let audioSeconds: Double?
+        public let detectedLanguage: String?
+        public let interrupted: Bool
+
+        public init(
+            wallSeconds: Double,
+            capturedSeconds: Double,
+            health: RecordingHealth,
+            path: String,
+            chunkCount: Int? = nil,
+            chunkFailures: Int? = nil,
+            transcribeWallSeconds: Double? = nil,
+            audioSeconds: Double? = nil,
+            detectedLanguage: String? = nil,
+            interrupted: Bool = false
+        ) {
+            self.wallSeconds = wallSeconds
+            self.capturedSeconds = capturedSeconds
+            self.health = health
+            self.path = path
+            self.chunkCount = chunkCount
+            self.chunkFailures = chunkFailures
+            self.transcribeWallSeconds = transcribeWallSeconds
+            self.audioSeconds = audioSeconds
+            self.detectedLanguage = detectedLanguage
+            self.interrupted = interrupted
+        }
+    }
+
+    public static func render(
+        appVersion: String,
+        osVersion: String,
+        chip: String,
+        model: String?,
+        lastRecording: LastRecording?,
+        events: [DiagEvent],
+        generatedAt: Date
+    ) -> String {
+        var lines: [String] = []
+        lines.append("OpenQuack diagnostics")
+        lines.append("app \(appVersion) · macOS \(osVersion) · \(chip)")
+        if let model { lines.append("model: \(model)") }
+        lines.append("")
+
+        if let r = lastRecording {
+            let flag = r.health.isIncomplete ? "  ⚠ INCOMPLETE CAPTURE" : ""
+            lines.append("last recording:")
+            lines.append(String(format: "  wall %.1fs / captured %.1fs%@", r.wallSeconds, r.capturedSeconds, flag))
+            if case let .incompleteCapture(_, _, shortfall) = r.health {
+                lines.append(String(format: "  shortfall %.1fs — the tap stopped feeding audio mid-recording", shortfall))
+            }
+            if r.interrupted {
+                lines.append("  interrupted by an audio device/route change")
+            }
+            var t = "  \(r.path)"
+            if let c = r.chunkCount { t += " · \(c) chunk\(c == 1 ? "" : "s")" }
+            if let f = r.chunkFailures { t += " · \(f) failure\(f == 1 ? "" : "s")" }
+            if let rtf = rtf(transcribe: r.transcribeWallSeconds, audio: r.audioSeconds) {
+                t += String(format: " · RTF %.2f", rtf)
+            }
+            if let lang = r.detectedLanguage { t += " · lang=\(lang)" }
+            lines.append(t)
+        } else {
+            lines.append("last recording: (none this session)")
+        }
+        lines.append("")
+
+        lines.append("recent events (\(events.count)):")
+        for e in events {
+            let dt = e.time.timeIntervalSince(generatedAt)   // negative = in the past
+            let stamp = String(format: "T%+.1fs", dt)
+            lines.append("  \(stamp) \(e.level.marker) [\(e.category.rawValue)] \(e.message)")
+        }
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Real-time factor: transcription wall over audio length. < 1 is
+    /// faster-than-realtime. nil when inputs are missing/zero.
+    public static func rtf(transcribe: Double?, audio: Double?) -> Double? {
+        guard let t = transcribe, let a = audio, a > 0, t > 0 else { return nil }
+        return t / a
+    }
+}

--- a/Sources/OpenQuackPlatform/RecordingHealth.swift
+++ b/Sources/OpenQuackPlatform/RecordingHealth.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// SPEC-036 — pure assessment of whether capture ran to completion.
+///
+/// `wallSeconds` is the user-facing recording length (wall clock since `start`);
+/// `capturedSeconds` is how much audio the tap actually delivered. A large
+/// shortfall means the audio engine stopped feeding the tap mid-recording
+/// (device/route change, interruption) — the freeze signature, where the
+/// waveform stalls and only a partial transcript comes back.
+public enum RecordingHealth: Equatable, Sendable {
+    case ok
+    /// Capture fell materially short of wall-clock; the tap likely stopped early.
+    case incompleteCapture(wallSeconds: Double, capturedSeconds: Double, shortfallSeconds: Double)
+
+    public var isIncomplete: Bool {
+        if case .incompleteCapture = self { return true }
+        return false
+    }
+
+    /// - Parameters:
+    ///   - minShortfallSeconds: ignore gaps under this — normal teardown,
+    ///     scheduling jitter, and rounding leave the captured stream a hair short.
+    ///   - maxCapturedFraction: only flag when captured audio is below this
+    ///     fraction of wall, so a brief sub-second hiccup on a short clip doesn't
+    ///     read as a mid-recording stop.
+    public static func assess(
+        wallSeconds: Double,
+        capturedSeconds: Double,
+        minShortfallSeconds: Double = 2.0,
+        maxCapturedFraction: Double = 0.85
+    ) -> RecordingHealth {
+        guard wallSeconds > 0 else { return .ok }
+        let shortfall = wallSeconds - capturedSeconds
+        if shortfall >= minShortfallSeconds, capturedSeconds < wallSeconds * maxCapturedFraction {
+            return .incompleteCapture(
+                wallSeconds: wallSeconds,
+                capturedSeconds: capturedSeconds,
+                shortfallSeconds: shortfall
+            )
+        }
+        return .ok
+    }
+}

--- a/Sources/OpenQuackStreaming/StreamingTranscriber.swift
+++ b/Sources/OpenQuackStreaming/StreamingTranscriber.swift
@@ -272,6 +272,7 @@ public actor StreamingTranscriber {
         options.language = decision.language
         options.detectLanguage = decision.detectLanguage
 
+        let t0 = Date()
         do {
             let results = try await pipe.transcribe(audioArray: samples, decodeOptions: options)
             let text = results.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -283,8 +284,27 @@ public actor StreamingTranscriber {
             if language == nil, decision.detectLanguage, !text.isEmpty, let detected {
                 runningLanguage = detected
             }
+            // SPEC-036 — per-chunk timing/RTF + language decision. Chunks are
+            // ~20 s apart so this is cheap; it's what lets us confirm "slow"
+            // (RTF, and detect-every-chunk doubling cost) and "inaccurate"
+            // (a language flip on an interior chunk) from a user's session.
+            let wall = Date().timeIntervalSince(t0)
+            let rtf = chunkSeconds > 0 ? wall / chunkSeconds : 0
+            Diagnostics.shared.log(.streaming, .info, String(
+                format: "chunk %.1fs detect=%@ lang=%@ → wall %.2fs rtf %.2f detected=%@ %dchars",
+                chunkSeconds,
+                decision.detectLanguage ? "y" : "n",
+                decision.language ?? "auto",
+                wall, rtf,
+                detected ?? "-",
+                text.count
+            ))
             return ChunkOutcome(text: text, detectedLanguage: detected, succeeded: true)
         } catch {
+            let wall = Date().timeIntervalSince(t0)
+            Diagnostics.shared.log(.streaming, .error, String(
+                format: "chunk %.1fs FAILED after %.2fs: %@", chunkSeconds, wall, "\(error)"
+            ))
             return ChunkOutcome(text: "", detectedLanguage: nil, succeeded: false)
         }
     }

--- a/Tests/OpenQuackKitTests/DiagnosticsReportTests.swift
+++ b/Tests/OpenQuackKitTests/DiagnosticsReportTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import OpenQuackPlatform
+
+/// SPEC-036 — the attachable diagnostics text the bug-report flow produces.
+final class DiagnosticsReportTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    func testRenderFlagsIncompleteCapture() {
+        let health = RecordingHealth.assess(wallSeconds: 92, capturedSeconds: 21)
+        let last = DiagnosticsReport.LastRecording(
+            wallSeconds: 92, capturedSeconds: 21, health: health,
+            path: "streaming", chunkCount: 1, chunkFailures: 0,
+            transcribeWallSeconds: 9.0, audioSeconds: 21,
+            detectedLanguage: "en", interrupted: true
+        )
+        let events = [
+            DiagEvent(time: now.addingTimeInterval(-3), category: .recording, level: .info, message: "start: input 48000 Hz"),
+            DiagEvent(time: now.addingTimeInterval(-1), category: .recording, level: .warn, message: "AVAudioEngineConfigurationChange mid-capture"),
+        ]
+        let out = DiagnosticsReport.render(
+            appVersion: "2.0.0-alpha.18", osVersion: "15.5", chip: "Apple M4",
+            model: "medium", lastRecording: last, events: events, generatedAt: now
+        )
+        XCTAssertTrue(out.contains("INCOMPLETE"), out)
+        XCTAssertTrue(out.contains("RTF"), out)
+        XCTAssertTrue(out.contains("1 chunk"), out)
+        XCTAssertTrue(out.contains("lang=en"), out)
+        XCTAssertTrue(out.contains("interrupted"), out)
+        XCTAssertTrue(out.contains("ConfigurationChange"), out)
+        XCTAssertTrue(out.contains("Apple M4"), out)
+    }
+
+    func testRenderOkRecordingHasNoIncompleteMarker() {
+        let last = DiagnosticsReport.LastRecording(
+            wallSeconds: 30, capturedSeconds: 29.8, health: .ok, path: "streaming",
+            chunkCount: 2, chunkFailures: 0, transcribeWallSeconds: 8,
+            audioSeconds: 30, detectedLanguage: "en"
+        )
+        let out = DiagnosticsReport.render(
+            appVersion: "x", osVersion: "y", chip: "z", model: nil,
+            lastRecording: last, events: [], generatedAt: now
+        )
+        XCTAssertFalse(out.contains("INCOMPLETE"), out)
+        XCTAssertTrue(out.contains("2 chunks"), out)
+        XCTAssertTrue(out.contains("RTF 0.27"), out)   // 8 / 30
+    }
+
+    func testRenderNoRecording() {
+        let out = DiagnosticsReport.render(
+            appVersion: "x", osVersion: "y", chip: "z", model: nil,
+            lastRecording: nil, events: [], generatedAt: now
+        )
+        XCTAssertTrue(out.contains("(none this session)"), out)
+    }
+
+    func testRTFComputation() {
+        XCTAssertEqual(DiagnosticsReport.rtf(transcribe: 5, audio: 10)!, 0.5, accuracy: 0.0001)
+        XCTAssertNil(DiagnosticsReport.rtf(transcribe: nil, audio: 10))
+        XCTAssertNil(DiagnosticsReport.rtf(transcribe: 5, audio: 0))
+    }
+}

--- a/Tests/OpenQuackKitTests/DiagnosticsRingTests.swift
+++ b/Tests/OpenQuackKitTests/DiagnosticsRingTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import OpenQuackPlatform
+
+/// SPEC-036 — the bounded in-memory event ring the diagnostics dump reads.
+final class DiagnosticsRingTests: XCTestCase {
+    func testRingCapsAtCapacityAndKeepsNewest() {
+        let d = Diagnostics(capacity: 5)
+        for i in 0..<20 { d.log(.app, .info, "e\(i)") }
+        let events = d.recentEvents()
+        XCTAssertEqual(events.count, 5)
+        XCTAssertEqual(events.first?.message, "e15")
+        XCTAssertEqual(events.last?.message, "e19")
+    }
+
+    func testEventsAreInOrder() {
+        let d = Diagnostics(capacity: 10)
+        d.log(.recording, .info, "a")
+        d.log(.streaming, .warn, "b")
+        d.log(.transcription, .error, "c")
+        let msgs = d.recentEvents().map(\.message)
+        XCTAssertEqual(msgs, ["a", "b", "c"])
+    }
+
+    func testClear() {
+        let d = Diagnostics(capacity: 10)
+        d.log(.app, .info, "x")
+        d.clear()
+        XCTAssertTrue(d.recentEvents().isEmpty)
+    }
+}

--- a/Tests/OpenQuackKitTests/RecordingHealthTests.swift
+++ b/Tests/OpenQuackKitTests/RecordingHealthTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import OpenQuackPlatform
+
+/// SPEC-036 — the captured-vs-wall assessment that flags a tap that stopped
+/// mid-recording (the freeze signature).
+final class RecordingHealthTests: XCTestCase {
+    func testIncompleteWhenCaptureFallsShort() {
+        let h = RecordingHealth.assess(wallSeconds: 90, capturedSeconds: 20)
+        XCTAssertTrue(h.isIncomplete)
+        guard case let .incompleteCapture(wall, captured, shortfall) = h else {
+            return XCTFail("expected incompleteCapture, got \(h)")
+        }
+        XCTAssertEqual(wall, 90, accuracy: 0.001)
+        XCTAssertEqual(captured, 20, accuracy: 0.001)
+        XCTAssertEqual(shortfall, 70, accuracy: 0.001)
+    }
+
+    func testOkWhenCaptureMatchesWall() {
+        XCTAssertEqual(RecordingHealth.assess(wallSeconds: 10, capturedSeconds: 9.6), .ok)
+    }
+
+    func testOkForShortfallUnderMinimum() {
+        // 1.5 s shortfall is below the 2 s floor → not flagged.
+        XCTAssertEqual(RecordingHealth.assess(wallSeconds: 10, capturedSeconds: 8.5), .ok)
+    }
+
+    func testOkWhenWallZero() {
+        XCTAssertEqual(RecordingHealth.assess(wallSeconds: 0, capturedSeconds: 0), .ok)
+    }
+
+    func testFractionBoundaryIsStrict() {
+        // Exactly 85 % captured → ok (the fraction test is strict `<`).
+        XCTAssertEqual(RecordingHealth.assess(wallSeconds: 100, capturedSeconds: 85), .ok)
+        // Just under 85 % with a >2 s shortfall → flagged.
+        XCTAssertTrue(RecordingHealth.assess(wallSeconds: 100, capturedSeconds: 84).isIncomplete)
+    }
+}

--- a/docs/SPECS/SPEC-033-crash-sentinel-bug-report.md
+++ b/docs/SPECS/SPEC-033-crash-sentinel-bug-report.md
@@ -1,0 +1,53 @@
+# SPEC-033 — Crash-sentinel bug-report prompt
+
+## Goal
+
+When OpenQuack detects it didn't exit cleanly (crash, force-quit, unexpected power loss),
+show a one-time alert on the next launch offering to file a GitHub bug report.
+
+## Background
+
+SPEC-014's `offerRecoveryIfNeeded()` surfaces incomplete recordings, but only when audio
+history is enabled — which is OFF by default. Most crashes are invisible to that path.
+A clean-exit sentinel closes the gap: it fires for any unclean exit regardless of whether
+audio was being saved.
+
+## Mechanism
+
+**Clean-exit sentinel** stored in `UserDefaults` under key `"crashSentinel"` (Bool).
+
+| Event | Action |
+|---|---|
+| App launches | Read value. If `true` → unclean exit detected. Immediately write `true` (this session is now running). |
+| App terminates cleanly | `applicationWillTerminate` writes `false`. |
+| App crashes / force-quit / power-loss | `applicationWillTerminate` never runs → value stays `true`. |
+
+First launch: key absent → `bool(forKey:)` returns `false` → no prompt.
+
+## UI
+
+`NSAlert` (same pattern as SPEC-014 recovery alert, modal).
+
+- **Message**: "OpenQuack didn't exit cleanly last time."
+- **Informative text**: "This is usually a crash or force-quit. Filing a report helps us fix it."
+- **Button 1 (default)**: "Report Bug" → opens `https://github.com/larryxiao/openquack/issues/new?template=bug_report.yml`
+- **Button 2**: "Dismiss" → no-op
+
+Alert is shown **before** the recovery alert so both can appear in a single launch without
+reordering surprises (crash → report → then recover the audio).
+
+## Non-goals
+
+- No auto-uploader, telemetry, or Sentry/Crashlytics integration.
+- No opt-in toggle — the prompt is one-time per event; dismissing it is enough.
+- No URL prefilling for now (GitHub YAML form prefill is inconsistent across browsers).
+- Not distinguishing crash vs. force-quit vs. power-loss — "unclean exit" is sufficient.
+
+## Acceptance criteria
+
+- [ ] After a simulated crash (force-quit the app), next launch shows the alert.
+- [ ] "Report Bug" opens the bug-report template in the default browser.
+- [ ] "Dismiss" closes without opening a browser.
+- [ ] Clean exit (`⌘Q` / "Quit OpenQuack") suppresses the alert on next launch.
+- [ ] First-ever launch does not trigger the alert.
+- [ ] The alert does not appear a second time for the same event.

--- a/docs/SPECS/SPEC-036-recording-diagnostics.md
+++ b/docs/SPECS/SPEC-036-recording-diagnostics.md
@@ -19,7 +19,7 @@ Concretely:
    of freezing.
 4. **Attachable bug reports**: a diagnostics `.txt` (app/OS/chip, last-recording
    wall-vs-captured, chunk count/failures, RTF, detected language, recent events)
-   written and revealed in Finder from the existing "Report Bug" (SPEC-033) and
+   written and revealed in Finder from the existing "Report Bug" (SPEC-039) and
    "Send feedback" (SPEC-018) entry points.
 
 ## Background
@@ -34,8 +34,7 @@ recover, or even log it. The bug is environment-triggered, so it is hard to
 reproduce and hard to attribute to a release.
 
 There is no per-recording instrumentation today, so "slow" / "inaccurate" reports
-(e.g. SPEC-035's per-chunk language re-detection roughly doubling per-chunk
-inference) can't be confirmed from a user's session either.
+(e.g. SPEC-035's per-chunk language re-detection) can't be confirmed from a user's session either.
 
 ## Mechanism
 

--- a/docs/SPECS/SPEC-036-recording-diagnostics.md
+++ b/docs/SPECS/SPEC-036-recording-diagnostics.md
@@ -1,0 +1,117 @@
+# SPEC-036 — Recording & transcription diagnostics + recording-health
+
+## Goal
+
+Make the intermittent "transcription stops mid-recording, the waveform freezes,
+and only a partial transcript comes back" class of bug **diagnosable** — and turn
+its most likely trigger from a silent freeze into a clean, finished result.
+
+Concretely:
+
+1. **Structured logging** across the capture → stream → transcribe path so a
+   single recording leaves a readable trail (lifecycle, per-chunk timing/RTF,
+   language decisions, errors).
+2. **Recording-health check**: compare wall-clock duration against the audio the
+   tap actually delivered. A large shortfall means the engine stopped feeding the
+   tap mid-recording — the freeze signature — and is flagged automatically.
+3. **Graceful interruption handling**: observe `AVAudioEngineConfigurationChange`
+   (device/route change, the usual trigger) and auto-stop-and-transcribe instead
+   of freezing.
+4. **Attachable bug reports**: a diagnostics `.txt` (app/OS/chip, last-recording
+   wall-vs-captured, chunk count/failures, RTF, detected language, recent events)
+   written and revealed in Finder from the existing "Report Bug" (SPEC-033) and
+   "Send feedback" (SPEC-018) entry points.
+
+## Background
+
+The capture tap (`AudioRecorder`) is the single driver of three things in one
+closure: the WAV write, the level meter (waveform), and the streaming frames fed
+to `StreamingTranscriber`. If the tap stops firing, **all three stall together** —
+which is exactly the reported triad. `AVAudioEngine` silently stops its tap when
+the input route/format changes (Bluetooth connect/disconnect, device switch,
+sample-rate change, sleep/wake), and there is currently no observer to notice,
+recover, or even log it. The bug is environment-triggered, so it is hard to
+reproduce and hard to attribute to a release.
+
+There is no per-recording instrumentation today, so "slow" / "inaccurate" reports
+(e.g. SPEC-035's per-chunk language re-detection roughly doubling per-chunk
+inference) can't be confirmed from a user's session either.
+
+## Mechanism
+
+### Captured-vs-wall
+
+`AudioRecorder` already exposes `elapsedSeconds` (wall clock since `start`). Add a
+captured-frame counter incremented in the tap closure → `capturedSeconds`
+(frames ÷ input sample rate). On stop, `RecordingHealth.assess(wall, captured)`
+flags `.incompleteCapture` when the shortfall is ≥ 2 s **and** captured < 85 % of
+wall (tolerances keep short clips and normal teardown rounding from
+false-positiving).
+
+### Interruption → graceful stop
+
+`AudioRecorder` registers a `.AVAudioEngineConfigurationChange` observer bound to
+its engine. The notification **also fires for benign changes that leave input
+capture intact** (default output-device change, Bluetooth codec renegotiation,
+sample-rate settle), so the handler only treats it as an interruption when
+`engine.isRunning == false` — otherwise auto-stopping would truncate a long
+dictation on a harmless route change. When the engine genuinely stopped it logs a
+warning and invokes `interruptionHandler` (main queue); the app sets that handler
+to auto-stop-and-transcribe while in `.recording`, surfacing "Recording
+interrupted by an audio device change." This fails safe: a real stop that still
+briefly reports running falls back to the prior freeze, which `capturedSeconds` +
+the logged event still surface. The observer is removed before our own
+`engine.stop()` so teardown doesn't re-enter it.
+
+> Out of scope: restarting the engine and *continuing* capture across the change
+> (the WAV is opened in the pre-change format; reinstalling the tap with a new
+> format risks a write mismatch). Tracked as a follow-up.
+
+### Logging
+
+`Diagnostics` wraps `os.Logger` (subsystem `org.openquack.OpenQuack`, categories
+`recording`/`streaming`/`transcription`/`app`) and mirrors every line into a
+bounded in-memory ring (cap 300) so the bug-report flow can dump recent events as
+plain text — users won't run `log show`.
+
+### Diagnostics file
+
+`DiagnosticsReport.render(...)` (pure) builds the report text. The app writes it to
+`~/Library/Logs/OpenQuack/diagnostics-<timestamp>.txt` and reveals it in Finder
+(`activateFileViewerSelecting`) so it can be dragged into a GitHub issue.
+
+## Privacy impact
+
+Preserves the `docs/VISION.md` contract. No audio, transcript text, or network IO
+is added. The diagnostics file contains only durations, counts, RTF, a detected
+language code, app/OS/chip strings, and event labels — **no transcript content** —
+and is written locally; the user chooses whether to attach it.
+
+## Acceptance criteria
+
+- [ ] `RecordingHealth.assess` returns `.incompleteCapture` for wall 90 s /
+      captured 20 s, and `.ok` for wall 10 s / captured 9.6 s and for wall 0.
+      (unit test)
+- [ ] `DiagnosticsReport.render` output contains an `INCOMPLETE` marker when health
+      is incomplete, and includes RTF and chunk counts. (unit test)
+- [ ] `Diagnostics` ring buffer never exceeds its capacity and returns events in
+      order. (unit test)
+- [ ] Switching the input device mid-recording (e.g. connect AirPods) logs an
+      `AVAudioEngineConfigurationChange` event. **First confirm the premise**: does
+      the log say the engine STOPPED or "still running"? If it stopped, the
+      recording auto-stops and pastes the partial transcript with the "interrupted"
+      status — no frozen waveform. If it stays running, capture continues
+      uninterrupted (no truncation). (manual — this is the load-bearing test; it
+      both verifies the freeze cause and exercises the interruption path.) (manual)
+- [ ] After a recording, `log show --predicate 'subsystem == "org.openquack.OpenQuack"'`
+      shows recording start/stop, per-chunk RTF, and the wall-vs-captured summary.
+      (manual)
+- [ ] "Report Bug" (crash alert) and "Send feedback…" both write and reveal a
+      `diagnostics-*.txt` in `~/Library/Logs/OpenQuack/`. (manual)
+- [ ] `swift build && swift test` green.
+
+## Out of scope
+
+- Restart-and-continue capture across a config change (follow-up).
+- Any auto-uploader / telemetry / network reporting — the file is local + manual.
+- Re-tuning SPEC-035's per-chunk detection cost; this spec only *measures* it.

--- a/docs/SPECS/SPEC-039-crash-sentinel-bug-report.md
+++ b/docs/SPECS/SPEC-039-crash-sentinel-bug-report.md
@@ -1,4 +1,4 @@
-# SPEC-033 — Crash-sentinel bug-report prompt
+# SPEC-039 — Crash-sentinel bug-report prompt
 
 ## Goal
 


### PR DESCRIPTION
## SPEC

SPEC-036 (Recording & transcription diagnostics + recording-health). Also lands the previously-uncommitted **SPEC-039** (crash-sentinel bug-report) base — SPEC-036's bug-report enrichment hooks into its `offerCrashBugReport`, and they share `OpenQuackApp.swift`, so they can't be split.

## Milestone

Adoption focus (reliability / observability).

## Why

The "dictation stops mid-recording, the waveform freezes, and only a partial transcript comes back" bug was intermittent and **undiagnosable** — no logging, no captured-vs-wall check, and no handler for the audio engine being interrupted. The capture tap drives the WAV write, the level meter, and the streaming frames from one closure, so when it stops, all three freeze together. This makes that class diagnosable and turns its likely trigger (a device/route change that stops the tap) from a silent freeze into a clean auto-stop.

## Change

- **`OpenQuackPlatform`**: `Diagnostics` (os.Logger + bounded in-memory event ring), `RecordingHealth` (pure `assess(wall, captured)` → `.incompleteCapture`), `DiagnosticsReport` (pure renderer for an attachable `.txt`).
- **`AudioRecorder`**: captured-frame counter → `capturedSeconds`; an `AVAudioEngineConfigurationChange` observer that auto-stops **only when the engine actually stopped** (`!isRunning`, so benign route changes don't truncate long dictations); lifecycle logging.
- **`StreamingTranscriber`**: per-chunk duration/decision/RTF logging.
- **App**: graceful auto-stop + "interrupted" notice; health check + summary on every stop; a diagnostics `.txt` written + revealed in Finder from "Report Bug" / "Send feedback…"; a local-only **Recording health** subsection in Settings → Stats (gated behind the existing `showUsageStats` toggle).

## Tests

- [x] unit tests added: `RecordingHealthTests`, `DiagnosticsReportTests`, `DiagnosticsRingTests`
- [x] `swift build && swift test` green locally (196 tests)
- [ ] bench: n/a — no transcription-quality change

## Privacy impact

Preserves the `docs/VISION.md` contract. No audio, transcript text, or network IO added. The diagnostics file contains only durations, counts, RTF, a detected-language code, app/OS/chip strings, and event labels — **never transcript text** — written locally; the user chooses whether to attach it.

## Out of scope

- Restart-and-continue capture across a config change (follow-up).
- Telemetry / network reporting.
- An e2e / app-behaviour test (sibling follow-up; see SPEC-038).
- SPEC-039's manual acceptance criteria (simulated crash) are not yet verified.
- The interruption path + the file-reveal still need on-device manual verification.
