### PR TITLE
docs(SPEC-037/038): agent-harness + CI eval-gate proposals; ROADMAP autonomy reflection

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,7 +134,7 @@ model on the short corpus only, so quality regressions pass unseen.
 | 🔵 | Committed `.claude/` agent harness — named roles, saved workflows, trigger + permissions model with human gates on irreversible steps | SPEC-037 | spec proposal |
 | 🔵 | CI eval-gate — fetchable corpus, medium-model WER/RTF thresholds on every quality-path PR | SPEC-038 | spec proposal |
 | 🟡 | Signed, tag-triggered release pipeline — the cut a release-bot can only PREP today | SPEC-025 | partial |
-| ⚪ | Privacy-preserving field-feedback loop — local self-diagnosis → consented reports → opt-in aggregates | SPEC-036 / 033 / 034 | building on shipped diagnostics |
+| ⚪ | Privacy-preserving field-feedback loop — local self-diagnosis → consented reports → opt-in aggregates | SPEC-036 / 039 / 040 | building on shipped diagnostics |
 
 **Autonomy ceilings, per domain.**
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -108,6 +108,52 @@ These have SPECs and are ready to claim, but we're **holding new feature scope**
 
 ---
 
+## Becoming autonomous
+
+> North-star reflection, **not a committed milestone**. No item below is claimed,
+> dated, or gated on the Adoption focus band. It records where the repo would have
+> to change to let agents run the contribution loop on their own — so the gaps are
+> written down, not rediscovered.
+
+**What exists — the contract.** Specs-as-law (`AGENTS.md`), four bench harnesses
+(`openquack-bench` / `-stream-bench` / `-polish-bench` / `-bias-bench`), issue +
+PR templates, the GTM trackers and playbooks, and persistent agent memory. An
+agent that reads these knows *what* good work looks like and *how* it is judged.
+
+**The meta-gap — no machinery.** The contract is human-readable, not
+machine-executable. `.claude/` holds only `worktrees/` — no committed
+`agents/`, `commands/`, `workflows/`, or `settings`. `AGENTS.md` is a manual a
+human (or a prompted agent) follows by hand; nothing *runs* the
+backlog → claim → branch → implement → draft-PR loop. CI smoke-tests the tiny
+model on the short corpus only, so quality regressions pass unseen.
+
+**Three unlocks.**
+
+| | Unlock | Spec | State |
+|---|---|---|---|
+| 🔵 | Committed `.claude/` agent harness — named roles, saved workflows, trigger + permissions model with human gates on irreversible steps | SPEC-037 | spec proposal |
+| 🔵 | CI eval-gate — fetchable corpus, medium-model WER/RTF thresholds on every quality-path PR | SPEC-038 | spec proposal |
+| 🟡 | Signed, tag-triggered release pipeline — the cut a release-bot can only PREP today | SPEC-025 | partial |
+| ⚪ | Privacy-preserving field-feedback loop — local self-diagnosis → consented reports → opt-in aggregates | SPEC-036 / 033 / 034 | building on shipped diagnostics |
+
+**Autonomy ceilings, per domain.**
+
+- **Product** — privacy-capped. No telemetry by design, so field validation
+  never closes to a metric automatically; the loop ends at a *consented*,
+  human-attached report. Self-diagnosis can be autonomous; collection cannot.
+- **Ops** — needs signing. Release stays manual (DMG + appcast + cask SHA)
+  until SPEC-025 lands a notarised, tag-triggered cut. A bot may prep the
+  release; a human gates it.
+- **GTM** — assisted, not autonomous. Platform anti-bot defences and fragile
+  community trust (see the flagged HN launch) make autonomous public posting a
+  liability. Target is agent-*assisted*: draft, schedule, scan, measure — with a
+  human gate on every outward post.
+
+**Realistic target.** Agents run the loop; humans gate the irreversible and
+outward steps — merge, release, public post.
+
+---
+
 ## How to claim a task
 
 1. **Pick from Adoption focus first.** Move to Feature backlog only if Adoption is empty.

--- a/docs/SPECS/SPEC-037-agent-harness-orchestration.md
+++ b/docs/SPECS/SPEC-037-agent-harness-orchestration.md
@@ -92,7 +92,7 @@ dictation or agent-dispatch hot path.
 Preserves the `docs/VISION.md` contract. The harness operates on repo source,
 specs, and the GitHub API — no audio, transcript text, or user data. The
 field-feedback loop the harness might one day consume stays consented and
-opt-in (SPEC-036 / 033 / 034 own that); SPEC-037 does not collect or transmit
+opt-in (SPEC-036 / 039 / 040 own that); SPEC-037 does not collect or transmit
 anything from users. The `gtm/` workspace stays gitignored and local; no role
 may stage it. No new network call enters the dictation or agent-dispatch hot
 path.

--- a/docs/SPECS/SPEC-037-agent-harness-orchestration.md
+++ b/docs/SPECS/SPEC-037-agent-harness-orchestration.md
@@ -1,0 +1,128 @@
+# SPEC-037 — Agent harness & orchestration
+
+**Status:** proposal
+
+## Goal
+
+Make the contribution loop machine-executable. Today `AGENTS.md` is a manual a
+human or a hand-prompted agent follows; nothing in the repo *runs* the
+backlog → claim → branch → implement → draft-PR cycle. This spec proposes a
+committed `.claude/` harness — named subagent roles, saved workflows, a trigger
+layer, and a permissions/secrets model — so an agent can pick up a 🔵 task and
+land a draft PR without a human kicking each step, while every irreversible or
+outward action (merge, release, public post) stays behind a hard human gate.
+
+Design-first: this PR adds the spec only. Implementation is a follow-up per
+`AGENTS.md` (one PR adds the spec; a later PR builds it).
+
+## Background
+
+`.claude/` currently holds only `worktrees/`. There is no committed
+`agents/`, `commands/`, `workflows/`, or `settings.json` — the orchestration
+layer lives in whatever ad-hoc prompt a maintainer types. The repo already has
+the *contract* an autonomous loop needs (specs-as-law, four bench harnesses,
+issue/PR templates, persistent memory); what is missing is the *runner*.
+
+Two adjacent capabilities are explicitly **not** built here and are cross-linked
+instead of duplicated: the quality eval-gate the implementer/bench-runner roles
+report against is **SPEC-038**, and the signed release the release-bot wants to
+cut is **SPEC-025**. SPEC-037 is the harness that *defers to* 038 for quality
+and *blocks on* 025 for the release cut.
+
+## Mechanism
+
+### Committed roles (`.claude/agents/`)
+
+One file per role, each scoped to a single concern:
+
+| Role | Does | May NOT |
+|---|---|---|
+| `spec-writer` | Drafts a `SPEC-XXX` for an ⚪ idea; opens a spec PR | implement before the spec PR merges |
+| `implementer` | Claims a 🔵 task, branches, implements, opens a draft PR | merge; touch the dictation/agent hot path with new network IO |
+| `reviewer` | Reviews a draft PR against its cited spec's acceptance criteria | approve-and-merge in one step |
+| `bench-runner` | Runs the relevant `openquack-*bench`, reports the delta in the PR | gate on results (that is SPEC-038's CI job, not a local role) |
+| `release-bot` | PREPs a release (version bump, cask SHA stub, draft notes) | cut a release — blocked until SPEC-025 signing lands |
+| `gtm-drafter` | Drafts/schedules/scans posts into the gitignored `gtm/` workspace | post publicly; `git add gtm/` |
+
+### Saved workflows (`.claude/workflows/`)
+
+Named, replayable multi-step flows that compose the roles — e.g.
+`claim-and-draft` (pick 🔵 → branch → implement → draft PR) and
+`spec-from-idea` (⚪ → spec PR). A workflow is a committed file, not a live
+prompt, so its steps and its gates are reviewable in a diff.
+
+### The loop
+
+`backlog → claim → branch → implement → draft-PR`, driven by `claim-and-draft`:
+read `ROADMAP.md`, pick the highest-priority unclaimed 🔵 (Adoption focus
+before Feature backlog, per the roadmap's own ordering), open the *Agent Task*
+issue, branch, implement against the spec's acceptance criteria, run build +
+test + any bench the change touches, open a **draft** PR citing the spec. The
+loop stops at draft. It never marks ready, never merges.
+
+### Trigger layer (`.claude/`)
+
+- **cron** — periodic backlog scan; emit one `claim-and-draft` run when an
+  unclaimed 🔵 exists and no draft PR already covers it.
+- **GitHub events** — a new bug-report issue routes to `spec-writer` triage; a
+  red CI on an agent's own draft routes back to `implementer`; a review comment
+  routes to the PR author role.
+
+Triggers may *start* work and *open drafts*. They may not advance state past a
+draft.
+
+### Permissions & secrets — hard human gates
+
+The permissions model is deny-by-default at every outward or irreversible edge:
+
+| Action | Gate |
+|---|---|
+| Merge a PR | human only — no role and no workflow holds merge capability |
+| Cut a release | human only, **and** blocked until SPEC-025 (release-bot may PREP) |
+| Public post | human only — `gtm-drafter` writes to local `gtm/`, never posts |
+| Force-push / history rewrite / hot-path network call | forbidden per `AGENTS.md` |
+
+Secrets (signing keys, API tokens) are never readable by the implementer,
+reviewer, or gtm roles; only the release pipeline (SPEC-025) sees signing
+secrets, and only inside its gated job. The harness adds no network call to the
+dictation or agent-dispatch hot path.
+
+## Privacy impact
+
+Preserves the `docs/VISION.md` contract. The harness operates on repo source,
+specs, and the GitHub API — no audio, transcript text, or user data. The
+field-feedback loop the harness might one day consume stays consented and
+opt-in (SPEC-036 / 033 / 034 own that); SPEC-037 does not collect or transmit
+anything from users. The `gtm/` workspace stays gitignored and local; no role
+may stage it. No new network call enters the dictation or agent-dispatch hot
+path.
+
+## Acceptance criteria
+
+- [ ] `.claude/agents/` contains exactly the six role files above, each naming
+      its allowed actions and its explicit deny-list. (file check)
+- [ ] `.claude/workflows/` contains at least `claim-and-draft` and
+      `spec-from-idea` as committed files. (file check)
+- [ ] A dry-run of `claim-and-draft` against a seeded `Agent Task` issue
+      produces a **draft** PR that cites the spec and runs build + test, with
+      **no** human action between trigger and draft. (manual)
+- [ ] `grep` over `.claude/workflows/` and `agents/` shows **no** role or
+      workflow holds merge, release-cut, or public-post capability — every such
+      step routes through an approval gate. (grep, verifiable)
+- [ ] `release-bot` on a tagged commit produces a *prepared* release (version
+      bump + draft notes + cask SHA stub) and **halts before the cut**, with a
+      note that the cut is blocked on SPEC-025. (manual)
+- [ ] The cron + GitHub-event triggers are committed and documented; firing one
+      starts work but cannot advance a PR past draft. (file check + manual)
+- [ ] `swift build && swift test` unaffected (harness is config, not product
+      code). (CI)
+
+## Out of scope
+
+- **Autonomous public posting.** GTM is agent-*assisted* only — draft, schedule,
+  scan, measure — with a human gate on every outward post. (`gtm-drafter`.)
+- **Autonomous releases without signing.** release-bot PREPs; the cut is
+  human-gated and blocked until **SPEC-025** lands notarisation.
+- **The CI eval-gate.** WER/RTF gating on real corpora is **SPEC-038**; this
+  spec's bench-runner only *reports*, it does not gate.
+- **Self-merge under any condition.** Merge is human-only, full stop.

--- a/docs/SPECS/SPEC-038-ci-eval-gate.md
+++ b/docs/SPECS/SPEC-038-ci-eval-gate.md
@@ -1,0 +1,110 @@
+# SPEC-038 — CI eval-gate on the real corpora
+
+**Status:** proposal
+
+## Goal
+
+Let CI fail a PR that regresses transcription quality or latency. Today
+`ci.yml` runs `openquack-bench` at **tiny** on **short** only, because the
+corpus audio is gitignored — so neither a human nor an agent can catch a WER or
+RTF regression before merge. The live SPEC-035 work (slow / inaccurate
+streaming reports) is exactly the class of regression that slips through. This
+spec proposes a CI eval-gate: a fetchable curated corpus, a medium-model run
+across multilingual + noisy + voices, PR thresholds with a stated no-regression
+margin, and the delta reported in the PR per `AGENTS.md`.
+
+Design-first: this PR adds the spec only; the workflow is a follow-up.
+
+## Background
+
+`.gitignore` excludes all corpus audio (`bench/corpus/**/*.wav` …), and
+`AGENTS.md` makes committing audio samples a **hard rule** — forbidden without
+explicit human approval. So the smoke in `ci.yml` is all CI can do as written.
+
+The audio is *reproducible*, not lost: `bench/corpus/fetch.sh` regenerates the
+synthetic buckets via macOS `say`, `fetch_librispeech.sh` pulls real human
+speech from openslr.org, and `mix_noise.py` derives the noisy buckets. The
+references (`*.txt`) are tracked. The gap is a *fixed* corpus CI can fetch and a
+job that gates on it.
+
+## Mechanism
+
+### Corpus delivery — recommendation
+
+Three options, with the tie broken by the hard rule:
+
+- **git-LFS** — still commits audio to git. Collides with the `AGENTS.md`
+  hard rule. **Rejected.**
+- **Committed golden subset** — *literally* the forbidden thing (audio in the
+  tree). Allowed **only** with explicit maintainer sign-off; named here for
+  completeness, not recommended.
+- **Hosted + cached fetch** — *recommended.* A fixed corpus tarball hosted out
+  of tree (GitHub Release asset / object store), fetched in CI and restored from
+  the Actions cache keyed by a **manifest hash**. Respects the hard rule (no
+  audio in git), and gives the byte-stable inputs a WER gate needs.
+
+A WER gate requires fixed inputs: `say`-regenerated audio drifts across runner
+macOS image updates, producing phantom regressions. So the gate fetches a
+*pinned* hosted corpus rather than regenerating it. The fetch verifies the
+manifest hash before running.
+
+### The eval job
+
+A workflow (label- or nightly-triggered for the slow medium path, not every doc
+PR) fetches the pinned corpus and runs at **medium** on the quality-relevant
+buckets:
+
+- `openquack-bench --models medium` on `multilingual`, `noisy`, `voices`
+- `openquack-stream-bench --models medium` on the long / code-switch clips
+
+Medium model weights are fetched + cached (committing weights is the same hard
+rule), not vendored.
+
+### Gating
+
+- **WER — hard gate.** Per-bucket WER must not regress beyond a stated margin
+  vs the committed baseline (e.g. ≤ +0.5 pp). WER is hardware-independent, so the
+  shared `macos-15` runner is a valid judge.
+- **RTF — soft gate, same-runner.** RTF is hardware-dependent; the runner is not
+  comparable to the host-tagged `M4-16GB` numbers in `BENCHMARKS.md`. Gate RTF
+  only against a *same-runner* baseline with a stated margin, host-tagged
+  separately, or it flaps.
+- **Report the delta in the PR** per `AGENTS.md` — WER/RTF per bucket vs baseline,
+  posted as a comment, regardless of pass/fail.
+
+## Privacy impact
+
+Preserves the `docs/VISION.md` contract. The corpus is synthetic (`say` TTS),
+public-domain (LibriSpeech, CC BY 4.0), and noise-augmented derivatives — no
+user audio, no transcripts, no telemetry. Everything runs in CI on public data;
+nothing touches the dictation hot path or a user's machine.
+
+## Acceptance criteria
+
+- [ ] CI fetches a pinned hosted corpus, verifies its manifest hash, and
+      restores it from the Actions cache on a warm run — **no audio committed to
+      git**. (CI log + `git ls-files | grep -c '\.wav$'` stays 0)
+- [ ] The eval job runs `openquack-bench --models medium` on `multilingual`,
+      `noisy`, and `voices`, and `openquack-stream-bench --models medium` on the
+      long/code-switch clips. (CI log)
+- [ ] A PR that pushes any bucket's WER beyond the stated margin **fails** the
+      gate; a within-margin change passes. (manual: seed a deliberate
+      regression)
+- [ ] Every eval run posts a per-bucket WER/RTF delta vs baseline as a PR
+      comment, pass or fail. (CI artifact + comment)
+- [ ] RTF is gated only against a same-runner baseline, host-tagged separately
+      from the `M4-16GB` BENCHMARKS numbers; a cold-runner RTF swing alone does
+      not fail the gate. (CI config review)
+- [ ] The slow medium path is label- or nightly-triggered, not run on every doc
+      PR. (workflow trigger config)
+
+## Out of scope
+
+- **An end-to-end / app-behaviour test.** There is no test that drives the
+  shipped app (hotkey → record → paste). This spec gates *engine* quality only;
+  the e2e gap is a sibling follow-up, not solved here.
+- **Committing the corpus or model weights to git** — forbidden by `AGENTS.md`;
+  the committed-subset option needs explicit maintainer sign-off if ever taken.
+- **The agent harness that consumes this gate** — that is **SPEC-037**.
+- **Polish/bias bench gating** (`openquack-polish-bench` / `-bias-bench`) — add
+  once the transcription gate is stable; out of scope here.


### PR DESCRIPTION
## SPEC

SPEC-037 (Agent harness & orchestration) + SPEC-038 (CI eval-gate on the real corpora) — both **proposal** specs. Plus a ROADMAP "Becoming autonomous" reflection.

## Milestone

n/a — design-first proposal docs + a north-star reflection (no milestone task claimed).

## Why

A reflection on making the repo agent-autonomous across product / ops / GTM: it writes the gaps down so they are tracked, not rediscovered. The repo already has the *contract* (specs-as-law, four bench harnesses, trackers, memory); what is missing is the *machinery* — and a real-corpus quality gate. (This batch's SPEC-035 A/B is the live case: a quality hypothesis that turned out false, which only a gate like SPEC-038 would catch in CI.)

## Change

- **`docs/ROADMAP.md`**: a `## Becoming autonomous` section — what exists, the meta-gap (no committed `.claude/` harness), the three unlocks, the per-domain autonomy ceilings.
- **SPEC-037**: a committed `.claude/` harness — six scoped subagent roles, saved workflows, cron + GitHub-event triggers, and a deny-by-default permissions model with **hard human gates** at every irreversible/outward step (merge, release, public post). release-bot PREPs; the cut blocks on SPEC-025.
- **SPEC-038**: a CI eval-gate running medium-model WER/RTF on the real corpora (today gitignored → CI smokes tiny/short only). Hosted+cached corpus fetch (no audio in git, per the AGENTS hard rule); WER hard-gate, RTF same-runner soft-gate; delta reported in the PR.

## Tests

- [x] docs only; `swift build && swift test` unaffected (still green, 196 tests)

## Privacy impact

None — docs only. Both specs preserve the privacy contract: no telemetry; the field-feedback loop stays consented/opt-in and is owned elsewhere (SPEC-036/039/040).

## Out of scope

- Implementation — design-first per `AGENTS.md` (the spec PR precedes the build PR).
- An e2e / app-behaviour test (sibling follow-up, noted in SPEC-038).
