### PR TITLE
fix(SPEC-010): resolve Swift 6 concurrency warnings in AppDelegate

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -27,6 +27,7 @@ struct OpenQuackApp {
     }
 }
 
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
     private var popover: NSPopover!
@@ -1096,7 +1097,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         polishIdleTimer?.invalidate()
         polishIdleTimer = Timer.scheduledTimer(withTimeInterval: Self.polishIdleUnload,
                                                repeats: false) { [weak self] _ in
-            self?.unloadPolishEngine()
+            MainActor.assumeIsolated { self?.unloadPolishEngine() }
         }
     }
 
@@ -1109,22 +1110,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func startElapsedTimer() {
         elapsedTimer?.invalidate()
         elapsedTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            let elapsed = self.recorder.elapsedSeconds
-            self.appState.elapsedSeconds = elapsed
+            // Timer fires on the main run loop it was scheduled from, so the
+            // @Sendable block is already on the main actor.
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let elapsed = self.recorder.elapsedSeconds
+                self.appState.elapsedSeconds = elapsed
 
-            // VAD auto-stop while recording.
-            guard self.vadEnabled,
-                  case .recording = self.appState.phase
-            else { return }
+                // VAD auto-stop while recording.
+                guard self.vadEnabled,
+                      case .recording = self.appState.phase
+                else { return }
 
-            if self.appState.currentLevel > Self.voiceThreshold {
-                self.lastVoiceAt = Date()
-            }
-            if let lastVoice = self.lastVoiceAt,
-               elapsed >= Self.vadMinDuration,
-               Date().timeIntervalSince(lastVoice) >= self.vadSilenceSeconds {
-                self.stopAndTranscribe()
+                if self.appState.currentLevel > Self.voiceThreshold {
+                    self.lastVoiceAt = Date()
+                }
+                if let lastVoice = self.lastVoiceAt,
+                   elapsed >= Self.vadMinDuration,
+                   Date().timeIntervalSince(lastVoice) >= self.vadSilenceSeconds {
+                    self.stopAndTranscribe()
+                }
             }
         }
     }
@@ -1252,7 +1257,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 extension AppDelegate: UNUserNotificationCenterDelegate {
     /// Show kickoff-result banners even while OpenQuack is foreground
     /// (e.g. user opened Settings) — otherwise macOS suppresses them.
-    func userNotificationCenter(
+    nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
@@ -1262,7 +1267,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
     /// Click handler — opens the response window for the result whose
     /// shortID is carried in userInfo.
-    func userNotificationCenter(
+    nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void


### PR DESCRIPTION
## SPEC
SPEC-010 (App shell)

## Milestone
M1

## Why
`AppDelegate` emitted four Swift 6 concurrency diagnostics (warnings today, errors under Swift 6 mode). No runtime race, but they're build noise blocking a clean future migration. Closes #76.

## Change
- Annotate `AppDelegate` `@MainActor` (the class becomes implicitly `Sendable`, clearing the non-Sendable `self` captures in the `@Sendable` Timer/Task closures).
- Wrap the two run-loop Timer bodies (`schedulePolishIdleUnload`, `startElapsedTimer`) in `MainActor.assumeIsolated` — synchronous, zero behaviour change since the timers fire on the main run loop.
- Mark the two `UNUserNotificationCenterDelegate` witnesses `nonisolated` so the conformance no longer crosses into main-actor code.

## Tests
- [ ] unit test added/updated: n/a — app layer is an executableTarget (untestable by SwiftPM); change is isolation annotations only
- [x] `swift build && swift test` green locally (223 passed, 2 skipped; 0 warnings in OpenQuackApp)

## Privacy impact
Preserved. No audio capture, transcription, agent dispatch, or output path touched — pure actor-isolation annotations.

## Out of scope
The `OpenQuackApp.swift` file split / `AppDelegate` responsibility decomposition floated in #76 — deferred.

## AI coding brief
- **Original request:** Fix the four Swift 6 concurrency warnings from #76; leave the larger refactor alone for now.
- **Manual interventions:** Human chose SPEC-010 as the citing SPEC.
- **Retro:** State up front "only the warning fix, not the refactor" and name the citing SPEC — would have skipped one clarification round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)