### PR TITLE
fix(history): prevent SIGABRT on recording stop when Opus rejects the sample rate

### DIFF
--- a/Sources/OpenQuackKit/History/HistoryStore.swift
+++ b/Sources/OpenQuackKit/History/HistoryStore.swift
@@ -504,6 +504,18 @@ public actor HistoryStore {
             AVNumberOfChannelsKey: 1,
             AVEncoderBitRateKey:   bitRate,
         ]
+        // `AVAssetWriterInput.init(mediaType:outputSettings:)` raises an
+        // Objective-C `NSInvalidArgumentException` — not a Swift error — when the
+        // settings are unsupported for this codec/container/sample-rate combo
+        // (e.g. Opus at a non-48 kHz rate). A Swift `do/catch` can't intercept an
+        // ObjC exception, so it would abort the process and bypass the AAC
+        // fallback in `encodeAudio`. Validate first and surface a Swift error
+        // instead, keeping the fallback path alive.
+        guard writer.canApply(outputSettings: outputSettings, forMediaType: .audio) else {
+            throw HistoryError.encodingFailed(
+                "unsupported outputSettings for codec 0x\(String(codec, radix: 16)) at \(sampleRate) Hz"
+            )
+        }
         let input = AVAssetWriterInput(mediaType: .audio, outputSettings: outputSettings)
         input.expectsMediaDataInRealTime = false
         guard writer.canAdd(input) else {

--- a/Tests/OpenQuackKitTests/HistoryStoreTests.swift
+++ b/Tests/OpenQuackKitTests/HistoryStoreTests.swift
@@ -90,6 +90,35 @@ final class HistoryStoreTests: XCTestCase {
         XCTAssertGreaterThan(size, 0, "encoded audio file should be non-empty")
     }
 
+    // Opus only supports 8/12/16/24/48 kHz; at 44.1 kHz the Opus encoder's
+    // settings are rejected. The rejection surfaces inside
+    // `AVAssetWriterInput.init(mediaType:outputSettings:)` as an Objective-C
+    // exception, which previously aborted the process (SIGABRT) instead of
+    // falling back to AAC. This guards the fallback path: the save must succeed
+    // and produce a non-empty AAC file rather than crash.
+    func testSaveWithAudio_atOpusUnsupportedRate_fallsBackToAAC() async throws {
+        let store = makeStore()
+        let sampleRate = 44_100.0
+        var samples = [Float](repeating: 0, count: 44_100)
+        for i in 0..<samples.count {
+            samples[i] = 0.1 * sin(2 * .pi * 440 * Float(i) / Float(sampleRate))
+        }
+        let entry = try await store.save(audio: samples,
+                                         audioSampleRate: sampleRate,
+                                         transcript: "tone",
+                                         language: nil,
+                                         modelID: "medium",
+                                         durationSeconds: 1.0)
+        guard let url = entry.audioURL else {
+            XCTFail("expected audioURL after save with audio")
+            return
+        }
+        XCTAssertEqual(url.pathExtension, "m4a", "should fall back to the AAC/m4a encoder")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let size = (try FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? 0
+        XCTAssertGreaterThan(size, 0, "encoded audio file should be non-empty")
+    }
+
     // MARK: - markTranscribed (errors)
 
     func testMarkTranscribed_throwsOnUnknownID() async throws {

--- a/scripts/wrap_app.sh
+++ b/scripts/wrap_app.sh
@@ -96,7 +96,7 @@ cat > "$BUNDLE/Contents/Info.plist" <<PLIST
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
     SPEC-026 — SUPublicEDKey is intentionally a placeholder. The user
-    runs Sparkle's bundled `generate_keys` once locally; the public half
+    runs Sparkle's bundled \`generate_keys\` once locally; the public half
     lands here as a follow-up commit, the private half stays in the
     maintainer's Keychain + a GH Actions secret. Until that swap lands,
     Sparkle fetches the appcast but refuses to install any update — by


### PR DESCRIPTION
## SPEC

SPEC-014 (Local history) — this is a bug fix in the existing implementation, so no new spec is added.

## Milestone

History (shipped) — defect fix.

## Why

OpenQuack aborted with `SIGABRT` on **every** recording stop and vanished, discarding the just-spoken transcript. The crash happened while persisting the recording to local history.

## Change

`Sources/OpenQuackKit/History/HistoryStore.swift`
- `encode(...)` constructs an `AVAssetWriterInput(mediaType:outputSettings:)`. When the output settings are unsupported for the codec — e.g. Opus at a sample rate outside `{8, 12, 16, 24, 48}` kHz — that initialiser raises an Objective-C `NSInvalidArgumentException`, **not** a Swift error. The `do/catch` in `encodeAudio(...)` that is meant to fall back from Opus to AAC cannot intercept an ObjC exception, so the fallback was bypassed and the process aborted.
- Fix: pre-validate the settings with `AVAssetWriter.canApply(outputSettings:forMediaType:)` (this method lives on `AVAssetWriter`, not `AVAssetWriterInput`) before constructing the input, and throw a Swift `HistoryError.encodingFailed` when it returns false. The Opus→AAC fallback now works as intended.

`scripts/wrap_app.sh`
- The Info.plist here-doc is unquoted (it interpolates `$VERSION`), so a stray backtick pair around `generate_keys` in a comment was executed as a command substitution, printing `generate_keys: command not found` on every build. Escaped the backticks.

## Tests

- [x] unit test added: `testSaveWithAudio_atOpusUnsupportedRate_fallsBackToAAC` (saves 44.1 kHz audio — an Opus-unsupported rate — and asserts a non-empty `.m4a` is produced instead of aborting)
- [x] `swift test --filter HistoryStoreTests` green locally (16 passed, 0 failures)

## Privacy impact

None. The change only affects how already-captured audio is encoded on disk for local history. No capture, transcription, or dispatch behaviour changes. The privacy contract in `docs/VISION.md` is preserved.

## Out of scope

Root-causing *why* the recording sample rate lands outside Opus's supported set on some hosts. Falling back to AAC is the correct behaviour regardless of the rate, so it is handled here; a follow-up could normalise the recording rate if Opus output is desired everywhere.
