### PR TITLE
docs(faq): explain blank-audio "You." transcripts + add in-app FAQ menu item

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -441,6 +441,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         feedback.target = self
         menu.addItem(feedback)
 
+        let faq = NSMenuItem(title: "FAQ / Help…", action: #selector(menuOpenFAQ), keyEquivalent: "")
+        faq.target = self
+        menu.addItem(faq)
+
         menu.addItem(.separator())
 
         let quit = NSMenuItem(title: "Quit OpenQuack", action: #selector(menuQuitApp), keyEquivalent: "q")
@@ -465,6 +469,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // SPEC-018. Opens the GitHub issue chooser; user picks bug report
         // or feature request from there. No app-side network IO.
         guard let url = URL(string: "https://github.com/larryxiao/openquack/issues/new/choose") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Opens the docs-site FAQ (includes the "blank/'You.' transcript" and
+    /// permission troubleshooting entries). No app-side network IO; hands off
+    /// to the default browser.
+    @MainActor
+    @objc private func menuOpenFAQ() {
+        guard let url = URL(string: "https://larryxiao.github.io/openquack/#faq") else {
             return
         }
         NSWorkspace.shared.open(url)

--- a/docs/WHISPER-ON-MAC-FAQ.md
+++ b/docs/WHISPER-ON-MAC-FAQ.md
@@ -56,7 +56,7 @@ In our experience, the first transcription takes ~10-30 s even on `medium`; the 
 
 ## How do I prevent silence-induced hallucinations?
 
-Whisper occasionally produces fluent text for silent audio — e.g. "Thanks for watching!" or "Subtitles by [name]" from Whisper's training data leaking through. Causes and mitigations:
+Whisper occasionally produces fluent text for silent audio — e.g. a bare "You.", "Thank you.", "Thanks for watching!", or "Subtitles by [name]" from Whisper's training data leaking through. Causes and mitigations:
 
 1. **VAD prefilter.** Strip silence before sending to Whisper. OpenQuack's auto-stop-after-silence uses a simple energy threshold; production systems use Silero VAD or similar. Strip leading and trailing silence; on long clips, strip mid-recording silence too.
 2. **`no_speech_threshold` parameter.** Whisper exposes a probability threshold below which it returns empty. Default is around 0.6; you can raise it to 0.8 or higher if hallucinations are frequent.
@@ -64,6 +64,8 @@ Whisper occasionally produces fluent text for silent audio — e.g. "Thanks for 
 4. **Clip-length lower bound.** Audio shorter than ~0.5 s often produces nonsense regardless. Reject sub-half-second clips at the application layer.
 
 Whisper-mini-tier models hallucinate more under silence than the larger ones; if you're seeing this on `tiny` or `base`, model size may be a faster fix than parameter-tuning.
+
+**If you're an end user seeing this on every recording:** the trigger usually isn't the model at all — it's an empty recording. A bare "You." or "Thank you." almost always means the mic captured silence. Confirm the recording overlay's level meter moves when you speak, and that the app has Microphone permission (System Settings → Privacy & Security → Microphone; restart OpenQuack after granting it). Play back `~/Library/Application Support/OpenQuack/last-recording.wav` to hear exactly what was captured.
 
 ## Can I bias Whisper toward specific words (proper nouns, jargon, project names)?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,9 @@ OpenQuack pastes at wherever your cursor is — including the prompt bars of Cla
 **Why does the first launch take a long time?**
 The speech model downloads once on first run and is cached permanently in `~/Library/Application Support/OpenQuack/models/`. Every subsequent launch is instant.
 
+**Why is my transcript just "You.", "Thank you.", or "Thanks for watching"?**
+That short, oddly generic output is Whisper hallucinating on *silent* audio — those exact phrases leak from its training data when it's given little or no speech. It almost always means OpenQuack recorded silence instead of your voice. Check, in order: (1) while recording, watch the level meter in the recording overlay — if the bars don't move when you talk, no audio is reaching the app; (2) open **System Settings → Privacy & Security → Microphone** and make sure OpenQuack is listed and enabled (after granting it, restart OpenQuack so the grant takes effect); (3) confirm your active input device under **System Settings → Sound → Input** is the mic you're actually speaking into, not a silent virtual device. To hear exactly what was captured, play back the last recording at `~/Library/Application Support/OpenQuack/last-recording.wav`.
+
 **Is there a Windows or Linux version?**
 Not currently. OpenQuack uses WhisperKit and CoreML, which are Apple-platform technologies.
 


### PR DESCRIPTION
## SPEC

SPEC-018 (Feedback menu) — extends the existing menu-bar right-click menu with a sibling "FAQ / Help…" item. The doc changes are user-facing FAQ content, so no new spec is added.

## Milestone

Docs + adoption polish.

## Why

When a user's microphone isn't actually captured — permission granted but not effective, or the wrong input device selected — every recording comes back as a bare `"You."`, `"Thank you."`, or `"Thanks for watching"`. That's Whisper hallucinating on silent audio. It's confusing because the app otherwise looks like it's working, and there was no user-facing guidance pointing at the real cause (the mic), only a developer-oriented note in the Whisper FAQ.

## Change

- `docs/index.md` — new FAQ entry **"Why is my transcript just 'You.', 'Thank you.', or 'Thanks for watching'?"** with an ordered checklist: (1) watch the recording overlay's level meter, (2) check **System Settings → Privacy & Security → Microphone** and restart after granting, (3) confirm the active input device. Points at `~/Library/Application Support/OpenQuack/last-recording.wav` to verify capture independently.
- `docs/WHISPER-ON-MAC-FAQ.md` — list `"You."` among the silence-hallucination tokens and add an end-user note in the existing "How do I prevent silence-induced hallucinations?" entry pointing at the same mic/permission checks.
- `Sources/OpenQuackApp/OpenQuackApp.swift` — add a **"FAQ / Help…"** item to the menu-bar right-click menu (next to "Send feedback…") that opens the docs-site FAQ in the browser, so help is reachable from the app itself.

## Tests

- [x] `swift build` green locally (release build via `scripts/wrap_app.sh`)
- [ ] No unit test — change is a docs addition plus a menu item that opens a URL (mirrors the existing `menuSendFeedback` pattern, which is likewise untested)
- Manual repro: right-click the menu-bar duck → **FAQ / Help…** opens `https://larryxiao.github.io/openquack/#faq`.

## Privacy impact

None. The menu item opens a URL in the default browser (no app-side network IO, same posture as the existing "Send feedback…" item). Docs-only otherwise. Privacy contract preserved.

## Out of scope

Deep-linking to the specific FAQ anchor inside an in-app help window, and any change to the permission-request flow itself.
