### PR TITLE
feat(capture): warn on silent recording instead of transcribing hallucinations

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -822,7 +822,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func stopAndTranscribe() {
         stopElapsedTimer()
         let audioDuration = recorder.elapsedSeconds
+        // Captured peak level, read before stop() tears the recorder down.
+        // A silent capture (dead/muted mic, or a virtual input device that
+        // emits silence) otherwise gets transcribed into a Whisper
+        // hallucination like "You." — warn the user instead.
+        let capturePeakRMS = recorder.peakRMS
         guard let url = recorder.stop() else { return }
+
+        if capturePeakRMS < AudioRecorder.silenceRMSThreshold {
+            Task {
+                await tearDownFramesPump()
+                if let streamer { await streamer.cancel() }
+                await MainActor.run {
+                    appState.phase = .error("No sound detected. Check your microphone in System Settings → Sound → Input, and that OpenQuack has mic permission.")
+                    schedulePolishIdleUnload()
+                }
+                try? FileManager.default.removeItem(at: url)
+            }
+            return
+        }
+
         Task {
             let phaseStart = Date()
             await MainActor.run {

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -43,6 +43,23 @@ public final class AudioRecorder {
     private var _outputURL: URL?
     private var _startTime: Date?
     private var _isRecording = false
+    private var _peakRMS: Float = 0
+
+    /// Peak raw-RMS (float32, ~0…1) seen across the current or most recent
+    /// recording. Reset on `start()`, retained after `stop()` so callers can
+    /// inspect it. Conversational speech peaks well above
+    /// `silenceRMSThreshold`; a dead/muted mic or a virtual input device that
+    /// emits silence stays near zero — letting callers warn the user instead
+    /// of feeding silence to Whisper (which hallucinates "You." / "Thank you.").
+    public var peakRMS: Float {
+        lock.lock(); defer { lock.unlock() }
+        return _peakRMS
+    }
+
+    /// Captures whose peak RMS stays under this are treated as "no usable
+    /// audio". Conversational speech sits at RMS ~0.02–0.1; ambient room
+    /// noise and silent virtual devices are well below this floor.
+    public static let silenceRMSThreshold: Float = 0.005
 
     /// Called on the main queue with each buffer's RMS level (0…1, gently
     /// scaled for UI). Set this before calling `start` to drive a level meter.
@@ -145,7 +162,7 @@ public final class AudioRecorder {
         let framesHandler = self.framesHandler
         let inputSampleRate = inputFormat.sampleRate
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
             do {
                 try file.write(from: buffer)
             } catch {
@@ -154,9 +171,14 @@ public final class AudioRecorder {
                 )
             }
 
+            // One RMS pass per buffer, reused for both the silence detector and
+            // the UI meter.
+            let rms = Self.rawRMS(from: buffer)
+            self?.recordPeak(rms)
+
             // Emit a UI-friendly level if anyone is subscribed.
             if let levelHandler {
-                let level = Self.uiLevel(from: buffer)
+                let level = Self.uiLevel(fromRMS: rms)
                 DispatchQueue.main.async { levelHandler(level) }
             }
 
@@ -185,7 +207,15 @@ public final class AudioRecorder {
         self._outputURL = url
         self._startTime = Date()
         self._isRecording = true
+        self._peakRMS = 0
         return url
+    }
+
+    /// Audio-thread hook: fold this buffer's RMS into the running peak. Held
+    /// under the same lock as start/stop; the critical section is a single
+    /// `max`, so contention with the (infrequent) lifecycle calls is negligible.
+    private func recordPeak(_ rms: Float) {
+        lock.lock(); _peakRMS = max(_peakRMS, rms); lock.unlock()
     }
 
     /// Stop capture; returns the URL of the finalised WAV (caller owns cleanup).
@@ -211,22 +241,25 @@ public final class AudioRecorder {
         try? FileManager.default.removeItem(at: url)
     }
 
-    /// Compute a 0…1 UI level from a PCM buffer. Conversational speech sits
-    /// around RMS 0.02–0.1 in float32. Loudness is roughly logarithmic so
-    /// raw amplitude × constant feels dead — sqrt + a healthy multiplier
-    /// makes a normal speaking voice swing across most of the meter.
-    private static func uiLevel(from buffer: AVAudioPCMBuffer) -> Float {
+    /// Raw RMS of a PCM buffer in float32 amplitude (0…~1). Subsamples every
+    /// 4th frame — plenty for both the meter and the silence detector.
+    static func rawRMS(from buffer: AVAudioPCMBuffer) -> Float {
         guard let channelData = buffer.floatChannelData?[0],
               buffer.frameLength > 0 else { return 0 }
         let count = Int(buffer.frameLength)
         var sumSq: Float = 0
-        for i in stride(from: 0, to: count, by: 4) {  // every 4th sample is plenty for a meter
+        for i in stride(from: 0, to: count, by: 4) {
             let s = channelData[i]
             sumSq += s * s
         }
-        let rms = sqrt(sumSq / Float(count / 4 + 1))
-        // sqrt(rms) approximates a perceptual curve; ×3 spreads conversational
-        // voice (RMS ~0.02–0.1) across roughly 0.4–0.95 of the meter.
+        return sqrt(sumSq / Float(count / 4 + 1))
+    }
+
+    /// Map a raw RMS to a 0…1 UI level. Loudness is roughly logarithmic so
+    /// raw amplitude × constant feels dead — sqrt + a healthy multiplier makes
+    /// a normal speaking voice swing across most of the meter. ×3 spreads
+    /// conversational voice (RMS ~0.02–0.1) across roughly 0.4–0.95.
+    static func uiLevel(fromRMS rms: Float) -> Float {
         let scaled = sqrt(rms) * 3.0
         return max(0, min(1.0, scaled))
     }

--- a/Tests/OpenQuackKitTests/AudioRecorderLevelTests.swift
+++ b/Tests/OpenQuackKitTests/AudioRecorderLevelTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import AVFoundation
+@testable import OpenQuackKit
+
+final class AudioRecorderLevelTests: XCTestCase {
+    private let sampleRate = 16_000.0
+    private let frames: AVAudioFrameCount = 1_600   // 0.1 s
+
+    private func buffer(fill: (Int) -> Float) -> AVAudioPCMBuffer {
+        let fmt = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                sampleRate: sampleRate,
+                                channels: 1,
+                                interleaved: false)!
+        let buf = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: frames)!
+        buf.frameLength = frames
+        let ch = buf.floatChannelData![0]
+        for i in 0..<Int(frames) { ch[i] = fill(i) }
+        return buf
+    }
+
+    func testRawRMS_silentBuffer_isBelowSilenceThreshold() {
+        let buf = buffer { _ in 0 }
+        let rms = AudioRecorder.rawRMS(from: buf)
+        XCTAssertLessThan(rms, AudioRecorder.silenceRMSThreshold)
+    }
+
+    func testRawRMS_veryQuietNoise_isBelowSilenceThreshold() {
+        // Ambient floor (~0.002 amplitude) should not count as speech.
+        var seed: UInt64 = 0x9E3779B97F4A7C15
+        let buf = buffer { _ in
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            let unit = Float(seed >> 40) / Float(1 << 24) * 2 - 1  // -1…1
+            return unit * 0.002
+        }
+        let rms = AudioRecorder.rawRMS(from: buf)
+        XCTAssertLessThan(rms, AudioRecorder.silenceRMSThreshold)
+    }
+
+    func testRawRMS_conversationalSine_isAboveSilenceThreshold() {
+        // Amplitude 0.05 → RMS ≈ 0.035, squarely in conversational range.
+        let buf = buffer { i in 0.05 * sin(2 * .pi * 220 * Float(i) / Float(sampleRate)) }
+        let rms = AudioRecorder.rawRMS(from: buf)
+        XCTAssertGreaterThan(rms, AudioRecorder.silenceRMSThreshold)
+        XCTAssertEqual(rms, 0.05 / Float(2).squareRoot(), accuracy: 0.01)  // A/√2
+    }
+
+    func testUILevel_isClampedAndMonotonic() {
+        XCTAssertEqual(AudioRecorder.uiLevel(fromRMS: 0), 0, accuracy: 1e-6)
+        let quiet = AudioRecorder.uiLevel(fromRMS: 0.02)
+        let loud = AudioRecorder.uiLevel(fromRMS: 0.1)
+        XCTAssertGreaterThan(loud, quiet)
+        XCTAssertLessThanOrEqual(AudioRecorder.uiLevel(fromRMS: 5.0), 1.0)  // clamps
+        XCTAssertGreaterThanOrEqual(AudioRecorder.uiLevel(fromRMS: 0), 0.0)
+    }
+}

--- a/scripts/diagnose-capture.sh
+++ b/scripts/diagnose-capture.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Diagnose & fix the "transcript is just 'You.' / 'Thank you.'" problem.
+#
+# That output is Whisper hallucinating on SILENT audio — it almost always
+# means the mic wasn't actually captured (permission not effective, or the
+# wrong input device), not a model bug. This script:
+#   1. Shows the active input device.
+#   2. Records 3 s straight from the mic (independent of OpenQuack) and
+#      reports the peak level, so you can tell signal from silence.
+#   3. Resets OpenQuack's stale Microphone/Accessibility TCC grants.
+#   4. Restarts the app so macOS re-prompts cleanly.
+#
+# Usage: bash scripts/diagnose-capture.sh          # full: probe + reset + restart
+#        bash scripts/diagnose-capture.sh probe    # mic probe only (no reset)
+set -uo pipefail
+
+MODE="${1:-full}"
+BUNDLE_ID="org.openquack.OpenQuack"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP="$ROOT/build/OpenQuack.app"
+[[ -d "$APP" ]] || APP="/Applications/OpenQuack.app"
+
+echo "──────────────────────────────────────────────"
+echo " OpenQuack capture diagnosis"
+echo "──────────────────────────────────────────────"
+
+echo
+echo "▸ Active audio input device(s):"
+system_profiler SPAudioDataType 2>/dev/null \
+  | awk '/Input Source|Default Input Device|Manufacturer:/{print "   "$0}' \
+  | sed 's/^   *//' | sed 's/^/   /' || echo "   (could not read)"
+
+echo
+echo "▸ Mic signal probe — recording 3 s directly from the system mic."
+PROBE="$(mktemp -t oqmicprobe).swift"
+cat > "$PROBE" <<'SWIFT'
+import AVFoundation
+import Foundation
+
+let status = AVCaptureDevice.authorizationStatus(for: .audio)
+if status == .denied || status == .restricted {
+    print("RESULT: TERMINAL_DENIED — the terminal running this script has no")
+    print("        Microphone permission. Grant it in System Settings →")
+    print("        Privacy & Security → Microphone (enable your terminal app),")
+    print("        then re-run. This is about the terminal, not OpenQuack.")
+    exit(2)
+}
+let sem = DispatchSemaphore(value: 0)
+var granted = true
+if status == .notDetermined {
+    AVCaptureDevice.requestAccess(for: .audio) { ok in granted = ok; sem.signal() }
+    sem.wait()
+}
+guard granted else {
+    print("RESULT: TERMINAL_DENIED — permission request was declined.")
+    exit(2)
+}
+
+let engine = AVAudioEngine()
+let input = engine.inputNode
+let fmt = input.inputFormat(forBus: 0)
+guard fmt.sampleRate > 0 else {
+    print("RESULT: NO_DEVICE — no usable input device/format (sampleRate=0).")
+    exit(3)
+}
+var peak: Float = 0
+var sumSq: Double = 0
+var count: Int = 0
+input.installTap(onBus: 0, bufferSize: 1024, format: fmt) { buf, _ in
+    guard let ch = buf.floatChannelData?[0] else { return }
+    let n = Int(buf.frameLength)
+    for i in 0..<n {
+        let v = ch[i]
+        peak = max(peak, abs(v))
+        sumSq += Double(v * v)
+        count += 1
+    }
+}
+do { try engine.start() } catch {
+    print("RESULT: ENGINE_FAILED — \(error.localizedDescription)")
+    exit(3)
+}
+FileHandle.standardOutput.write("   >>> please speak now (3s)…\n".data(using: .utf8)!)
+Thread.sleep(forTimeInterval: 3)
+engine.stop()
+let rms = count > 0 ? (sumSq / Double(count)).squareRoot() : 0
+print(String(format: "   device sample rate: %.0f Hz", fmt.sampleRate))
+print(String(format: "   peak amplitude: %.4f   rms: %.4f", peak, rms))
+if peak < 0.01 {
+    print("RESULT: SILENT — the mic captured essentially no signal.")
+    print("        Either nothing was spoken, the input device is wrong/muted,")
+    print("        or the mic is dead. Try System Settings → Sound → Input and")
+    print("        watch the input level bar while you talk.")
+} else {
+    print("RESULT: OK — the mic IS capturing audio at the system level.")
+    print("        So if OpenQuack still returns 'You.', it's OpenQuack's mic")
+    print("        permission specifically — the reset below fixes that.")
+}
+SWIFT
+swift "$PROBE" 2>&1
+PROBE_RC=$?
+rm -f "$PROBE"
+
+[[ "$MODE" == "probe" ]] && { echo; echo "(probe-only mode — skipping reset/restart)"; exit "$PROBE_RC"; }
+
+echo
+echo "▸ Resetting OpenQuack's TCC grants (clears stale entries so macOS"
+echo "  re-prompts cleanly on next recording)…"
+tccutil reset Microphone   "$BUNDLE_ID" 2>&1 | sed 's/^/   /' || true
+tccutil reset Accessibility "$BUNDLE_ID" 2>&1 | sed 's/^/   /' || true
+echo "   done."
+
+echo
+echo "▸ Restarting OpenQuack…"
+pkill -f "OpenQuack.app/Contents/MacOS/openquack" 2>/dev/null && echo "   stopped old instance" || echo "   (no running instance)"
+sleep 1
+if [[ -d "$APP" ]]; then
+    open "$APP" && echo "   launched: $APP"
+else
+    echo "   ⚠ app bundle not found at $APP — build it with scripts/wrap_app.sh"
+fi
+
+echo
+echo "──────────────────────────────────────────────"
+echo " Next: record once in OpenQuack. macOS will re-ask for the mic —"
+echo " click Allow. Watch the overlay's level meter move as you speak."
+echo " Probe exit code: $PROBE_RC"
+echo "──────────────────────────────────────────────"


### PR DESCRIPTION
## SPEC

SPEC-001 (Voice capture) — hardens the capture path's failure handling. No new spec; this is a robustness fix on existing behaviour.

## Milestone

Capture reliability / adoption polish.

## Why

When the microphone captures no usable audio, Whisper doesn't return empty — it **hallucinates** fluent text from its training data, most often a bare `"You."` or `"Thank you."`. This happens whenever the real mic isn't the one being read: a muted/dead mic, the wrong input device, or a **virtual input device** (Lark/飞书, Microsoft Teams, etc.) that some other app set as the system default and that emits silence when idle. The app looked like it was working — record, "transcribe", paste `"You."` — so the failure was baffling. (Reported from a real setup: an external mic was connected but not configured, leaving a silent virtual device as the default input.)

## Change

- `Sources/OpenQuackKit/Audio/AudioRecorder.swift`
  - Track the **peak raw RMS** across a recording: reset on `start()`, folded in on every tap buffer, retained after `stop()` so callers can inspect it. Exposes `peakRMS` and `static let silenceRMSThreshold: Float = 0.005` (conversational speech is RMS ~0.02–0.1; silence and idle virtual devices sit near zero).
  - Refactor the per-buffer RMS into a reusable `rawRMS(from:)` + `uiLevel(fromRMS:)` so the meter and the silence detector share one pass.
- `Sources/OpenQuackApp/OpenQuackApp.swift`
  - `stopAndTranscribe()` reads `recorder.peakRMS` before teardown; if it's below the threshold it tears down the streamer, skips transcription entirely, and surfaces an actionable error — **"No sound detected. Check your microphone in System Settings → Sound → Input, and that OpenQuack has mic permission."** — instead of pasting a hallucinated word.
- `scripts/diagnose-capture.sh` (new)
  - Standalone diagnosis/fix tool: records 3 s straight from the mic and reports peak/RMS (signal vs silence), lists input devices + the current default, and resets OpenQuack's `Microphone`/`Accessibility` TCC grants so macOS re-prompts cleanly. `probe` arg runs the mic probe only.

## Tests

- [x] `Tests/OpenQuackKitTests/AudioRecorderLevelTests.swift` — `rawRMS` for silent / quiet-noise / conversational-sine buffers vs `silenceRMSThreshold`, plus `uiLevel` clamp/monotonicity. 4 tests, green.
- [x] `swift test` green locally; release build via `scripts/wrap_app.sh` green.
- Manual: with a silent default input device, recording now shows the "No sound detected" message instead of pasting "You.".

## Privacy impact

None. All detection is local (an RMS threshold on the already-captured buffer). No new capture, transcription, or network behaviour. A silent recording is discarded, same as before. Privacy contract preserved.

## Out of scope

- Auto-switching the system default input device (the script reports it; changing it is left to the user).
- A live "no signal" hint *during* recording (this fires at stop). A mid-recording warning could follow.
- Tuning the threshold per-device; 0.005 is a conservative global floor.
