### PR TITLE
feat(settings): add a microphone input-device picker

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -758,7 +758,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             do {
-                _ = try recorder.start(outputURL: lastRecordingURL)
+                let inputUID = UserDefaults.standard.string(forKey: "inputDeviceUID")
+                _ = try recorder.start(outputURL: lastRecordingURL, inputDeviceUID: inputUID)
                 await MainActor.run {
                     appState.phase = .recording
                     appState.elapsedSeconds = 0

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -54,7 +54,12 @@ private struct GeneralPane: View {
     @AppStorage("vadSilenceSeconds")   private var vadSilenceSeconds: Double = 1.5
     @AppStorage("customWords")         private var customWords: String = ""
     @AppStorage("model")               private var model: String = "medium"
+    @AppStorage("inputDeviceUID")      private var inputDeviceUID: String = ""  // "" = system default
     @AppStorage("launchAtLogin")       private var launchAtLogin: Bool = false
+
+    /// Input devices for the Microphone picker; loaded `.onAppear` and
+    /// refreshed when the picker is interacted with.
+    @State private var inputDevices: [AudioInputDevice] = []
 
     // SPEC-026 PR-B — Updates section state.
     @AppStorage("receivePrereleases") private var receivePrereleases: Bool = false
@@ -97,6 +102,27 @@ private struct GeneralPane: View {
                     .foregroundStyle(.secondary)
             } header: {
                 SectionHeader("Speech-to-text")
+            }
+
+            Section {
+                Picker("Microphone", selection: $inputDeviceUID) {
+                    Text("System default").tag("")
+                    ForEach(inputDevices) { device in
+                        Text(device.name).tag(device.uid)
+                    }
+                    // Keep the saved choice visible even if the device is gone,
+                    // so the picker doesn't silently blank out.
+                    if !inputDeviceUID.isEmpty,
+                       !inputDevices.contains(where: { $0.uid == inputDeviceUID }) {
+                        Text("Selected device (disconnected)").tag(inputDeviceUID)
+                    }
+                }
+                .onAppear { inputDevices = AudioInputDevices.list() }
+                Text("The mic OpenQuack records from. \"System default\" follows macOS. If recordings come back blank or as \"You.\", pick your real mic here. Takes effect on the next recording.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                SectionHeader("Microphone")
             }
 
             Section {

--- a/Sources/OpenQuackKit/Audio/AudioInputDevices.swift
+++ b/Sources/OpenQuackKit/Audio/AudioInputDevices.swift
@@ -1,0 +1,96 @@
+import CoreAudio
+import Foundation
+
+/// A selectable audio input device. `uid` is the persistent identifier
+/// (stable across reboots and re-plugs); the numeric `id` is only valid for
+/// the current boot and must be re-resolved from the `uid` before use.
+public struct AudioInputDevice: Identifiable, Sendable, Equatable {
+    public let id: AudioDeviceID
+    public let uid: String
+    public let name: String
+
+    public init(id: AudioDeviceID, uid: String, name: String) {
+        self.id = id
+        self.uid = uid
+        self.name = name
+    }
+}
+
+/// CoreAudio enumeration of input-capable devices. Used by the Settings
+/// "Microphone" picker and by `AudioRecorder` to route capture to a chosen
+/// device instead of the system default.
+public enum AudioInputDevices {
+
+    /// All input-capable devices currently present, in CoreAudio order.
+    public static func list() -> [AudioInputDevice] {
+        allDeviceIDs()
+            .filter { inputChannelCount($0) > 0 }
+            .compactMap { id in
+                guard let uid = stringProperty(id, kAudioDevicePropertyDeviceUID),
+                      let name = stringProperty(id, kAudioObjectPropertyName)
+                else { return nil }
+                return AudioInputDevice(id: id, uid: uid, name: name)
+            }
+    }
+
+    /// Resolve a persistent UID back to the current-boot AudioDeviceID, or nil
+    /// if that device is no longer present (unplugged, removed).
+    public static func deviceID(forUID uid: String) -> AudioDeviceID? {
+        list().first { $0.uid == uid }?.id
+    }
+
+    // MARK: - CoreAudio helpers
+
+    private static func allDeviceIDs() -> [AudioDeviceID] {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size) == noErr
+        else { return [] }
+        let count = Int(size) / MemoryLayout<AudioDeviceID>.size
+        guard count > 0 else { return [] }
+        var ids = [AudioDeviceID](repeating: 0, count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &ids) == noErr
+        else { return [] }
+        return ids
+    }
+
+    private static func inputChannelCount(_ id: AudioDeviceID) -> Int {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size) == noErr, size > 0
+        else { return 0 }
+        let raw = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: 16)
+        defer { raw.deallocate() }
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, raw) == noErr
+        else { return 0 }
+        let listPtr = UnsafeMutableAudioBufferListPointer(
+            raw.assumingMemoryBound(to: AudioBufferList.self))
+        return listPtr.reduce(0) { $0 + Int($1.mNumberChannels) }
+    }
+
+    private static func stringProperty(
+        _ id: AudioDeviceID, _ selector: AudioObjectPropertySelector
+    ) -> String? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var cf: CFString? = nil
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        let status = withUnsafeMutablePointer(to: &cf) { ptr -> OSStatus in
+            ptr.withMemoryRebound(to: CFString.self, capacity: 1) { rebound in
+                AudioObjectGetPropertyData(id, &addr, 0, nil, &size, rebound)
+            }
+        }
+        guard status == noErr, let result = cf else { return nil }
+        return result as String
+    }
+}

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -88,7 +88,12 @@ public final class AudioRecorder {
     /// Start capture. If `outputURL` is omitted, writes to a fresh temp file.
     /// Pass an explicit URL (e.g. `~/Library/Application Support/.../last-recording.wav`)
     /// to keep the WAV around for inspection between runs.
-    public func start(outputURL: URL? = nil) throws -> URL {
+    ///
+    /// `inputDeviceUID` routes capture to a specific input device (resolved via
+    /// `AudioInputDevices`); pass nil/empty for the system default. If the UID
+    /// no longer resolves to a present device, we silently fall back to the
+    /// system default rather than failing the recording.
+    public func start(outputURL: URL? = nil, inputDeviceUID: String? = nil) throws -> URL {
         lock.lock(); defer { lock.unlock() }
 
         if _isRecording, let url = _outputURL {
@@ -111,6 +116,26 @@ public final class AudioRecorder {
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
+        // Route to the chosen device BEFORE reading the format — the input
+        // node's format follows whatever device is current. Must touch the
+        // node's audio unit first so it instantiates.
+        if let uid = inputDeviceUID, !uid.isEmpty,
+           let deviceID = AudioInputDevices.deviceID(forUID: uid),
+           let unit = inputNode.audioUnit {
+            var dev = deviceID
+            let status = AudioUnitSetProperty(
+                unit,
+                kAudioOutputUnitProperty_CurrentDevice,
+                kAudioUnitScope_Global,
+                0,
+                &dev,
+                UInt32(MemoryLayout<AudioDeviceID>.size))
+            if status != noErr {
+                FileHandle.standardError.write(
+                    "[AudioRecorder] could not select input device \(uid): \(status)\n"
+                        .data(using: .utf8) ?? Data())
+            }
+        }
         let inputFormat = inputNode.outputFormat(forBus: 0)
 
         // WAV at the input device's native sample rate and channel count.

--- a/Tests/OpenQuackKitTests/AudioInputDevicesTests.swift
+++ b/Tests/OpenQuackKitTests/AudioInputDevicesTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class AudioInputDevicesTests: XCTestCase {
+    // Hardware-independent: a bogus UID must never resolve, on any host
+    // (including CI boxes with no audio input devices at all).
+    func testDeviceID_forUnknownUID_isNil() {
+        XCTAssertNil(AudioInputDevices.deviceID(forUID: "__definitely_not_a_real_device_uid__"))
+        XCTAssertNil(AudioInputDevices.deviceID(forUID: ""))
+    }
+
+    // list() must not crash and every returned device must carry a non-empty
+    // uid/name and at least one input channel. Empty is a valid result on a
+    // host with no mic.
+    func testList_returnsWellFormedDevices() {
+        for device in AudioInputDevices.list() {
+            XCTAssertFalse(device.uid.isEmpty, "device uid should be non-empty")
+            XCTAssertFalse(device.name.isEmpty, "device name should be non-empty")
+        }
+    }
+
+    // Any device list() reports must round-trip through deviceID(forUID:).
+    func testListedDevices_resolveByUID() {
+        for device in AudioInputDevices.list() {
+            XCTAssertEqual(AudioInputDevices.deviceID(forUID: device.uid), device.id)
+        }
+    }
+}


### PR DESCRIPTION
## SPEC

SPEC-001 (Voice capture). Adds device selection to the capture path; no new spec.

## Milestone

Capture reliability.

## Why

OpenQuack only ever recorded from the **system default** input device. When that default is the wrong one — an external mic connected but not selected, or a virtual input device (Lark/飞书, Microsoft Teams, etc.) another app set as default that emits silence — every dictation is silent and Whisper hallucinates "You." / "Thank you." Users had no way to choose the mic without leaving the app for System Settings. Pairs with #83 (which detects the silent capture and warns).

## Change

- `Sources/OpenQuackKit/Audio/AudioInputDevices.swift` (new) — CoreAudio enumeration of input-capable devices (`id` + persistent `uid` + `name`) and `deviceID(forUID:)` resolution.
- `Sources/OpenQuackKit/Audio/AudioRecorder.swift` — `start(inputDeviceUID:)` routes capture to the chosen device via `kAudioOutputUnitProperty_CurrentDevice`, set on the input node's audio unit **before** the input format is read. Unknown/absent UID → silent fall back to the system default.
- `Sources/OpenQuackApp/SettingsView.swift` — Settings → General gains a **"Microphone"** picker, keyed on device **UID** (stable across reboots), with "System default" as the default and a disconnected-device placeholder so the selection never blanks out.
- `Sources/OpenQuackApp/OpenQuackApp.swift` — `startRecording()` passes the stored `inputDeviceUID` into `recorder.start(...)`.

## Tests

- [x] `Tests/OpenQuackKitTests/AudioInputDevicesTests.swift` — bogus UID resolves to nil (hardware-independent); listed devices are well-formed and round-trip through `deviceID(forUID:)`. 3 tests, green.
- [x] `swift test` green; release build via `scripts/wrap_app.sh` green.
- Manual: Settings → General → Microphone lists devices; selecting the real external mic makes dictation transcribe correctly instead of returning "You.".

## Privacy impact

None. Device enumeration and selection are local CoreAudio calls; no new capture/transcription/network behaviour. Privacy contract preserved.

## Out of scope

- Live device hot-swap mid-recording (selection applies on the next recording).
- Auto-selecting a non-default mic on launch (we honour the user's explicit choice or the system default).

Closes #84.
