### PR TITLE
feat(SPEC-002): speech-model download UX, hot-swap, and a downloaded-model library

### DIFF
--- a/Sources/OpenQuackApp/AppState.swift
+++ b/Sources/OpenQuackApp/AppState.swift
@@ -71,8 +71,8 @@ public final class AppState: ObservableObject {
     /// its progress here so `MenuBarContent` keeps reading only `AppState`.
     @Published public var polishDownload: PolishDownloadStatus = .inactive
     /// Drives the menu-bar download banner for the Whisper speech model.
-    /// Reuses `PolishDownloadStatus` (it only models a download fraction).
-    @Published public var speechDownload: PolishDownloadStatus = .inactive
+    /// Carries the variant so the banner can name the model being downloaded.
+    @Published public var speechDownload: SpeechDownloadStatus = .inactive
 
     /// Convenience for the popover banner — only present when the
     /// status terminal-states into `.available`.
@@ -87,6 +87,12 @@ public final class AppState: ObservableObject {
 public enum PolishDownloadStatus: Equatable {
     case inactive
     case downloading(fraction: Double)
+}
+
+public enum SpeechDownloadStatus: Equatable {
+    case inactive
+    /// `model` is the Whisper variant id (e.g. "large-v3").
+    case downloading(model: String, fraction: Double)
 }
 
 public enum UpdateCheckStatus: Equatable {

--- a/Sources/OpenQuackApp/AppState.swift
+++ b/Sources/OpenQuackApp/AppState.swift
@@ -70,6 +70,9 @@ public final class AppState: ObservableObject {
     /// SPEC-007 — drives the menu-bar download banner. The controller mirrors
     /// its progress here so `MenuBarContent` keeps reading only `AppState`.
     @Published public var polishDownload: PolishDownloadStatus = .inactive
+    /// Drives the menu-bar download banner for the Whisper speech model.
+    /// Reuses `PolishDownloadStatus` (it only models a download fraction).
+    @Published public var speechDownload: PolishDownloadStatus = .inactive
 
     /// Convenience for the popover banner — only present when the
     /// status terminal-states into `.available`.

--- a/Sources/OpenQuackApp/MenuBarContent.swift
+++ b/Sources/OpenQuackApp/MenuBarContent.swift
@@ -93,25 +93,40 @@ struct MenuBarContent: View {
     @ViewBuilder
     private var downloadBanner: some View {
         if case .downloading(let fraction) = state.polishDownload {
-            HStack(alignment: .top, spacing: Theme.s8) {
-                Image(systemName: "arrow.down.circle")
-                    .font(.title3)
-                    .foregroundStyle(Theme.moss)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Downloading Local LLM model")
-                        .font(.caption.weight(.semibold))
-                    ProgressView(value: fraction)
-                        .frame(maxWidth: .infinity)
-                }
-                Spacer(minLength: Theme.s4)
-                Button("Show") {
-                    SettingsWindowController.show(appState: state)
-                    (NSApp.delegate as? AppDelegate)?.polishDownload.resurface()
-                }
-                .buttonStyle(.oqPrimarySmall)
+            downloadBannerRow(label: "Downloading Local LLM model", fraction: fraction) {
+                SettingsWindowController.show(appState: state)
+                (NSApp.delegate as? AppDelegate)?.polishDownload.resurface()
             }
-            .oqBanner(tint: Theme.moss)
         }
+        if case .downloading(let fraction) = state.speechDownload {
+            downloadBannerRow(label: "Downloading speech model", fraction: fraction) {
+                SettingsWindowController.show(appState: state)
+                (NSApp.delegate as? AppDelegate)?.speechDownload.resurface()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func downloadBannerRow(
+        label: String,
+        fraction: Double,
+        onShow: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .top, spacing: Theme.s8) {
+            Image(systemName: "arrow.down.circle")
+                .font(.title3)
+                .foregroundStyle(Theme.moss)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                ProgressView(value: fraction)
+                    .frame(maxWidth: .infinity)
+            }
+            Spacer(minLength: Theme.s4)
+            Button("Show", action: onShow)
+                .buttonStyle(.oqPrimarySmall)
+        }
+        .oqBanner(tint: Theme.moss)
     }
 
     @ViewBuilder

--- a/Sources/OpenQuackApp/MenuBarContent.swift
+++ b/Sources/OpenQuackApp/MenuBarContent.swift
@@ -98,7 +98,7 @@ struct MenuBarContent: View {
                 (NSApp.delegate as? AppDelegate)?.polishDownload.resurface()
             }
         }
-        if case .downloading(let fraction) = state.speechDownload {
+        if case .downloading(let model, let fraction) = state.speechDownload {
             let controller = (NSApp.delegate as? AppDelegate)?.speechDownload
             // A launch download has no sheet to re-open — omit "Show" for it.
             let onShow: (() -> Void)? = (controller?.canResurface ?? false)
@@ -107,7 +107,8 @@ struct MenuBarContent: View {
                     controller?.resurface()
                 }
                 : nil
-            downloadBannerRow(label: "Downloading speech model", fraction: fraction, onShow: onShow)
+            downloadBannerRow(label: "Downloading \(SpeechModelCatalog.displayName(for: model))",
+                              fraction: fraction, onShow: onShow)
         }
     }
 

--- a/Sources/OpenQuackApp/MenuBarContent.swift
+++ b/Sources/OpenQuackApp/MenuBarContent.swift
@@ -99,10 +99,15 @@ struct MenuBarContent: View {
             }
         }
         if case .downloading(let fraction) = state.speechDownload {
-            downloadBannerRow(label: "Downloading speech model", fraction: fraction) {
-                SettingsWindowController.show(appState: state)
-                (NSApp.delegate as? AppDelegate)?.speechDownload.resurface()
-            }
+            let controller = (NSApp.delegate as? AppDelegate)?.speechDownload
+            // A launch download has no sheet to re-open — omit "Show" for it.
+            let onShow: (() -> Void)? = (controller?.canResurface ?? false)
+                ? {
+                    SettingsWindowController.show(appState: state)
+                    controller?.resurface()
+                }
+                : nil
+            downloadBannerRow(label: "Downloading speech model", fraction: fraction, onShow: onShow)
         }
     }
 
@@ -110,7 +115,7 @@ struct MenuBarContent: View {
     private func downloadBannerRow(
         label: String,
         fraction: Double,
-        onShow: @escaping () -> Void
+        onShow: (() -> Void)? = nil
     ) -> some View {
         HStack(alignment: .top, spacing: Theme.s8) {
             Image(systemName: "arrow.down.circle")
@@ -123,8 +128,10 @@ struct MenuBarContent: View {
                     .frame(maxWidth: .infinity)
             }
             Spacer(minLength: Theme.s4)
-            Button("Show", action: onShow)
-                .buttonStyle(.oqPrimarySmall)
+            if let onShow {
+                Button("Show", action: onShow)
+                    .buttonStyle(.oqPrimarySmall)
+            }
         }
         .oqBanner(tint: Theme.moss)
     }

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -1103,19 +1103,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // now-stale model so the new warm-up wins.
             try Task.checkCancellation()
             let engine = try await WhisperKitEngine(model: model)
-            // A dictation may have started during a force-reload's load window —
-            // don't swap the engine under it; defer until it finishes.
-            if force, await MainActor.run(body: { self.isDictating }) {
-                await MainActor.run { pendingSwap = true }
-                return
-            }
-            self.transcriber = engine
-            self.streamer = engine.makeStreamingTranscriber()  // SPEC-012
-            await MainActor.run {
+            // Swap atomically on the main actor so a dictation can't start
+            // between the busy-check and the assignment. If a force-reload's
+            // load window overlapped a dictation, don't swap under it — defer to
+            // idle. (A large model briefly holds old + new engine in memory here.)
+            let swapped = await MainActor.run { () -> Bool in
+                if force, self.isDictating { self.pendingSwap = true; return false }
+                self.transcriber = engine
+                self.streamer = engine.makeStreamingTranscriber()  // SPEC-012
                 appState.speechDownload = .inactive
                 appState.phase = .idle
                 appState.modelLabel = model
+                return true
             }
+            guard swapped else { return }
             // Keep the freshly loaded model up to date. Sibling variants are
             // kept on disk — the user manages them in Settings (SPEC: model table).
             Task.detached(priority: .background) {

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -1024,13 +1024,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let model = defaultModel
         await MainActor.run { appState.phase = .warming(modelLabel: model) }
         do {
-            // If the saved model isn't cached yet, download it with a visible
+            // If the weights aren't on disk yet, download them with a visible
             // menu-bar progress banner instead of a silent blocking fetch inside
-            // the engine init. No sheet — this isn't user-initiated.
-            if !WhisperKitEngine.hasCompleteLocalCache(for: model) {
-                await MainActor.run { appState.speechDownload = .downloading(fraction: 0) }
+            // the engine init. No sheet — this isn't user-initiated. (A missing
+            // tokenizer alone isn't worth a banner; the engine init fetches it.)
+            if !WhisperKitEngine.hasModelWeights(for: model) {
+                await MainActor.run { appState.speechDownload = .downloading(model: model, fraction: 0) }
                 try await WhisperKitEngine.ensureDownloaded(model: model) { fraction in
-                    Task { @MainActor in self.appState.speechDownload = .downloading(fraction: fraction) }
+                    Task { @MainActor in self.appState.speechDownload = .downloading(model: model, fraction: fraction) }
                 }
                 await MainActor.run { appState.speechDownload = .inactive }
             }

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -1108,6 +1108,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // load window overlapped a dictation, don't swap under it — defer to
             // idle. (A large model briefly holds old + new engine in memory here.)
             let swapped = await MainActor.run { () -> Bool in
+                // A dictation started during the load window: don't swap under it.
+                // We discard this just-loaded engine and re-load on idle rather
+                // than stash it — keeps the swap state machine to one in-flight
+                // model. Costs one extra load only in the rare switch-then-
+                // immediately-dictate race; not worth more state to optimise.
                 if force, self.isDictating { self.pendingSwap = true; return false }
                 self.transcriber = engine
                 self.streamer = engine.makeStreamingTranscriber()  // SPEC-012

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -1021,19 +1021,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // model download completes, once on window close); a re-init would
         // pointlessly drop and reload the engine.
         if self.transcriber != nil { return }
-        await MainActor.run { appState.phase = .warming(modelLabel: defaultModel) }
+        let model = defaultModel
+        await MainActor.run { appState.phase = .warming(modelLabel: model) }
         do {
-            let engine = try await WhisperKitEngine(model: defaultModel)
+            // If the saved model isn't cached yet, download it with a visible
+            // menu-bar progress banner instead of a silent blocking fetch inside
+            // the engine init. No sheet — this isn't user-initiated.
+            if !WhisperKitEngine.hasCompleteLocalCache(for: model) {
+                await MainActor.run { appState.speechDownload = .downloading(fraction: 0) }
+                try await WhisperKitEngine.ensureDownloaded(model: model) { fraction in
+                    Task { @MainActor in self.appState.speechDownload = .downloading(fraction: fraction) }
+                }
+                await MainActor.run { appState.speechDownload = .inactive }
+            }
+            let engine = try await WhisperKitEngine(model: model)
             self.transcriber = engine
             self.streamer = engine.makeStreamingTranscriber()  // SPEC-012
             await MainActor.run {
                 appState.phase = .idle
-                appState.modelLabel = defaultModel
+                appState.modelLabel = model
             }
             // Active model is loaded — drop sibling variants so the disk
             // footprint stays at one model. Bench leftovers and the previous
             // model after a switch both get cleaned up here.
-            let active = defaultModel
+            let active = model
             Task.detached(priority: .background) {
                 _ = WhisperKitEngine.cleanupOtherModels(keeping: active)
             }
@@ -1042,6 +1053,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         } catch {
             await MainActor.run {
+                appState.speechDownload = .inactive
                 appState.phase = .error("Failed to load Whisper: \(error)")
             }
         }

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -87,6 +87,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor lazy var speechDownload = SpeechModelDownloadController()
     private var transcriber: WhisperKitEngine?
     private var streamer: StreamingTranscriber?   // SPEC-012; long-lived after warm
+    /// Cancellable warm-up. Restarted (retargeted) when the user switches the
+    /// active model while the launch download is still running.
+    private var warmTask: Task<Void, Never>?
+    /// Model the in-flight warm-up is for — guards against redundant restarts.
+    private var warmingModel: String?
     // SPEC-007 — in-process polish engine kept warm across dictations: warmed on
     // record-start, idle-unloaded after polishIdleUnload of no dictation.
     private var polishEngine: LlamaCppPolishEngine?
@@ -213,7 +218,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let hasOnboarded = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
         if hasOnboarded {
             // Seasoned user — warm the model in the background.
-            Task { await warmTranscriber() }
+            startWarm()
         } else {
             // First launch. Warm the transcriber the moment the onboarding's
             // model download finishes, not when the window closes — the demo
@@ -223,10 +228,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             OnboardingWindowController.showIfFirstLaunch(
                 appState: appState,
                 onModelReady: { [weak self] in
-                    Task { await self?.warmTranscriber() }
+                    Task { @MainActor in self?.startWarm() }
                 },
                 onComplete: { [weak self] in
-                    Task { await self?.warmTranscriber() }
+                    Task { @MainActor in self?.startWarm() }
                 }
             )
         }
@@ -301,10 +306,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         OnboardingWindowController.show(
             appState: appState,
             onModelReady: { [weak self] in
-                Task { await self?.warmTranscriber() }
+                Task { @MainActor in self?.startWarm() }
             },
             onComplete: { [weak self] in
-                Task { await self?.warmTranscriber() }
+                Task { @MainActor in self?.startWarm() }
             }
         )
     }
@@ -1016,12 +1021,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func warmTranscriber() async {
-        // Idempotent — the onboarding flow can call this twice (once when the
-        // model download completes, once on window close); a re-init would
-        // pointlessly drop and reload the engine.
-        if self.transcriber != nil { return }
+    /// Start (or restart) warm-up for the current `defaultModel`. Restarting
+    /// cancels an in-flight warm download and re-aims at the new model — this is
+    /// how a model switch during launch warm-up retargets without spawning a
+    /// second concurrent download. Idempotent for the same model.
+    @MainActor
+    func startWarm() {
+        if transcriber != nil { return }
         let model = defaultModel
+        if warmingModel == model { return }   // already warming this one
+        warmTask?.cancel()
+        warmingModel = model
+        warmTask = Task { [weak self] in
+            await self?.warmBody(model: model)
+            await MainActor.run { if self?.warmingModel == model { self?.warmingModel = nil } }
+        }
+    }
+
+    private func warmBody(model: String) async {
+        if self.transcriber != nil { return }
         await MainActor.run { appState.phase = .warming(modelLabel: model) }
         do {
             // If the weights aren't on disk yet, download them with a visible
@@ -1039,20 +1057,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.transcriber = engine
             self.streamer = engine.makeStreamingTranscriber()  // SPEC-012
             await MainActor.run {
+                appState.speechDownload = .inactive
                 appState.phase = .idle
                 appState.modelLabel = model
             }
-            // Active model is loaded — drop sibling variants so the disk
-            // footprint stays at one model. Bench leftovers and the previous
-            // model after a switch both get cleaned up here.
-            let active = model
+            // Keep the freshly loaded model up to date. Sibling variants are
+            // kept on disk — the user manages them in Settings (SPEC: model table).
             Task.detached(priority: .background) {
-                _ = WhisperKitEngine.cleanupOtherModels(keeping: active)
-            }
-            Task.detached(priority: .background) {
-                await WhisperKitEngine.refreshModelInBackground(model: active)
+                await WhisperKitEngine.refreshModelInBackground(model: model)
             }
         } catch {
+            // A retarget cancels this task; let the new warm take over silently.
+            if Task.isCancelled || error is CancellationError { return }
             await MainActor.run {
                 appState.speechDownload = .inactive
                 appState.phase = .error("Failed to load Whisper: \(error)")
@@ -1226,7 +1242,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let audioURL = entry.audioURL else { return }
         // Engine may not be warm yet at this stage; warm if needed before
         // attempting recovery so the user-facing flow doesn't error out.
-        if transcriber == nil { await warmTranscriber() }
+        if transcriber == nil { startWarm(); await warmTask?.value }
         guard let engine = transcriber else { return }
         do {
             let result = try await engine.transcribe(

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -1040,7 +1040,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func warmBody(model: String) async {
         if self.transcriber != nil { return }
-        await MainActor.run { appState.phase = .warming(modelLabel: model) }
+        await MainActor.run {
+            appState.phase = .warming(modelLabel: model)
+            // Clear any banner left by a just-retargeted warm-up so it doesn't
+            // briefly show the old model while this one prepares.
+            appState.speechDownload = .inactive
+        }
         do {
             // If the weights aren't on disk yet, download them with a visible
             // menu-bar progress banner instead of a silent blocking fetch inside
@@ -1049,10 +1054,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if !WhisperKitEngine.hasModelWeights(for: model) {
                 await MainActor.run { appState.speechDownload = .downloading(model: model, fraction: 0) }
                 try await WhisperKitEngine.ensureDownloaded(model: model) { fraction in
-                    Task { @MainActor in self.appState.speechDownload = .downloading(model: model, fraction: fraction) }
+                    // Guard against a late tick from a just-cancelled (retargeted)
+                    // download flicking the banner back to the old model.
+                    Task { @MainActor in
+                        if self.warmingModel == model {
+                            self.appState.speechDownload = .downloading(model: model, fraction: fraction)
+                        }
+                    }
                 }
                 await MainActor.run { appState.speechDownload = .inactive }
             }
+            // A retarget may have landed in the gap between file downloads (where
+            // the snapshot returns without throwing) — bail before loading the
+            // now-stale model so the new warm-up wins.
+            try Task.checkCancellation()
             let engine = try await WhisperKitEngine(model: model)
             self.transcriber = engine
             self.streamer = engine.makeStreamingTranscriber()  // SPEC-012

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -82,6 +82,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// SPEC-007 — long-lived owner of the polish-model download (survives the
     /// Settings sheet). Wired to `appState` + reconciled in didFinishLaunching.
     @MainActor lazy var polishDownload = PolishModelDownloadController()
+    /// Long-lived owner of the speech-model download (survives the Settings
+    /// sheet). Wired to `appState` in didFinishLaunching.
+    @MainActor lazy var speechDownload = SpeechModelDownloadController()
     private var transcriber: WhisperKitEngine?
     private var streamer: StreamingTranscriber?   // SPEC-012; long-lived after warm
     // SPEC-007 — in-process polish engine kept warm across dictations: warmed on
@@ -174,6 +177,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // from a previous launch.
         polishDownload.appState = appState
         polishDownload.reconcileOnLaunch()
+        speechDownload.appState = appState
 
         // SPEC-031 — kickoff notification plumbing. Set the delegate
         // BEFORE any notification is posted so first-press clicks are

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -92,6 +92,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var warmTask: Task<Void, Never>?
     /// Model the in-flight warm-up is for — guards against redundant restarts.
     private var warmingModel: String?
+    /// A model swap requested mid-dictation, applied when we next go idle.
+    private var pendingSwap = false
     // SPEC-007 — in-process polish engine kept warm across dictations: warmed on
     // record-start, idle-unloaded after polishIdleUnload of no dictation.
     private var polishEngine: LlamaCppPolishEngine?
@@ -183,6 +185,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         polishDownload.appState = appState
         polishDownload.reconcileOnLaunch()
         speechDownload.appState = appState
+        // Hot-swap the live engine when a Settings download commits a new model.
+        speechDownload.onCommitted = { [weak self] in self?.swapModel() }
 
         // SPEC-031 — kickoff notification plumbing. Set the delegate
         // BEFORE any notification is posted so first-press clicks are
@@ -516,6 +520,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] phase, status in
                 self?.updateIcon(for: phase, hasUpdate: status.hasAvailableUpdate)
+                Task { @MainActor in self?.applyPendingSwapIfIdle() }
             }
             .store(in: &cancellables)
     }
@@ -1026,20 +1031,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// how a model switch during launch warm-up retargets without spawning a
     /// second concurrent download. Idempotent for the same model.
     @MainActor
-    func startWarm() {
-        if transcriber != nil { return }
+    func startWarm(force: Bool = false) {
+        if !force, transcriber != nil { return }
         let model = defaultModel
-        if warmingModel == model { return }   // already warming this one
+        if !force, warmingModel == model { return }   // already warming this one
         warmTask?.cancel()
         warmingModel = model
         warmTask = Task { [weak self] in
-            await self?.warmBody(model: model)
+            await self?.warmBody(model: model, force: force)
             await MainActor.run { if self?.warmingModel == model { self?.warmingModel = nil } }
         }
     }
 
-    private func warmBody(model: String) async {
-        if self.transcriber != nil { return }
+    /// True while a dictation is in flight — we never swap the engine under it.
+    @MainActor private var isDictating: Bool {
+        switch appState.phase {
+        case .starting, .recording, .transcribing, .polishing: return true
+        default: return false
+        }
+    }
+
+    /// Hot-swap the live engine to the current `defaultModel`. Cold start →
+    /// normal warm-up; already running it → no-op; mid-dictation → deferred
+    /// until the dictation finishes (see `applyPendingSwapIfIdle`).
+    @MainActor
+    func swapModel() {
+        let target = defaultModel
+        guard transcriber != nil else { startWarm(); return }
+        guard transcriber?.modelID != target else { return }
+        if isDictating { pendingSwap = true; return }
+        pendingSwap = false
+        startWarm(force: true)
+    }
+
+    /// Phase-observer hook: apply a deferred swap once dictation ends.
+    @MainActor
+    func applyPendingSwapIfIdle() {
+        guard pendingSwap, !isDictating else { return }
+        pendingSwap = false
+        startWarm(force: true)
+    }
+
+    private func warmBody(model: String, force: Bool = false) async {
+        if !force, self.transcriber != nil { return }
         await MainActor.run {
             appState.phase = .warming(modelLabel: model)
             // Clear any banner left by a just-retargeted warm-up so it doesn't
@@ -1069,6 +1103,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // now-stale model so the new warm-up wins.
             try Task.checkCancellation()
             let engine = try await WhisperKitEngine(model: model)
+            // A dictation may have started during a force-reload's load window —
+            // don't swap the engine under it; defer until it finishes.
+            if force, await MainActor.run(body: { self.isDictating }) {
+                await MainActor.run { pendingSwap = true }
+                return
+            }
             self.transcriber = engine
             self.streamer = engine.makeStreamingTranscriber()  // SPEC-012
             await MainActor.run {

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -95,7 +95,8 @@ private struct GeneralPane: View {
     /// the SwiftUI type-checker.
     @ViewBuilder
     private var speechDownloadRow: some View {
-        if case .downloading(let fraction) = speechDownload.phase, !speechDownload.isPresented {
+        switch speechDownload.phase {
+        case .downloading(let fraction) where !speechDownload.isPresented:
             let caption = "\(SpeechModelCatalog.displayName(for: speechDownload.target)) · \(SpeechModelDownloadSheet.percentLabel(fraction))"
             HStack(spacing: Theme.s8) {
                 ProgressView(value: fraction).frame(maxWidth: 160)
@@ -105,6 +106,18 @@ private struct GeneralPane: View {
                 Button("Show") { speechDownload.resurface() }
                     .font(.caption)
             }
+        case .failed(let message) where !speechDownload.isPresented:
+            // A background download (sheet dismissed) that failed has no other
+            // surface, so show it here with a retry.
+            HStack(spacing: Theme.s8) {
+                Text(message)
+                    .font(.caption).foregroundStyle(.red)
+                Spacer()
+                Button("Retry") { speechDownload.retry() }.font(.caption)
+                Button("Dismiss") { speechDownload.cancel() }.font(.caption)
+            }
+        default:
+            EmptyView()
         }
     }
 

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -90,6 +90,54 @@ private struct GeneralPane: View {
     /// successful download flows the committed `model` back into the Picker.
     @State private var pickerModel: String = ""
 
+    /// Variants whose weights are on disk — drives the "Downloaded models"
+    /// table. Recomputed on appear, when a download settles, and after a delete
+    /// (disk state isn't observable, so we refresh it explicitly).
+    @State private var downloadedModels: [String] = []
+
+    private func refreshDownloadedModels() {
+        downloadedModels = SpeechModelCatalog.all.filter { WhisperKitEngine.hasModelWeights(for: $0) }
+    }
+
+    @ViewBuilder
+    private var downloadedModelsTable: some View {
+        if !downloadedModels.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.s8) {
+                Text("Downloaded models")
+                    .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                ForEach(downloadedModels, id: \.self) { variant in
+                    let isActive = (variant == model)
+                    HStack(spacing: Theme.s8) {
+                        Text(SpeechModelCatalog.displayName(for: variant))
+                        Text(SpeechModelCatalog.sizeLabel(for: variant))
+                            .font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                        if isActive {
+                            Text("Active").font(.caption.weight(.semibold)).foregroundStyle(Theme.moss)
+                        }
+                        Button("Delete") { confirmDeleteSpeechModel(variant) }
+                            .font(.caption)
+                            .disabled(isActive)
+                            .help(isActive
+                                  ? "This model is in use. Switch to another model first, then delete it."
+                                  : "Remove this model from disk to free space.")
+                    }
+                }
+            }
+        }
+    }
+
+    private func confirmDeleteSpeechModel(_ variant: String) {
+        let alert = NSAlert()
+        alert.messageText = "Delete \(SpeechModelCatalog.displayName(for: variant))?"
+        alert.informativeText = "Frees \(SpeechModelCatalog.sizeLabel(for: variant)) of disk. You can re-download it any time from the Speech model menu."
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        WhisperKitEngine.deleteModel(variant)
+        refreshDownloadedModels()
+    }
+
     /// Inline progress row shown under the picker while a download runs in the
     /// background (sheet dismissed). Extracted to keep the Form body light for
     /// the SwiftUI type-checker.
@@ -125,6 +173,14 @@ private struct GeneralPane: View {
     /// not-yet-downloaded one opens the download sheet and the visual pick reverts.
     private func selectSpeechModel(_ target: String) {
         guard target != model else { return }
+        // Warm-up is still downloading a model (banner, no controller sheet) —
+        // we're choosing what to load right now, so retarget warm-up to the new
+        // model: commit it and restart warm-up. No sheet, no second download.
+        if case .downloading = appState.speechDownload, !speechDownload.canResurface {
+            model = target
+            (NSApp.delegate as? AppDelegate)?.startWarm()
+            return
+        }
         if WhisperKitEngine.hasModelWeights(for: target) {
             model = target
         } else {
@@ -133,27 +189,33 @@ private struct GeneralPane: View {
         }
     }
 
+    private var speechModelPicker: some View {
+        Picker("Speech model", selection: $pickerModel) {
+            Text("tiny — fastest, lowest accuracy (~150 MB)").tag("tiny")
+            Text("base — fast, modest accuracy (~290 MB)").tag("base")
+            Text("small — balanced (~480 MB)").tag("small")
+            Text("medium — best balance, default (~1.5 GB)").tag("medium")
+            Text("large-v3 — highest accuracy (~3 GB)").tag("large-v3")
+        }
+        .onAppear { pickerModel = model; refreshDownloadedModels() }
+        .onChange(of: model) { pickerModel = $0; refreshDownloadedModels() }
+        .onChange(of: pickerModel) { selectSpeechModel($0) }
+        .onChange(of: appState.speechDownload) { _ in refreshDownloadedModels() }
+        .sheet(isPresented: $speechDownload.isPresented,
+               onDismiss: { speechDownload.detachToBackground() }) {
+            SpeechModelDownloadSheet(model: speechDownload)
+        }
+    }
+
     var body: some View {
         Form {
             Section {
-                Picker("Speech model", selection: $pickerModel) {
-                    Text("tiny — fastest, lowest accuracy (~150 MB)").tag("tiny")
-                    Text("base — fast, modest accuracy (~290 MB)").tag("base")
-                    Text("small — balanced (~480 MB)").tag("small")
-                    Text("medium — best balance, default (~1.5 GB)").tag("medium")
-                    Text("large-v3 — highest accuracy (~3 GB)").tag("large-v3")
-                }
-                .onAppear { pickerModel = model }
-                .onChange(of: model) { pickerModel = $0 }
-                .onChange(of: pickerModel) { selectSpeechModel($0) }
-                .sheet(isPresented: $speechDownload.isPresented,
-                       onDismiss: { speechDownload.detachToBackground() }) {
-                    SpeechModelDownloadSheet(model: speechDownload)
-                }
+                speechModelPicker
                 speechDownloadRow
                 Text("Downloads the model now; the new model takes effect on next launch.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                downloadedModelsTable
             } header: {
                 SectionHeader("Speech-to-text")
             }

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -48,6 +48,7 @@ private struct GeneralPane: View {
     @AppStorage("polishText")          private var polishText: Bool = true
     @AppStorage("polishEngine")        private var polishEngine: String = "off"
     @ObservedObject private var modelDownload = (NSApp.delegate as! AppDelegate).polishDownload
+    @ObservedObject private var speechDownload = (NSApp.delegate as! AppDelegate).speechDownload
     @AppStorage("language")            private var language: String = ""   // "" = auto-detect (SPEC-035)
     @AppStorage("playSounds")          private var playSounds: Bool = true
     @AppStorage("vadAutoStop")         private var vadAutoStop: Bool = false
@@ -82,17 +83,46 @@ private struct GeneralPane: View {
         category: "LaunchAtLogin"
     )
 
+    /// Switching to an uncached model routes through the download sheet (which
+    /// commits the preference on success); a cached model switches immediately.
+    private var speechModelSelection: Binding<String> {
+        Binding(
+            get: { model },
+            set: { target in
+                if target != model, !WhisperKitEngine.hasCompleteLocalCache(for: target) {
+                    speechDownload.begin(target: target)
+                } else {
+                    model = target
+                }
+            }
+        )
+    }
+
     var body: some View {
         Form {
             Section {
-                Picker("Speech model", selection: $model) {
+                Picker("Speech model", selection: speechModelSelection) {
                     Text("tiny — fastest, lowest accuracy (~150 MB)").tag("tiny")
                     Text("base — fast, modest accuracy (~290 MB)").tag("base")
                     Text("small — balanced (~480 MB)").tag("small")
                     Text("medium — best balance, default (~1.5 GB)").tag("medium")
                     Text("large-v3 — highest accuracy (~3 GB)").tag("large-v3")
                 }
-                Text("Takes effect on next launch. New models download in the background.")
+                .sheet(isPresented: $speechDownload.isPresented,
+                       onDismiss: { speechDownload.detachToBackground() }) {
+                    SpeechModelDownloadSheet(model: speechDownload)
+                }
+                if case .downloading(let stats) = speechDownload.phase, !speechDownload.isPresented {
+                    HStack(spacing: Theme.s8) {
+                        ProgressView(value: stats.fraction).frame(maxWidth: 160)
+                        Text(SpeechModelDownloadSheet.progressCaption(stats))
+                            .font(.caption).foregroundStyle(.secondary)
+                        Spacer()
+                        Button("Show") { speechDownload.resurface() }
+                            .font(.caption)
+                    }
+                }
+                Text("Downloads the model now; the new model takes effect on next launch.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } header: {
@@ -1133,6 +1163,65 @@ private struct PolishModelDownloadSheet: View {
         if let bps = s.bytesPerSecond {
             parts.append(String(format: "%.1f MB/s", bps / 1_000_000))
         }
+        if let eta = s.eta {
+            parts.append("~\(Self.formatETA(eta)) left")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private static func formatETA(_ seconds: TimeInterval) -> String {
+        let s = max(0, Int(seconds.rounded()))
+        if s < 60 { return "\(s) sec" }
+        let m = (s + 30) / 60
+        return "\(m) min"
+    }
+}
+
+private struct SpeechModelDownloadSheet: View {
+    @ObservedObject var model: SpeechModelDownloadController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Download \(SpeechModelCatalog.displayName(for: model.target))")
+                .font(.headline)
+
+            switch model.phase {
+            case .confirming:
+                Text("This speech model needs a one-time \(SpeechModelCatalog.sizeLabel(for: model.target)) download. It stays on your Mac and takes effect the next time OpenQuack launches.")
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack {
+                    Spacer()
+                    Button("Cancel") { model.cancel() }
+                    Button("Download") { model.confirm() }
+                        .keyboardShortcut(.defaultAction)
+                }
+            case .downloading(let stats):
+                ProgressView(value: stats.fraction)
+                Text(Self.progressCaption(stats))
+                    .font(.caption).foregroundStyle(.secondary)
+                HStack {
+                    Spacer()
+                    Button("Cancel") { model.cancel() }
+                    Button("Download in Background") { model.detachToBackground() }
+                        .keyboardShortcut(.defaultAction)
+                }
+            case .failed(let message):
+                Text(message).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
+                HStack {
+                    Spacer()
+                    Button("Cancel") { model.cancel() }
+                    Button("Retry") { model.retry() }
+                        .keyboardShortcut(.defaultAction)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 380)
+    }
+
+    static func progressCaption(_ s: SpeechModelDownloadController.Stats) -> String {
+        if s.reconnecting { return "Starting…" }
+        var parts = ["\(Int(s.fraction * 100))%"]
         if let eta = s.eta {
             parts.append("~\(Self.formatETA(eta)) left")
         }

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -114,19 +114,23 @@ private struct GeneralPane: View {
                 Text("Downloaded models")
                     .font(.caption.weight(.semibold)).foregroundStyle(.secondary)
                 ForEach(downloadedModels, id: \.self) { variant in
-                    let isActive = (variant == model)
+                    // "Active" = the model actually loaded right now (hot-swap
+                    // updates it). `model` is the selection; they differ only
+                    // briefly when a swap is deferred behind an in-progress dictation.
+                    let isLoaded = (variant == appState.modelLabel)
+                    let isProtected = isLoaded || (variant == model)
                     HStack(spacing: Theme.s8) {
                         Text(SpeechModelCatalog.displayName(for: variant))
                         Text(SpeechModelCatalog.sizeLabel(for: variant))
                             .font(.caption).foregroundStyle(.secondary)
                         Spacer()
-                        if isActive {
+                        if isLoaded {
                             Text("Active").font(.caption.weight(.semibold)).foregroundStyle(Theme.moss)
                         }
                         Button("Delete") { confirmDeleteSpeechModel(variant) }
                             .font(.caption)
-                            .disabled(isActive)
-                            .help(isActive
+                            .disabled(isProtected)
+                            .help(isProtected
                                   ? "This model is in use. Switch to another model first, then delete it."
                                   : "Remove this model from disk to free space.")
                     }
@@ -181,19 +185,18 @@ private struct GeneralPane: View {
     /// not-yet-downloaded one opens the download sheet and the visual pick reverts.
     private func selectSpeechModel(_ target: String) {
         guard target != model else { return }
-        // Warm-up is still downloading a model (banner, no controller sheet) —
-        // we're choosing what to load right now, so retarget warm-up to the new
-        // model: commit it and restart warm-up. No sheet, no second download.
-        if case .downloading = appState.speechDownload, !speechDownload.canResurface {
-            model = target
-            (NSApp.delegate as? AppDelegate)?.startWarm()
-            return
-        }
-        if WhisperKitEngine.hasModelWeights(for: target) {
-            model = target
-        } else {
+        var warmingNow = false
+        if case .downloading = appState.speechDownload, !speechDownload.canResurface { warmingNow = true }
+        if !warmingNow, !WhisperKitEngine.hasModelWeights(for: target) {
+            // App is warm but the model isn't downloaded → confirm + download;
+            // the controller hot-swaps the engine once it lands.
             speechDownload.begin(target: target)
             pickerModel = model
+        } else {
+            // Downloaded (hot-swap now) or mid warm-up (retarget) — commit and let
+            // AppDelegate apply it: immediately, or after the current dictation.
+            model = target
+            (NSApp.delegate as? AppDelegate)?.swapModel()
         }
     }
 
@@ -220,7 +223,7 @@ private struct GeneralPane: View {
             Section {
                 speechModelPicker
                 speechDownloadRow
-                Text("Downloads the model now; the new model takes effect on next launch.")
+                Text("Switches right away (downloads first if the model isn't on your Mac). A switch during dictation applies once it finishes.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 downloadedModelsTable

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -96,7 +96,15 @@ private struct GeneralPane: View {
     @State private var downloadedModels: [String] = []
 
     private func refreshDownloadedModels() {
-        downloadedModels = SpeechModelCatalog.all.filter { WhisperKitEngine.hasModelWeights(for: $0) }
+        // Exclude the model currently downloading: WhisperKit writes weight
+        // bundles to their final path mid-transfer, so `hasModelWeights` flips
+        // true before the download finishes — without this it would show (and
+        // be deletable) while still downloading.
+        var downloading: String?
+        if case .downloading(let m, _) = appState.speechDownload { downloading = m }
+        downloadedModels = SpeechModelCatalog.all.filter {
+            $0 != downloading && WhisperKitEngine.hasModelWeights(for: $0)
+        }
     }
 
     @ViewBuilder

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -83,45 +83,61 @@ private struct GeneralPane: View {
         category: "LaunchAtLogin"
     )
 
-    /// Switching to an uncached model routes through the download sheet (which
-    /// commits the preference on success); a cached model switches immediately.
-    private var speechModelSelection: Binding<String> {
-        Binding(
-            get: { model },
-            set: { target in
-                if target != model, !WhisperKitEngine.hasCompleteLocalCache(for: target) {
-                    speechDownload.begin(target: target)
-                } else {
-                    model = target
-                }
+    /// Mirror of `@AppStorage("model")` that the Picker binds to. A plain
+    /// rejecting binding leaves the Picker showing a rejected value, so we drive
+    /// it through `@State` and reconcile in `.onChange`: a not-yet-downloaded
+    /// model opens the download sheet and the visual selection snaps back; a
+    /// successful download flows the committed `model` back into the Picker.
+    @State private var pickerModel: String = ""
+
+    /// Inline progress row shown under the picker while a download runs in the
+    /// background (sheet dismissed). Extracted to keep the Form body light for
+    /// the SwiftUI type-checker.
+    @ViewBuilder
+    private var speechDownloadRow: some View {
+        if case .downloading(let fraction) = speechDownload.phase, !speechDownload.isPresented {
+            let caption = "\(SpeechModelCatalog.displayName(for: speechDownload.target)) · \(SpeechModelDownloadSheet.percentLabel(fraction))"
+            HStack(spacing: Theme.s8) {
+                ProgressView(value: fraction).frame(maxWidth: 160)
+                Text(caption)
+                    .font(.caption).foregroundStyle(.secondary)
+                Spacer()
+                Button("Show") { speechDownload.resurface() }
+                    .font(.caption)
             }
-        )
+        }
+    }
+
+    /// Reconcile a picker selection: a downloaded model switches immediately; a
+    /// not-yet-downloaded one opens the download sheet and the visual pick reverts.
+    private func selectSpeechModel(_ target: String) {
+        guard target != model else { return }
+        if WhisperKitEngine.hasModelWeights(for: target) {
+            model = target
+        } else {
+            speechDownload.begin(target: target)
+            pickerModel = model
+        }
     }
 
     var body: some View {
         Form {
             Section {
-                Picker("Speech model", selection: speechModelSelection) {
+                Picker("Speech model", selection: $pickerModel) {
                     Text("tiny — fastest, lowest accuracy (~150 MB)").tag("tiny")
                     Text("base — fast, modest accuracy (~290 MB)").tag("base")
                     Text("small — balanced (~480 MB)").tag("small")
                     Text("medium — best balance, default (~1.5 GB)").tag("medium")
                     Text("large-v3 — highest accuracy (~3 GB)").tag("large-v3")
                 }
+                .onAppear { pickerModel = model }
+                .onChange(of: model) { pickerModel = $0 }
+                .onChange(of: pickerModel) { selectSpeechModel($0) }
                 .sheet(isPresented: $speechDownload.isPresented,
                        onDismiss: { speechDownload.detachToBackground() }) {
                     SpeechModelDownloadSheet(model: speechDownload)
                 }
-                if case .downloading(let stats) = speechDownload.phase, !speechDownload.isPresented {
-                    HStack(spacing: Theme.s8) {
-                        ProgressView(value: stats.fraction).frame(maxWidth: 160)
-                        Text(SpeechModelDownloadSheet.progressCaption(stats))
-                            .font(.caption).foregroundStyle(.secondary)
-                        Spacer()
-                        Button("Show") { speechDownload.resurface() }
-                            .font(.caption)
-                    }
-                }
+                speechDownloadRow
                 Text("Downloads the model now; the new model takes effect on next launch.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -1186,7 +1202,7 @@ private struct SpeechModelDownloadSheet: View {
                 .font(.headline)
 
             switch model.phase {
-            case .confirming:
+            case .idle, .confirming:
                 Text("This speech model needs a one-time \(SpeechModelCatalog.sizeLabel(for: model.target)) download. It stays on your Mac and takes effect the next time OpenQuack launches.")
                     .fixedSize(horizontal: false, vertical: true)
                 HStack {
@@ -1195,9 +1211,9 @@ private struct SpeechModelDownloadSheet: View {
                     Button("Download") { model.confirm() }
                         .keyboardShortcut(.defaultAction)
                 }
-            case .downloading(let stats):
-                ProgressView(value: stats.fraction)
-                Text(Self.progressCaption(stats))
+            case .downloading(let fraction):
+                ProgressView(value: fraction)
+                Text(Self.percentLabel(fraction))
                     .font(.caption).foregroundStyle(.secondary)
                 HStack {
                     Spacer()
@@ -1219,19 +1235,9 @@ private struct SpeechModelDownloadSheet: View {
         .frame(width: 380)
     }
 
-    static func progressCaption(_ s: SpeechModelDownloadController.Stats) -> String {
-        if s.reconnecting { return "Starting…" }
-        var parts = ["\(Int(s.fraction * 100))%"]
-        if let eta = s.eta {
-            parts.append("~\(Self.formatETA(eta)) left")
-        }
-        return parts.joined(separator: " · ")
-    }
-
-    private static func formatETA(_ seconds: TimeInterval) -> String {
-        let s = max(0, Int(seconds.rounded()))
-        if s < 60 { return "\(s) sec" }
-        let m = (s + 30) / 60
-        return "\(m) min"
+    /// WhisperKit only exposes a lumpy completion fraction (no reliable byte
+    /// rate), so we show percent only — no fabricated ETA.
+    static func percentLabel(_ fraction: Double) -> String {
+        fraction <= 0 ? "Starting…" : "\(Int(fraction * 100))%"
     }
 }

--- a/Sources/OpenQuackApp/SpeechModelDownloadController.swift
+++ b/Sources/OpenQuackApp/SpeechModelDownloadController.swift
@@ -82,6 +82,11 @@ final class SpeechModelDownloadController: ObservableObject {
         isPresented = true
     }
 
+    /// True when a sheet-backed download is in flight (one the user can re-open).
+    /// Launch-time downloads drive the banner without a controller task, so the
+    /// banner hides its "Show" button for those.
+    var canResurface: Bool { task != nil }
+
     /// Idempotent: starting while a task already runs is a no-op.
     private func start() {
         guard task == nil else { return }

--- a/Sources/OpenQuackApp/SpeechModelDownloadController.swift
+++ b/Sources/OpenQuackApp/SpeechModelDownloadController.swift
@@ -95,10 +95,11 @@ final class SpeechModelDownloadController: ObservableObject {
                 }
                 self.finishSuccessfully()
             } catch {
-                // `ensureDownloaded` wraps every error (incl. cancellation) into
-                // EngineError.loadFailed, so distinguish a user cancel via the
-                // task's own flag — cancel() has already torn down state.
-                if Task.isCancelled { self.task = nil; return }
+                // A user cancel tears down state in cancel(); detect it via the
+                // task's flag. `ensureDownloaded` currently absorbs
+                // CancellationError, but guard on it too so this stays correct
+                // if that ever changes.
+                if Task.isCancelled || error is CancellationError { self.task = nil; return }
                 self.task = nil
                 self.phase = .failed("Download failed. Check your connection and retry.")
                 self.appState?.speechDownload = .inactive

--- a/Sources/OpenQuackApp/SpeechModelDownloadController.swift
+++ b/Sources/OpenQuackApp/SpeechModelDownloadController.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Combine
+import OpenQuackKit
+
+/// Long-lived owner of the Whisper speech-model download. Held by `AppDelegate`
+/// so the transfer survives sheet/window dismissal. Commits the new
+/// `@AppStorage("model")` value only on verified success; mirrors progress into
+/// `AppState` for the menu-bar banner. The model takes effect on next launch
+/// (no live engine hot-swap) — the existing `warmTranscriber` path loads it.
+@MainActor
+final class SpeechModelDownloadController: ObservableObject {
+    enum Phase: Equatable {
+        case confirming
+        case downloading(Stats)
+        case failed(String)
+    }
+
+    struct Stats: Equatable {
+        var fraction: Double
+        var eta: TimeInterval?
+        var reconnecting: Bool
+    }
+
+    @Published var isPresented = false
+    @Published var phase: Phase = .confirming
+
+    /// The variant the user is switching to. Drives the sheet copy and the
+    /// commit target.
+    private(set) var target: String = ""
+
+    /// Set by AppDelegate so progress can drive the menu-bar banner.
+    weak var appState: AppState?
+
+    private var task: Task<Void, Never>?
+    private var estimator = DownloadRateEstimator()
+
+    /// Fraction (0…1) is scaled onto this nominal unit count so the
+    /// byte-oriented `DownloadRateEstimator` can produce a time-to-completion.
+    private static let etaScale: Int64 = 1_000_000
+
+    /// Open the sheet for a target the picker found uncached. If a download is
+    /// already running, re-surface it instead of resetting to the confirm step.
+    func begin(target: String) {
+        guard task == nil else { resurface(); return }
+        self.target = target
+        phase = .confirming
+        isPresented = true
+    }
+
+    /// User tapped Download.
+    func confirm() {
+        start()
+        isPresented = true
+    }
+
+    func retry() { start() }
+
+    /// Dismiss the sheet but keep downloading. The window-close path and the
+    /// "Download in Background" button both route here.
+    func detachToBackground() {
+        isPresented = false
+    }
+
+    /// Stop the transfer. Leaves `@AppStorage("model")` untouched so the picker
+    /// reverts to the previously selected model. WhisperKit owns its own partial
+    /// cache; a half-finished download is harmless (next launch's cache check
+    /// fails and re-downloads).
+    func cancel() {
+        task?.cancel()
+        task = nil
+        appState?.speechDownload = .inactive
+        isPresented = false
+    }
+
+    /// Re-open the sheet on a background download (from the Settings row or the
+    /// menu-bar banner click). No-op if nothing is in flight.
+    func resurface() {
+        guard task != nil else { return }
+        isPresented = true
+    }
+
+    /// Idempotent: starting while a task already runs is a no-op.
+    private func start() {
+        guard task == nil else { return }
+        estimator = DownloadRateEstimator()
+        phase = .downloading(Stats(fraction: 0, eta: nil, reconnecting: true))
+        appState?.speechDownload = .downloading(fraction: 0)
+        let begin = Date()
+        let variant = target
+        task = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await WhisperKitEngine.ensureDownloaded(model: variant) { fraction in
+                    Task { @MainActor in self.ingest(fraction: fraction, since: begin) }
+                }
+                self.finishSuccessfully()
+            } catch {
+                // `ensureDownloaded` wraps every error (incl. cancellation) into
+                // EngineError.loadFailed, so distinguish a user cancel via the
+                // task's own flag — cancel() has already torn down state.
+                if Task.isCancelled { self.task = nil; return }
+                self.task = nil
+                self.phase = .failed("Download failed. Check your connection and retry.")
+                self.appState?.speechDownload = .inactive
+            }
+        }
+    }
+
+    private func finishSuccessfully() {
+        task = nil
+        UserDefaults.standard.set(target, forKey: "model")
+        appState?.speechDownload = .inactive
+        isPresented = false
+    }
+
+    private func ingest(fraction: Double, since start: Date) {
+        guard case .downloading = phase else { return }
+        let elapsed = Date().timeIntervalSince(start)
+        let completed = Int64(fraction * Double(Self.etaScale))
+        estimator.add(completed: completed, at: elapsed)
+        phase = .downloading(Stats(
+            fraction: fraction,
+            eta: estimator.eta(completed: completed, total: Self.etaScale),
+            reconnecting: fraction <= 0
+        ))
+        appState?.speechDownload = .downloading(fraction: fraction)
+    }
+}

--- a/Sources/OpenQuackApp/SpeechModelDownloadController.swift
+++ b/Sources/OpenQuackApp/SpeechModelDownloadController.swift
@@ -10,19 +10,14 @@ import OpenQuackKit
 @MainActor
 final class SpeechModelDownloadController: ObservableObject {
     enum Phase: Equatable {
+        case idle
         case confirming
-        case downloading(Stats)
+        case downloading(Double)   // fraction 0…1
         case failed(String)
     }
 
-    struct Stats: Equatable {
-        var fraction: Double
-        var eta: TimeInterval?
-        var reconnecting: Bool
-    }
-
     @Published var isPresented = false
-    @Published var phase: Phase = .confirming
+    @Published var phase: Phase = .idle
 
     /// The variant the user is switching to. Drives the sheet copy and the
     /// commit target.
@@ -32,17 +27,12 @@ final class SpeechModelDownloadController: ObservableObject {
     weak var appState: AppState?
 
     private var task: Task<Void, Never>?
-    private var estimator = DownloadRateEstimator()
     /// The "model" preference value when the current download started. Used to
     /// avoid clobbering a newer explicit selection the user made mid-download.
     private var baselineModel = ""
 
-    /// Fraction (0…1) is scaled onto this nominal unit count so the
-    /// byte-oriented `DownloadRateEstimator` can produce a time-to-completion.
-    private static let etaScale: Int64 = 1_000_000
-
-    /// Open the sheet for a target the picker found uncached. If a download is
-    /// already running, re-surface it instead of resetting to the confirm step.
+    /// Open the sheet for a target the picker found not-yet-downloaded. If a
+    /// download is already running, re-surface it instead of resetting to confirm.
     func begin(target: String) {
         guard task == nil else { resurface(); return }
         self.target = target
@@ -64,13 +54,13 @@ final class SpeechModelDownloadController: ObservableObject {
         isPresented = false
     }
 
-    /// Stop the transfer. Leaves `@AppStorage("model")` untouched so the picker
-    /// reverts to the previously selected model. WhisperKit owns its own partial
-    /// cache; a half-finished download is harmless (next launch's cache check
-    /// fails and re-downloads).
+    /// Stop the transfer and clear all download UI. Leaves `@AppStorage("model")`
+    /// untouched so the picker reverts to the previously selected model.
+    /// WhisperKit keeps its partial in a resume cache; a future selection resumes.
     func cancel() {
         task?.cancel()
         task = nil
+        phase = .idle
         appState?.speechDownload = .inactive
         isPresented = false
     }
@@ -91,16 +81,14 @@ final class SpeechModelDownloadController: ObservableObject {
     private func start() {
         guard task == nil else { return }
         baselineModel = UserDefaults.standard.string(forKey: "model") ?? "medium"
-        estimator = DownloadRateEstimator()
-        phase = .downloading(Stats(fraction: 0, eta: nil, reconnecting: true))
-        appState?.speechDownload = .downloading(fraction: 0)
-        let begin = Date()
+        phase = .downloading(0)
         let variant = target
+        appState?.speechDownload = .downloading(model: variant, fraction: 0)
         task = Task { [weak self] in
             guard let self else { return }
             do {
                 try await WhisperKitEngine.ensureDownloaded(model: variant) { fraction in
-                    Task { @MainActor in self.ingest(fraction: fraction, since: begin) }
+                    Task { @MainActor in self.ingest(fraction: fraction) }
                 }
                 self.finishSuccessfully()
             } catch {
@@ -118,6 +106,7 @@ final class SpeechModelDownloadController: ObservableObject {
 
     private func finishSuccessfully() {
         task = nil
+        phase = .idle
         // Adopt the freshly downloaded model only if the user hasn't switched to
         // another model while this ran — their later choice wins. The download
         // still completed, so the model stays cached for a future selection.
@@ -129,16 +118,9 @@ final class SpeechModelDownloadController: ObservableObject {
         isPresented = false
     }
 
-    private func ingest(fraction: Double, since start: Date) {
+    private func ingest(fraction: Double) {
         guard case .downloading = phase else { return }
-        let elapsed = Date().timeIntervalSince(start)
-        let completed = Int64(fraction * Double(Self.etaScale))
-        estimator.add(completed: completed, at: elapsed)
-        phase = .downloading(Stats(
-            fraction: fraction,
-            eta: estimator.eta(completed: completed, total: Self.etaScale),
-            reconnecting: fraction <= 0
-        ))
-        appState?.speechDownload = .downloading(fraction: fraction)
+        phase = .downloading(fraction)
+        appState?.speechDownload = .downloading(model: target, fraction: fraction)
     }
 }

--- a/Sources/OpenQuackApp/SpeechModelDownloadController.swift
+++ b/Sources/OpenQuackApp/SpeechModelDownloadController.swift
@@ -55,8 +55,9 @@ final class SpeechModelDownloadController: ObservableObject {
     }
 
     /// Stop the transfer and clear all download UI. Leaves `@AppStorage("model")`
-    /// untouched so the picker reverts to the previously selected model.
-    /// WhisperKit keeps its partial in a resume cache; a future selection resumes.
+    /// untouched so the picker reverts to the previously selected model. The
+    /// partial weights stay in WhisperKit's cache; re-selecting the model
+    /// re-runs the download (HubApi resumes from where it stopped).
     func cancel() {
         task?.cancel()
         task = nil

--- a/Sources/OpenQuackApp/SpeechModelDownloadController.swift
+++ b/Sources/OpenQuackApp/SpeechModelDownloadController.swift
@@ -33,6 +33,9 @@ final class SpeechModelDownloadController: ObservableObject {
 
     private var task: Task<Void, Never>?
     private var estimator = DownloadRateEstimator()
+    /// The "model" preference value when the current download started. Used to
+    /// avoid clobbering a newer explicit selection the user made mid-download.
+    private var baselineModel = ""
 
     /// Fraction (0…1) is scaled onto this nominal unit count so the
     /// byte-oriented `DownloadRateEstimator` can produce a time-to-completion.
@@ -82,6 +85,7 @@ final class SpeechModelDownloadController: ObservableObject {
     /// Idempotent: starting while a task already runs is a no-op.
     private func start() {
         guard task == nil else { return }
+        baselineModel = UserDefaults.standard.string(forKey: "model") ?? "medium"
         estimator = DownloadRateEstimator()
         phase = .downloading(Stats(fraction: 0, eta: nil, reconnecting: true))
         appState?.speechDownload = .downloading(fraction: 0)
@@ -109,7 +113,13 @@ final class SpeechModelDownloadController: ObservableObject {
 
     private func finishSuccessfully() {
         task = nil
-        UserDefaults.standard.set(target, forKey: "model")
+        // Adopt the freshly downloaded model only if the user hasn't switched to
+        // another model while this ran — their later choice wins. The download
+        // still completed, so the model stays cached for a future selection.
+        let current = UserDefaults.standard.string(forKey: "model") ?? "medium"
+        if current == baselineModel {
+            UserDefaults.standard.set(target, forKey: "model")
+        }
         appState?.speechDownload = .inactive
         isPresented = false
     }

--- a/Sources/OpenQuackApp/SpeechModelDownloadController.swift
+++ b/Sources/OpenQuackApp/SpeechModelDownloadController.swift
@@ -26,6 +26,10 @@ final class SpeechModelDownloadController: ObservableObject {
     /// Set by AppDelegate so progress can drive the menu-bar banner.
     weak var appState: AppState?
 
+    /// Called (main actor) after a download successfully commits the model
+    /// preference, so AppDelegate can hot-swap the live engine to it.
+    var onCommitted: (() -> Void)?
+
     private var task: Task<Void, Never>?
     /// The "model" preference value when the current download started. Used to
     /// avoid clobbering a newer explicit selection the user made mid-download.
@@ -114,6 +118,7 @@ final class SpeechModelDownloadController: ObservableObject {
         let current = UserDefaults.standard.string(forKey: "model") ?? "medium"
         if current == baselineModel {
             UserDefaults.standard.set(target, forKey: "model")
+            onCommitted?()
         }
         appState?.speechDownload = .inactive
         isPresented = false

--- a/Sources/OpenQuackKit/Transcription/SpeechModelCatalog.swift
+++ b/Sources/OpenQuackKit/Transcription/SpeechModelCatalog.swift
@@ -6,6 +6,9 @@ import Foundation
 /// place. The byte-accurate download is owned by WhisperKit; these are the
 /// human-facing labels only.
 public enum SpeechModelCatalog {
+    /// The variants offered in Settings, in display order.
+    public static let all = ["tiny", "base", "small", "medium", "large-v3"]
+
     public static func displayName(for variant: String) -> String {
         switch variant {
         case "tiny":     return "Tiny"

--- a/Sources/OpenQuackKit/Transcription/SpeechModelCatalog.swift
+++ b/Sources/OpenQuackKit/Transcription/SpeechModelCatalog.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Display metadata for the Whisper speech-model variants offered in the
+/// Settings picker. Pure lookups — used by the download sheet, the menu-bar
+/// banner, and `SpeechModelDownloadController` so the strings live in one
+/// place. The byte-accurate download is owned by WhisperKit; these are the
+/// human-facing labels only.
+public enum SpeechModelCatalog {
+    public static func displayName(for variant: String) -> String {
+        switch variant {
+        case "tiny":     return "Tiny"
+        case "base":     return "Base"
+        case "small":    return "Small"
+        case "medium":   return "Medium"
+        case "large-v3": return "Large v3"
+        default:         return variant
+        }
+    }
+
+    public static func sizeLabel(for variant: String) -> String {
+        switch variant {
+        case "tiny":     return "~150 MB"
+        case "base":     return "~290 MB"
+        case "small":    return "~480 MB"
+        case "medium":   return "~1.5 GB"
+        case "large-v3": return "~3 GB"
+        default:         return "the model"
+        }
+    }
+}

--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -244,46 +244,6 @@ public final class WhisperKitEngine: TranscriptionEngine {
         }
     }
 
-    /// Delete every cached WhisperKit model variant except `keeping`. Returns
-    /// the number of bytes freed. Safe to call while the kept model is
-    /// actively in use — we only touch sibling directories.
-    @discardableResult
-    public static func cleanupOtherModels(keeping: String, downloadBase: URL? = nil) -> Int64 {
-        let fm = FileManager.default
-        let cacheDir = downloadBase ?? defaultDownloadBase()
-
-        // Reconcile the legacy orphan tree first so a single pass over the
-        // canonical path is enough.
-        cleanupOrphanLegacyTree(in: cacheDir)
-
-        var freed: Int64 = 0
-
-        // CoreML weights — argmaxinc/whisperkit-coreml/openai_whisper-<size>.
-        let keptWeights = localModelFolder(for: keeping, downloadBase: cacheDir)
-        let weightsRoot = keptWeights.deletingLastPathComponent()
-        let weightsKeep = keptWeights.lastPathComponent
-        if let entries = try? fm.contentsOfDirectory(atPath: weightsRoot.path) {
-            for entry in entries where entry != weightsKeep && !entry.hasPrefix(".") {
-                let url = weightsRoot.appendingPathComponent(entry)
-                freed += directorySize(at: url)
-                try? fm.removeItem(at: url)
-            }
-        }
-
-        // Tokenizer/config — openai/whisper-<size> (a few MB each).
-        let keptTokenizer = localTokenizerFolder(for: keeping, downloadBase: cacheDir)
-        let tokenizerRoot = keptTokenizer.deletingLastPathComponent()
-        let tokenizerKeep = keptTokenizer.lastPathComponent
-        if let entries = try? fm.contentsOfDirectory(atPath: tokenizerRoot.path) {
-            for entry in entries where entry != tokenizerKeep && !entry.hasPrefix(".") {
-                let url = tokenizerRoot.appendingPathComponent(entry)
-                freed += directorySize(at: url)
-                try? fm.removeItem(at: url)
-            }
-        }
-        return freed
-    }
-
     /// Delete a single cached model variant — weights, tokenizer, and the
     /// HubApi download-staging copy — to reclaim disk. Returns bytes freed.
     /// Safe if the variant is only partially present.

--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -92,7 +92,7 @@ public final class WhisperKitEngine: TranscriptionEngine {
             .appendingPathComponent("whisper-\(variant)", isDirectory: true)
     }
 
-    static func hasCompleteLocalCache(for variant: String, downloadBase: URL? = nil) -> Bool {
+    public static func hasCompleteLocalCache(for variant: String, downloadBase: URL? = nil) -> Bool {
         let fm = FileManager.default
         let modelFolder = localModelFolder(for: variant, downloadBase: downloadBase)
         let required = ["AudioEncoder.mlmodelc", "MelSpectrogram.mlmodelc", "TextDecoder.mlmodelc"]

--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -92,16 +92,28 @@ public final class WhisperKitEngine: TranscriptionEngine {
             .appendingPathComponent("whisper-\(variant)", isDirectory: true)
     }
 
-    public static func hasCompleteLocalCache(for variant: String, downloadBase: URL? = nil) -> Bool {
+    /// True when the model *weights* (the three large `.mlmodelc` bundles) are
+    /// on disk. This — not `hasCompleteLocalCache` — answers "do we need the
+    /// multi-GB download?", because `WhisperKit.download` fetches only the
+    /// weights; the small tokenizer is pulled lazily at model load. The Settings
+    /// picker and the launch warm-up gate use this so a downloaded model isn't
+    /// re-offered for download just because its tokenizer hasn't been fetched yet.
+    public static func hasModelWeights(for variant: String, downloadBase: URL? = nil) -> Bool {
         let fm = FileManager.default
         let modelFolder = localModelFolder(for: variant, downloadBase: downloadBase)
         let required = ["AudioEncoder.mlmodelc", "MelSpectrogram.mlmodelc", "TextDecoder.mlmodelc"]
-        let modelsPresent = required.allSatisfy {
+        return required.allSatisfy {
             fm.fileExists(atPath: modelFolder.appendingPathComponent($0).path)
         }
+    }
+
+    /// Weights **and** tokenizer present — a fully loadable cache. Used by the
+    /// engine init to decide whether it can skip the network manifest call.
+    public static func hasCompleteLocalCache(for variant: String, downloadBase: URL? = nil) -> Bool {
+        guard hasModelWeights(for: variant, downloadBase: downloadBase) else { return false }
         let tokenizer = localTokenizerFolder(for: variant, downloadBase: downloadBase)
             .appendingPathComponent("tokenizer.json")
-        return modelsPresent && fm.fileExists(atPath: tokenizer.path)
+        return FileManager.default.fileExists(atPath: tokenizer.path)
     }
 
     public static func refreshModelInBackground(model: String, downloadBase: URL? = nil) async {

--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -284,6 +284,25 @@ public final class WhisperKitEngine: TranscriptionEngine {
         return freed
     }
 
+    /// Delete a single cached model variant — weights, tokenizer, and the
+    /// HubApi download-staging copy — to reclaim disk. Returns bytes freed.
+    /// Safe if the variant is only partially present.
+    @discardableResult
+    public static func deleteModel(_ variant: String, downloadBase: URL? = nil) -> Int64 {
+        let fm = FileManager.default
+        let cacheDir = downloadBase ?? defaultDownloadBase()
+        let weights = localModelFolder(for: variant, downloadBase: cacheDir)
+        let staging = weights.deletingLastPathComponent()
+            .appendingPathComponent(".cache/huggingface/download/openai_whisper-\(variant)", isDirectory: true)
+        var freed: Int64 = 0
+        for url in [weights, localTokenizerFolder(for: variant, downloadBase: cacheDir), staging]
+        where fm.fileExists(atPath: url.path) {
+            freed += directorySize(at: url)
+            try? fm.removeItem(at: url)
+        }
+        return freed
+    }
+
     private static func directorySize(at url: URL) -> Int64 {
         let fm = FileManager.default
         guard let enumerator = fm.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else {

--- a/Tests/OpenQuackKitTests/SpeechModelCatalogTests.swift
+++ b/Tests/OpenQuackKitTests/SpeechModelCatalogTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class SpeechModelCatalogTests: XCTestCase {
+    func testDisplayName_knownVariants() {
+        XCTAssertEqual(SpeechModelCatalog.displayName(for: "medium"), "Medium")
+        XCTAssertEqual(SpeechModelCatalog.displayName(for: "large-v3"), "Large v3")
+        XCTAssertEqual(SpeechModelCatalog.displayName(for: "tiny"), "Tiny")
+    }
+
+    func testDisplayName_unknownVariantFallsBackToRaw() {
+        XCTAssertEqual(SpeechModelCatalog.displayName(for: "distil-large-v3"), "distil-large-v3")
+    }
+
+    func testSizeLabel_knownVariants() {
+        XCTAssertEqual(SpeechModelCatalog.sizeLabel(for: "tiny"), "~150 MB")
+        XCTAssertEqual(SpeechModelCatalog.sizeLabel(for: "medium"), "~1.5 GB")
+        XCTAssertEqual(SpeechModelCatalog.sizeLabel(for: "large-v3"), "~3 GB")
+    }
+
+    func testSizeLabel_unknownVariantFallsBack() {
+        XCTAssertEqual(SpeechModelCatalog.sizeLabel(for: "mystery"), "the model")
+    }
+}

--- a/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
+++ b/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
@@ -54,6 +54,25 @@ final class WhisperKitEngineCacheTests: XCTestCase {
         XCTAssertFalse(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))
     }
 
+    func testHasModelWeights_trueWhenWeightsPresentEvenWithoutTokenizer() throws {
+        let fm = FileManager.default
+        let model = WhisperKitEngine.localModelFolder(for: "tiny", downloadBase: base)
+        for name in ["AudioEncoder.mlmodelc", "MelSpectrogram.mlmodelc", "TextDecoder.mlmodelc"] {
+            try fm.createDirectory(at: model.appendingPathComponent(name), withIntermediateDirectories: true)
+        }
+        // No tokenizer — mirrors a fresh `ensureDownloaded` (weights only).
+        XCTAssertTrue(WhisperKitEngine.hasModelWeights(for: "tiny", downloadBase: base))
+        XCTAssertFalse(WhisperKitEngine.hasCompleteLocalCache(for: "tiny", downloadBase: base))
+    }
+
+    func testHasModelWeights_falseWhenAWeightIsMissing() throws {
+        try seedCompleteCache(for: "tiny")
+        let path = WhisperKitEngine.localModelFolder(for: "tiny", downloadBase: base)
+            .appendingPathComponent("TextDecoder.mlmodelc")
+        try FileManager.default.removeItem(at: path)
+        XCTAssertFalse(WhisperKitEngine.hasModelWeights(for: "tiny", downloadBase: base))
+    }
+
     func testHasCompleteLocalCache_isPerVariant() throws {
         try seedCompleteCache(for: "medium")
         XCTAssertTrue(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))

--- a/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
+++ b/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
@@ -73,6 +73,20 @@ final class WhisperKitEngineCacheTests: XCTestCase {
         XCTAssertFalse(WhisperKitEngine.hasModelWeights(for: "tiny", downloadBase: base))
     }
 
+    func testDeleteModel_removesWeightsAndTokenizer() throws {
+        try seedCompleteCache(for: "tiny")
+        try seedCompleteCache(for: "base")
+        XCTAssertTrue(WhisperKitEngine.hasCompleteLocalCache(for: "tiny", downloadBase: base))
+
+        WhisperKitEngine.deleteModel("tiny", downloadBase: base)
+
+        XCTAssertFalse(WhisperKitEngine.hasModelWeights(for: "tiny", downloadBase: base))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: WhisperKitEngine.localTokenizerFolder(for: "tiny", downloadBase: base).path))
+        // Sibling untouched.
+        XCTAssertTrue(WhisperKitEngine.hasCompleteLocalCache(for: "base", downloadBase: base))
+    }
+
     func testHasCompleteLocalCache_isPerVariant() throws {
         try seedCompleteCache(for: "medium")
         XCTAssertTrue(WhisperKitEngine.hasCompleteLocalCache(for: "medium", downloadBase: base))

--- a/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
+++ b/Tests/OpenQuackKitTests/WhisperKitEngineCacheTests.swift
@@ -109,25 +109,4 @@ final class WhisperKitEngineCacheTests: XCTestCase {
         )
     }
 
-    func testCleanupOtherModels_keepsActiveAndDeletesSiblings() throws {
-        let fm = FileManager.default
-        let weightsRoot = WhisperKitEngine.localModelFolder(for: "x", downloadBase: base)
-            .deletingLastPathComponent()
-        let tokenizerRoot = WhisperKitEngine.localTokenizerFolder(for: "x", downloadBase: base)
-            .deletingLastPathComponent()
-        for variant in ["medium", "tiny", "large-v3"] {
-            try fm.createDirectory(at: weightsRoot.appendingPathComponent("openai_whisper-\(variant)"),
-                                    withIntermediateDirectories: true)
-            try fm.createDirectory(at: tokenizerRoot.appendingPathComponent("whisper-\(variant)"),
-                                    withIntermediateDirectories: true)
-        }
-
-        _ = WhisperKitEngine.cleanupOtherModels(keeping: "medium", downloadBase: base)
-
-        XCTAssertTrue(fm.fileExists(atPath: weightsRoot.appendingPathComponent("openai_whisper-medium").path))
-        XCTAssertFalse(fm.fileExists(atPath: weightsRoot.appendingPathComponent("openai_whisper-tiny").path))
-        XCTAssertFalse(fm.fileExists(atPath: weightsRoot.appendingPathComponent("openai_whisper-large-v3").path))
-        XCTAssertTrue(fm.fileExists(atPath: tokenizerRoot.appendingPathComponent("whisper-medium").path))
-        XCTAssertFalse(fm.fileExists(atPath: tokenizerRoot.appendingPathComponent("whisper-tiny").path))
-    }
 }


### PR DESCRIPTION
## SPEC
SPEC-002 (Transcription)

## Milestone
M2

Relates to #87 (not closing — leaving the enhancement open for follow-ups).

## Why
Switching the Speech model silently wrote a preference with no confirmation and no visible download; the choice only took effect on next launch, and there was no way to see or manage which models were on disk. This brings the speech model in line with the Local LLM polish flow and goes further: confirm + progress on download, immediate hot-swap on switch, and a user-managed model library.

## Change
- **Confirm + progress** when switching to a not-yet-downloaded model: sheet + inline row + menu-bar banner (model name + percent; no ETA — WhisperKit's fraction is lumpy). Commits the preference only on a verified download.
- **Hot-swap**: a switch now takes effect immediately by rebuilding the live engine; a switch mid-dictation defers until the current one finishes (replaces the previous "next launch" behaviour).
- **Launch warm-up** uses the same banner and is cancellable/retargetable — switching during it re-aims warm-up at the new model instead of spawning a second concurrent download.
- **Downloaded-models table**: lists only downloaded variants with size, an *Active* badge (the actually-loaded model), and per-model **Delete** (disabled for the in-use model). Removed the auto-delete of sibling models — models persist as a library the user manages.
- **Kit**: `SpeechModelCatalog`; `hasModelWeights` (weights-only check, split out of `hasCompleteLocalCache`, since `WhisperKit.download` fetches weights but not the tokenizer); `deleteModel`.

## Tests
- [x] unit tests added: `SpeechModelCatalogTests`; `WhisperKitEngineCacheTests` (hasModelWeights / deleteModel)
- [x] `swift build && swift test` green locally (230 tests, 0 failures)
- [ ] bench: n/a — no transcription-quality or latency change

## Privacy impact
Preserved. Model downloads are local-to-disk (HuggingFace, as before); no new network calls in the dictation hot path. Audio capture, transcription, and output are unchanged — only which model is loaded, and when.

## Out of scope
- Fully offline first-load of a freshly downloaded model: the small tokenizer is still fetched at first load (pre-existing WhisperKit behaviour).

## AI coding brief
- **Original request**: user noticed switching the Speech model gave no prompt or progress and silently committed; wanted it to match the Local LLM polish download UX, then iteratively asked for immediate hot-swap, no auto-deletion of other models, and a per-model delete table.
- **Manual interventions**: user live-tested and reported real bugs (cancel not reverting the picker, progress bar never clearing, the sheet reopening for already-downloaded models, inaccurate ETA, menu-bar banner vs Settings model mismatch, a model showing in the table mid-download) plus the library/management requirements — each was root-caused and fixed.
- **Retro**: front-load the full UX shape (library + hot-swap) before implementing; several rework rounds came from requirements arriving after the first build.