### PR TITLE
perf(transcription): load Whisper on CPU+GPU to skip the slow ANE compile

### DIFF
--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -62,11 +62,27 @@ public final class WhisperKitEngine: TranscriptionEngine {
             : nil
 
         do {
+            // Force CPU+GPU for every stage instead of the Apple Neural
+            // Engine. The ANE path requires a per-model compile/specialize
+            // pass on first load that can take ~80s for `medium` and isn't
+            // reliably cached across process launches (observed e5bundlecache
+            // staying empty, ANECompilerService re-compiling every cold start).
+            // CPU+GPU skips that compile entirely — warm drops to a few
+            // seconds. Inference is marginally slower than ANE but still well
+            // under real-time on Apple Silicon, a worthwhile trade for not
+            // blocking the hotkey behind a minute-plus model load.
+            let compute = ModelComputeOptions(
+                melCompute: .cpuAndGPU,
+                audioEncoderCompute: .cpuAndGPU,
+                textDecoderCompute: .cpuAndGPU,
+                prefillCompute: .cpuAndGPU
+            )
             let config = WhisperKitConfig(
                 model: model,
                 downloadBase: cacheDir,
                 modelFolder: modelFolderArg,
                 tokenizerFolder: tokenizerFolderArg,
+                computeOptions: compute,
                 verbose: false,
                 logLevel: .error,
                 load: true


### PR DESCRIPTION
## SPEC

SPEC-002 (Transcription) — load-time performance fix; no new spec.

## Why

`medium` cold-start was ~80s and recurred on **every** launch. WhisperKit loads on the Apple Neural Engine by default, which compiles/specializes the model on first load; on at least one machine that compile result wasn't caching across processes (empty `e5bundlecache`, `ANECompilerService` recompiling each cold start), so the hotkey was blocked behind a minute-plus "loading model" each time.

## Change

`Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift` — pass `ModelComputeOptions(.cpuAndGPU)` for all stages (mel / audioEncoder / textDecoder / prefill). CPU+GPU (Metal) skips the ANE specialize compile entirely.

## Result

`medium` cold load **~80s → ~15s**, stable across launches; transcript output unchanged (verified, identical text). Inference is marginally slower than ANE in steady state but stays well under real-time on Apple Silicon — a worthwhile trade for not blocking the hotkey.

## Tests

- [x] `swift build` + existing suites green.
- Manual: medium cold-load timed at ~15s via `openquack-cli`, transcript identical to ANE path.

## Privacy impact

None — compute-unit selection only.
