### PR TITLE
feat(capture): in-app microphone selection, test, silent-capture recovery & crash-safe tap

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,13 @@ let package = Package(
             dependencies: [],
             path: "Sources/OpenQuackPlatform"
         ),
+        // Tiny Objective-C shim: lets Swift catch the NSExceptions that
+        // AVAudioEngine.installTap raises on format mismatches (otherwise an
+        // uncatchable SIGABRT). See OQObjCSupport.h.
+        .target(
+            name: "OQObjCSupport",
+            path: "Sources/OQObjCSupport"
+        ),
         .target(
             name: "OpenQuackStreaming",
             dependencies: [
@@ -74,6 +81,7 @@ let package = Package(
             dependencies: [
                 "OpenQuackPlatform",
                 "OpenQuackStreaming",
+                "OQObjCSupport",
                 .product(name: "WhisperKit", package: "argmax-oss-swift"),
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
                 .product(name: "LlamaSwift", package: "llama.swift"),

--- a/Sources/OQObjCSupport/OQObjCSupport.m
+++ b/Sources/OQObjCSupport/OQObjCSupport.m
@@ -1,0 +1,16 @@
+#import "OQObjCSupport.h"
+
+NSError * _Nullable OQTryCatch(void (NS_NOESCAPE ^ _Nonnull block)(void)) {
+    @try {
+        block();
+        return nil;
+    } @catch (NSException *exception) {
+        NSMutableDictionary *info = [NSMutableDictionary dictionary];
+        info[NSLocalizedDescriptionKey] =
+            exception.reason ?: exception.name ?: @"Objective-C exception";
+        if (exception.name) {
+            info[@"OQExceptionName"] = exception.name;
+        }
+        return [NSError errorWithDomain:@"OQObjCException" code:1 userInfo:info];
+    }
+}

--- a/Sources/OQObjCSupport/include/OQObjCSupport.h
+++ b/Sources/OQObjCSupport/include/OQObjCSupport.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Runs `block` inside an Objective-C @try/@catch and converts any thrown
+/// `NSException` into an `NSError` (domain `OQObjCException`). Returns `nil`
+/// when the block completes normally.
+///
+/// Swift's `do/try/catch` cannot intercept Objective-C exceptions — and several
+/// AVFoundation calls (notably `-[AVAudioNode installTapOnBus:bufferSize:format:block:]`)
+/// raise `NSInvalidArgumentException` on a format/hardware mismatch, which would
+/// otherwise abort the whole process (SIGABRT). Wrapping those calls in
+/// `OQTryCatch` turns the crash into a recoverable Swift error.
+NSError * _Nullable OQTryCatch(void (NS_NOESCAPE ^ _Nonnull block)(void));
+
+NS_ASSUME_NONNULL_END

--- a/Sources/OpenQuackApp/AppState.swift
+++ b/Sources/OpenQuackApp/AppState.swift
@@ -59,6 +59,13 @@ public final class AppState: ObservableObject {
     /// "ready" overlay state.
     @Published public var lastKickoffError: String?
     @Published public var accessibilityTrusted: Bool = false
+    /// Set when the most-recent recording came back silent (mic captured no
+    /// usable audio — wrong/muted device). Drives the "Switch microphone"
+    /// banner in the popover; cleared at the start of the next transcription.
+    @Published public var lastCaptureSilent: Bool = false
+    /// Name of the input device that produced the silent capture, for the
+    /// banner/notification copy ("No sound from <device>").
+    @Published public var lastSilentDeviceName: String?
     @Published public var modelLabel: String = "medium"
     /// Lifecycle of an update check — drives both the menu-bar 🦆⬆
     /// indicator and the Settings → About status line. Single source of

--- a/Sources/OpenQuackApp/MenuBarContent.swift
+++ b/Sources/OpenQuackApp/MenuBarContent.swift
@@ -16,6 +16,7 @@ struct MenuBarContent: View {
         VStack(alignment: .leading, spacing: Theme.s12) {
             updateBanner
             downloadBanner
+            micIssueBanner
             accessibilityBanner
             heroSection
             transcriptSection
@@ -111,6 +112,32 @@ struct MenuBarContent: View {
                 .buttonStyle(.oqPrimarySmall)
             }
             .oqBanner(tint: Theme.moss)
+        }
+    }
+
+    @ViewBuilder
+    private var micIssueBanner: some View {
+        if state.lastCaptureSilent {
+            HStack(alignment: .top, spacing: Theme.s8) {
+                Image(systemName: "mic.slash")
+                    .font(.title3)
+                    .foregroundStyle(Theme.amber)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("No sound from \(state.lastSilentDeviceName ?? "your microphone")")
+                        .font(.caption.weight(.semibold))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("That recording was silent. Pick a different microphone and test it.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: Theme.s4)
+                Button("Switch mic") {
+                    SettingsWindowController.show(appState: state)
+                }
+                .buttonStyle(.oqPrimarySmall)
+            }
+            .oqBanner(tint: Theme.amber)
         }
     }
 

--- a/Sources/OpenQuackApp/MicTestModel.swift
+++ b/Sources/OpenQuackApp/MicTestModel.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import OpenQuackKit
+
+/// Drives the "Test" mic-level UI in Settings and onboarding. Wraps a
+/// listen-only `MicMonitor`, publishes a sliding level window, and auto-stops
+/// after a few seconds so the mic doesn't stay hot if the user wanders off.
+final class MicTestModel: ObservableObject {
+    @Published var isTesting = false
+    @Published var levels: [Float] = Array(repeating: 0, count: MicTestModel.barCount)
+    /// Flips true once a clearly-above-idle level is seen — drives the
+    /// "Sounds good" confirmation.
+    @Published var sawSignal = false
+
+    static let barCount = 11
+    private static let autoStopSeconds: UInt64 = 8
+
+    private let monitor = MicMonitor()
+    private var autoStopTask: Task<Void, Never>?
+
+    func toggle(deviceUID: String) {
+        isTesting ? stop() : start(deviceUID: deviceUID)
+    }
+
+    func start(deviceUID: String) {
+        monitor.levelHandler = { [weak self] level in self?.push(level) }
+        do {
+            try monitor.start(deviceUID: deviceUID)
+        } catch {
+            return  // engine couldn't start (no permission/device); leave isTesting false
+        }
+        isTesting = true
+        sawSignal = false
+        autoStopTask?.cancel()
+        autoStopTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.autoStopSeconds * 1_000_000_000)
+            await MainActor.run { self?.stop() }
+        }
+    }
+
+    func stop() {
+        monitor.stop()
+        autoStopTask?.cancel()
+        autoStopTask = nil
+        isTesting = false
+        levels = Array(repeating: 0, count: Self.barCount)
+    }
+
+    private func push(_ level: Float) {
+        var h = levels
+        h.removeFirst()
+        h.append(level)
+        levels = h
+        if level > 0.15 { sawSignal = true }   // well above the idle floor
+    }
+
+    deinit { monitor.stop() }
+}
+
+/// Small green bar meter shared by the Settings and onboarding mic tests.
+struct MicLevelMeter: View {
+    let levels: [Float]
+    private let maxHeight: CGFloat = 20
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 3) {
+            ForEach(Array(levels.enumerated()), id: \.offset) { _, level in
+                Capsule()
+                    .fill(Theme.moss.opacity(0.85))
+                    .frame(width: 3, height: max(3, min(maxHeight, CGFloat(level) * maxHeight)))
+                    .animation(.easeOut(duration: 0.1), value: level)
+            }
+        }
+        .frame(height: maxHeight)
+    }
+}

--- a/Sources/OpenQuackApp/MicTestModel.swift
+++ b/Sources/OpenQuackApp/MicTestModel.swift
@@ -10,6 +10,9 @@ final class MicTestModel: ObservableObject {
     /// Flips true once a clearly-above-idle level is seen — drives the
     /// "Sounds good" confirmation.
     @Published var sawSignal = false
+    /// Non-nil when the test couldn't start (permission denied, engine failed),
+    /// so the UI can explain instead of silently doing nothing.
+    @Published var errorMessage: String?
 
     static let barCount = 11
     private static let autoStopSeconds: UInt64 = 8
@@ -22,11 +25,30 @@ final class MicTestModel: ObservableObject {
     }
 
     func start(deviceUID: String) {
+        errorMessage = nil
+        // The monitor needs mic permission just like recording does. The
+        // engine won't prompt on its own, so request access first; without
+        // this a notDetermined/denied state just produced "nothing happens".
+        Task { [weak self] in
+            let granted = await AudioRecorder.requestPermission()
+            await MainActor.run {
+                guard let self else { return }
+                guard granted else {
+                    self.errorMessage = "Microphone access is off. Enable OpenQuack in System Settings → Privacy & Security → Microphone."
+                    return
+                }
+                self.beginMonitoring(deviceUID: deviceUID)
+            }
+        }
+    }
+
+    private func beginMonitoring(deviceUID: String) {
         monitor.levelHandler = { [weak self] level in self?.push(level) }
         do {
             try monitor.start(deviceUID: deviceUID)
         } catch {
-            return  // engine couldn't start (no permission/device); leave isTesting false
+            errorMessage = "Couldn't start the microphone: \(error.localizedDescription)"
+            return
         }
         isTesting = true
         sawSignal = false

--- a/Sources/OpenQuackApp/OnboardingFlow.swift
+++ b/Sources/OpenQuackApp/OnboardingFlow.swift
@@ -88,16 +88,18 @@ final class OnboardingState: ObservableObject {
         // user grants in System Settings — they may not return to OpenQuack).
         let micJustGranted = oldMic != .authorized && micStatus == .authorized
         let axJustGranted  = !oldAX && accessibilityTrusted
-        if (step == .microphone && micJustGranted) || (step == .accessibility && axJustGranted) {
-            // Bring our window forward so the user sees the progression.
+        if step == .microphone && micJustGranted {
+            // Mic just granted — bring our window forward so the user sees the
+            // device picker + test the mic step now shows. Deliberately do NOT
+            // auto-advance: we want them to pick and verify a working mic here.
+            NSApp.activate(ignoringOtherApps: true)
+        } else if step == .accessibility && axJustGranted {
+            // AX is granted in System Settings; the user may not return, so
+            // auto-advance once it flips.
             NSApp.activate(ignoringOtherApps: true)
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 700_000_000)
-                switch step {
-                case .microphone where micStatus == .authorized:    advance()
-                case .accessibility where accessibilityTrusted:     advance()
-                default:                                             break
-                }
+                if accessibilityTrusted { advance() }
             }
         }
     }
@@ -145,8 +147,8 @@ final class OnboardingState: ObservableObject {
         try? await Task.sleep(nanoseconds: 1_200_000_000)
         guard !Task.isCancelled else { return }
         switch step {
-        case .microphone where micStatus == .authorized:
-            advance()
+        // Microphone deliberately omitted — the mic step lets the user pick and
+        // test a device, so we stay there even when permission is already granted.
         case .accessibility where accessibilityTrusted:
             advance()
         default:
@@ -372,6 +374,9 @@ private struct WelcomeStep: View {
 
 private struct MicrophoneStep: View {
     @ObservedObject var state: OnboardingState
+    @AppStorage("inputDeviceUID") private var inputDeviceUID: String = ""
+    @StateObject private var micTest = MicTestModel()
+    @State private var devices: [AudioInputDevice] = []
 
     var body: some View {
         VStack(spacing: Theme.s16) {
@@ -382,12 +387,56 @@ private struct MicrophoneStep: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: 400)
             Spacer().frame(height: Theme.s8)
-            statusBadge
+
+            if state.micStatus == .authorized {
+                deviceChooser
+            } else {
+                statusBadge
+            }
             Spacer()
         }
-        .task {
-            await state.autoAdvanceIfAlreadyGranted()
+        .onAppear { devices = AudioInputDevices.list() }
+        .onDisappear { micTest.stop() }
+    }
+
+    /// Picker + Test so the user confirms a working mic on day one — this is
+    /// where the "silent default device → 'You.'" bug bites hardest.
+    private var deviceChooser: some View {
+        VStack(spacing: Theme.s12) {
+            Picker("Microphone", selection: $inputDeviceUID) {
+                Text("System default").tag("")
+                ForEach(devices) { device in
+                    Text(device.name).tag(device.uid)
+                }
+            }
+            .frame(maxWidth: 360)
+            .onChange(of: inputDeviceUID) { _ in
+                if micTest.isTesting { micTest.start(deviceUID: inputDeviceUID) }
+            }
+
+            HStack(spacing: Theme.s8) {
+                Button(micTest.isTesting ? "Stop" : "Test mic") {
+                    micTest.toggle(deviceUID: inputDeviceUID)
+                }
+                .buttonStyle(.bordered)
+                if micTest.isTesting {
+                    MicLevelMeter(levels: micTest.levels)
+                }
+            }
+
+            Group {
+                if micTest.sawSignal {
+                    Label("Sounds good — that mic is picking you up.", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(Theme.moss)
+                } else if micTest.isTesting {
+                    Text("Speak — the bars should move.").foregroundStyle(.secondary)
+                } else {
+                    Text("Pick your mic and hit Test to make sure it hears you.").foregroundStyle(.secondary)
+                }
+            }
+            .font(.caption)
         }
+        .frame(maxWidth: 400)
     }
 
     private var glyph: String {
@@ -401,7 +450,7 @@ private struct MicrophoneStep: View {
     private var bodyCopy: String {
         switch state.micStatus {
         case .authorized:
-            return "Microphone access is already enabled — moving on."
+            return "Pick the microphone OpenQuack should listen to, then test it."
         case .denied, .restricted:
             return "Microphone access was denied. Open System Settings → Privacy & Security → Microphone to enable it."
         case .notDetermined:
@@ -414,10 +463,6 @@ private struct MicrophoneStep: View {
     @ViewBuilder
     private var statusBadge: some View {
         switch state.micStatus {
-        case .authorized:
-            Label("Granted", systemImage: "checkmark.circle.fill")
-                .font(.body.weight(.medium))
-                .foregroundStyle(Theme.moss)
         case .denied, .restricted:
             Button("Open System Settings") {
                 NSWorkspace.shared.open(URL(string:
@@ -425,10 +470,8 @@ private struct MicrophoneStep: View {
                 )!)
             }
             .buttonStyle(.bordered)
-        case .notDetermined:
+        default:
             EmptyView()  // Continue button drives the prompt
-        @unknown default:
-            EmptyView()
         }
     }
 }

--- a/Sources/OpenQuackApp/OnboardingFlow.swift
+++ b/Sources/OpenQuackApp/OnboardingFlow.swift
@@ -425,7 +425,11 @@ private struct MicrophoneStep: View {
             }
 
             Group {
-                if micTest.sawSignal {
+                if let err = micTest.errorMessage {
+                    Label(err, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Theme.amber)
+                        .multilineTextAlignment(.center)
+                } else if micTest.sawSignal {
                     Label("Sounds good — that mic is picking you up.", systemImage: "checkmark.circle.fill")
                         .foregroundStyle(Theme.moss)
                 } else if micTest.isTesting {

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -773,7 +773,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
 
             do {
-                _ = try recorder.start(outputURL: lastRecordingURL)
+                let inputUID = UserDefaults.standard.string(forKey: "inputDeviceUID")
+                _ = try recorder.start(outputURL: lastRecordingURL, inputDeviceUID: inputUID)
                 await MainActor.run {
                     appState.phase = .recording
                     appState.elapsedSeconds = 0

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -835,6 +835,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// short audio). Mirrors `StreamingTranscriber.Config.streamingThreshold`.
     private static let streamingThreshold: TimeInterval = 30
 
+    /// Display name of the input device the next recording will use: the
+    /// user's picked device, or the system default. Used in the silent-capture
+    /// banner/notification copy.
+    private static func currentInputDeviceName() -> String {
+        let uid = UserDefaults.standard.string(forKey: "inputDeviceUID") ?? ""
+        if !uid.isEmpty, let match = AudioInputDevices.list().first(where: { $0.uid == uid }) {
+            return match.name
+        }
+        return "the system default microphone"
+    }
+
+    /// SPEC-031-style local notification: fires even if OpenQuack is in the
+    /// background so the user notices a dead-mic recording without opening the
+    /// popover. Best-effort — silently no-ops if notifications are denied.
+    private static func postSilentCaptureNotification(deviceName: String) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = "No sound detected"
+            content.body = "OpenQuack heard nothing from \(deviceName). Open OpenQuack to switch microphones."
+            content.sound = .default
+            let request = UNNotificationRequest(
+                identifier: "openquack.capture.silent",
+                content: content,
+                trigger: nil
+            )
+            center.add(request)
+        }
+    }
+
     private func stopAndTranscribe() {
         stopElapsedTimer()
         let audioDuration = recorder.elapsedSeconds
@@ -846,13 +877,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let url = recorder.stop() else { return }
 
         if capturePeakRMS < AudioRecorder.silenceRMSThreshold {
+            let deviceName = Self.currentInputDeviceName()
             Task {
                 await tearDownFramesPump()
                 if let streamer { await streamer.cancel() }
                 await MainActor.run {
-                    appState.phase = .error("No sound detected. Check your microphone in System Settings → Sound → Input, and that OpenQuack has mic permission.")
+                    appState.phase = .error("No sound detected. Pick your microphone in Settings → General, or check System Settings → Sound → Input.")
+                    appState.lastCaptureSilent = true
+                    appState.lastSilentDeviceName = deviceName
                     schedulePolishIdleUnload()
                 }
+                Self.postSilentCaptureNotification(deviceName: deviceName)
                 try? FileManager.default.removeItem(at: url)
             }
             return
@@ -863,6 +898,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await MainActor.run {
                 appState.phase = .transcribing
                 appState.transcriptionProgress = 0
+                appState.lastCaptureSilent = false   // a non-silent capture clears the warning
             }
 
             guard let engine = transcriber else {

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -441,6 +441,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         feedback.target = self
         menu.addItem(feedback)
 
+        let faq = NSMenuItem(title: "FAQ / Help…", action: #selector(menuOpenFAQ), keyEquivalent: "")
+        faq.target = self
+        menu.addItem(faq)
+
         menu.addItem(.separator())
 
         let quit = NSMenuItem(title: "Quit OpenQuack", action: #selector(menuQuitApp), keyEquivalent: "q")
@@ -465,6 +469,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // SPEC-018. Opens the GitHub issue chooser; user picks bug report
         // or feature request from there. No app-side network IO.
         guard let url = URL(string: "https://github.com/larryxiao/openquack/issues/new/choose") else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Opens the docs-site FAQ (includes the "blank/'You.' transcript" and
+    /// permission troubleshooting entries). No app-side network IO; hands off
+    /// to the default browser.
+    @MainActor
+    @objc private func menuOpenFAQ() {
+        guard let url = URL(string: "https://larryxiao.github.io/openquack/#faq") else {
             return
         }
         NSWorkspace.shared.open(url)

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -838,9 +838,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Display name of the input device the next recording will use: the
     /// user's picked device, or the system default. Used in the silent-capture
     /// banner/notification copy.
-    private static func currentInputDeviceName() -> String {
-        let uid = UserDefaults.standard.string(forKey: "inputDeviceUID") ?? ""
-        if !uid.isEmpty, let match = AudioInputDevices.list().first(where: { $0.uid == uid }) {
+    private static func currentInputDeviceName(uid: String?) -> String {
+        if let uid, !uid.isEmpty,
+           let match = AudioInputDevices.list().first(where: { $0.uid == uid }) {
             return match.name
         }
         return "the system default microphone"
@@ -874,10 +874,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // emits silence) otherwise gets transcribed into a Whisper
         // hallucination like "You." — warn the user instead.
         let capturePeakRMS = recorder.peakRMS
+        // The device actually captured from (may be the system-default fallback,
+        // not the saved preference). Read before stop() tears the recorder down.
+        let activeDeviceUID = recorder.activeInputDeviceUID
         guard let url = recorder.stop() else { return }
 
         if capturePeakRMS < AudioRecorder.silenceRMSThreshold {
-            let deviceName = Self.currentInputDeviceName()
+            let deviceName = Self.currentInputDeviceName(uid: activeDeviceUID)
             Task {
                 await tearDownFramesPump()
                 if let streamer { await streamer.cancel() }

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -837,7 +837,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func stopAndTranscribe() {
         stopElapsedTimer()
         let audioDuration = recorder.elapsedSeconds
+        // Captured peak level, read before stop() tears the recorder down.
+        // A silent capture (dead/muted mic, or a virtual input device that
+        // emits silence) otherwise gets transcribed into a Whisper
+        // hallucination like "You." — warn the user instead.
+        let capturePeakRMS = recorder.peakRMS
         guard let url = recorder.stop() else { return }
+
+        if capturePeakRMS < AudioRecorder.silenceRMSThreshold {
+            Task {
+                await tearDownFramesPump()
+                if let streamer { await streamer.cancel() }
+                await MainActor.run {
+                    appState.phase = .error("No sound detected. Check your microphone in System Settings → Sound → Input, and that OpenQuack has mic permission.")
+                    schedulePolishIdleUnload()
+                }
+                try? FileManager.default.removeItem(at: url)
+            }
+            return
+        }
+
         Task {
             let phaseStart = Date()
             await MainActor.run {

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -140,6 +140,12 @@ private struct GeneralPane: View {
                     }
                     Spacer()
                 }
+                if let err = micTest.errorMessage {
+                    Label(err, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(Theme.amber)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
                 Text("The mic OpenQuack records from. \"System default\" follows macOS. If recordings come back blank or as \"You.\", pick your real mic here and hit Test. Takes effect on the next recording.")
                     .font(.caption)

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -60,6 +60,8 @@ private struct GeneralPane: View {
     /// Input devices for the Microphone picker; loaded `.onAppear` and
     /// refreshed when the picker is interacted with.
     @State private var inputDevices: [AudioInputDevice] = []
+    /// Drives the "Test" button's live level meter.
+    @StateObject private var micTest = MicTestModel()
 
     // SPEC-026 PR-B — Updates section state.
     @AppStorage("receivePrereleases") private var receivePrereleases: Bool = false
@@ -118,7 +120,28 @@ private struct GeneralPane: View {
                     }
                 }
                 .onAppear { inputDevices = AudioInputDevices.list() }
-                Text("The mic OpenQuack records from. \"System default\" follows macOS. If recordings come back blank or as \"You.\", pick your real mic here. Takes effect on the next recording.")
+                .onChange(of: inputDeviceUID) { _ in
+                    if micTest.isTesting { micTest.start(deviceUID: inputDeviceUID) }  // re-point test
+                }
+
+                HStack(spacing: Theme.s8) {
+                    Button(micTest.isTesting ? "Stop" : "Test") {
+                        micTest.toggle(deviceUID: inputDeviceUID)
+                    }
+                    if micTest.isTesting {
+                        MicLevelMeter(levels: micTest.levels)
+                        if micTest.sawSignal {
+                            Label("Sounds good", systemImage: "checkmark.circle.fill")
+                                .font(.caption).foregroundStyle(Theme.moss)
+                        } else {
+                            Text("Speak — bars should move.")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                }
+
+                Text("The mic OpenQuack records from. \"System default\" follows macOS. If recordings come back blank or as \"You.\", pick your real mic here and hit Test. Takes effect on the next recording.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } header: {

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -54,7 +54,12 @@ private struct GeneralPane: View {
     @AppStorage("vadSilenceSeconds")   private var vadSilenceSeconds: Double = 1.5
     @AppStorage("customWords")         private var customWords: String = ""
     @AppStorage("model")               private var model: String = "medium"
+    @AppStorage("inputDeviceUID")      private var inputDeviceUID: String = ""  // "" = system default
     @AppStorage("launchAtLogin")       private var launchAtLogin: Bool = false
+
+    /// Input devices for the Microphone picker; loaded `.onAppear` and
+    /// refreshed when the picker is interacted with.
+    @State private var inputDevices: [AudioInputDevice] = []
 
     // SPEC-026 PR-B — Updates section state.
     @AppStorage("receivePrereleases") private var receivePrereleases: Bool = false
@@ -97,6 +102,27 @@ private struct GeneralPane: View {
                     .foregroundStyle(.secondary)
             } header: {
                 SectionHeader("Speech-to-text")
+            }
+
+            Section {
+                Picker("Microphone", selection: $inputDeviceUID) {
+                    Text("System default").tag("")
+                    ForEach(inputDevices) { device in
+                        Text(device.name).tag(device.uid)
+                    }
+                    // Keep the saved choice visible even if the device is gone,
+                    // so the picker doesn't silently blank out.
+                    if !inputDeviceUID.isEmpty,
+                       !inputDevices.contains(where: { $0.uid == inputDeviceUID }) {
+                        Text("Selected device (disconnected)").tag(inputDeviceUID)
+                    }
+                }
+                .onAppear { inputDevices = AudioInputDevices.list() }
+                Text("The mic OpenQuack records from. \"System default\" follows macOS. If recordings come back blank or as \"You.\", pick your real mic here. Takes effect on the next recording.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                SectionHeader("Microphone")
             }
 
             Section {

--- a/Sources/OpenQuackKit/Audio/AudioInputDevices.swift
+++ b/Sources/OpenQuackKit/Audio/AudioInputDevices.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import CoreAudio
 import Foundation
 
@@ -37,6 +38,28 @@ public enum AudioInputDevices {
     /// if that device is no longer present (unplugged, removed).
     public static func deviceID(forUID uid: String) -> AudioDeviceID? {
         list().first { $0.uid == uid }?.id
+    }
+
+    /// Route an `AVAudioEngine` input node to the device identified by `uid`.
+    /// Must be called before reading the node's format — the format follows
+    /// whatever device is current. Returns true on success; false (leaving the
+    /// system default in place) if the UID is empty/unresolved or the audio
+    /// unit rejects the change. Shared by `AudioRecorder` and `MicMonitor`.
+    @discardableResult
+    public static func route(_ inputNode: AVAudioInputNode, toUID uid: String) -> Bool {
+        guard !uid.isEmpty,
+              let deviceID = deviceID(forUID: uid),
+              let unit = inputNode.audioUnit
+        else { return false }
+        var dev = deviceID
+        let status = AudioUnitSetProperty(
+            unit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &dev,
+            UInt32(MemoryLayout<AudioDeviceID>.size))
+        return status == noErr
     }
 
     // MARK: - CoreAudio helpers

--- a/Sources/OpenQuackKit/Audio/AudioInputDevices.swift
+++ b/Sources/OpenQuackKit/Audio/AudioInputDevices.swift
@@ -1,0 +1,96 @@
+import CoreAudio
+import Foundation
+
+/// A selectable audio input device. `uid` is the persistent identifier
+/// (stable across reboots and re-plugs); the numeric `id` is only valid for
+/// the current boot and must be re-resolved from the `uid` before use.
+public struct AudioInputDevice: Identifiable, Sendable, Equatable {
+    public let id: AudioDeviceID
+    public let uid: String
+    public let name: String
+
+    public init(id: AudioDeviceID, uid: String, name: String) {
+        self.id = id
+        self.uid = uid
+        self.name = name
+    }
+}
+
+/// CoreAudio enumeration of input-capable devices. Used by the Settings
+/// "Microphone" picker and by `AudioRecorder` to route capture to a chosen
+/// device instead of the system default.
+public enum AudioInputDevices {
+
+    /// All input-capable devices currently present, in CoreAudio order.
+    public static func list() -> [AudioInputDevice] {
+        allDeviceIDs()
+            .filter { inputChannelCount($0) > 0 }
+            .compactMap { id in
+                guard let uid = stringProperty(id, kAudioDevicePropertyDeviceUID),
+                      let name = stringProperty(id, kAudioObjectPropertyName)
+                else { return nil }
+                return AudioInputDevice(id: id, uid: uid, name: name)
+            }
+    }
+
+    /// Resolve a persistent UID back to the current-boot AudioDeviceID, or nil
+    /// if that device is no longer present (unplugged, removed).
+    public static func deviceID(forUID uid: String) -> AudioDeviceID? {
+        list().first { $0.uid == uid }?.id
+    }
+
+    // MARK: - CoreAudio helpers
+
+    private static func allDeviceIDs() -> [AudioDeviceID] {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size) == noErr
+        else { return [] }
+        let count = Int(size) / MemoryLayout<AudioDeviceID>.size
+        guard count > 0 else { return [] }
+        var ids = [AudioDeviceID](repeating: 0, count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &ids) == noErr
+        else { return [] }
+        return ids
+    }
+
+    private static func inputChannelCount(_ id: AudioDeviceID) -> Int {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &addr, 0, nil, &size) == noErr, size > 0
+        else { return 0 }
+        let raw = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: 16)
+        defer { raw.deallocate() }
+        guard AudioObjectGetPropertyData(id, &addr, 0, nil, &size, raw) == noErr
+        else { return 0 }
+        let listPtr = UnsafeMutableAudioBufferListPointer(
+            raw.assumingMemoryBound(to: AudioBufferList.self))
+        return listPtr.reduce(0) { $0 + Int($1.mNumberChannels) }
+    }
+
+    private static func stringProperty(
+        _ id: AudioDeviceID, _ selector: AudioObjectPropertySelector
+    ) -> String? {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var cf: CFString? = nil
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        let status = withUnsafeMutablePointer(to: &cf) { ptr -> OSStatus in
+            ptr.withMemoryRebound(to: CFString.self, capacity: 1) { rebound in
+                AudioObjectGetPropertyData(id, &addr, 0, nil, &size, rebound)
+            }
+        }
+        guard status == noErr, let result = cf else { return nil }
+        return result as String
+    }
+}

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -142,7 +142,19 @@ public final class AudioRecorder {
                 "[AudioRecorder] could not select input device \(uid)\n"
                     .data(using: .utf8) ?? Data())
         }
+        // Prepare BEFORE reading the format: after a device switch the input
+        // node only reconciles its output format once the engine is prepared.
+        // Reading it earlier returns the *previous* device's format, and then
+        // installTap(format:) raises an uncatchable Objective-C exception
+        // (AVAudioIONodeImpl::SetOutputFormat) → SIGABRT on record start.
+        engine.prepare()
         let inputFormat = inputNode.outputFormat(forBus: 0)
+        // A not-ready / disconnected device can report a 0-rate / 0-channel
+        // format; installTap would crash on it. Surface a Swift error instead.
+        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+            throw RecorderError.engineFailed(
+                "input device has no usable audio format (sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount))")
+        }
 
         // WAV at the input device's native sample rate and channel count.
         // Stored as Int16 PCM (compact, broadly compatible). WhisperKit
@@ -208,7 +220,6 @@ public final class AudioRecorder {
             }
         }
 
-        engine.prepare()
         do {
             try engine.start()
         } catch {

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -105,7 +105,12 @@ public final class AudioRecorder {
     /// Start capture. If `outputURL` is omitted, writes to a fresh temp file.
     /// Pass an explicit URL (e.g. `~/Library/Application Support/.../last-recording.wav`)
     /// to keep the WAV around for inspection between runs.
-    public func start(outputURL: URL? = nil) throws -> URL {
+    ///
+    /// `inputDeviceUID` routes capture to a specific input device (resolved via
+    /// `AudioInputDevices`); pass nil/empty for the system default. If the UID
+    /// no longer resolves to a present device, we silently fall back to the
+    /// system default rather than failing the recording.
+    public func start(outputURL: URL? = nil, inputDeviceUID: String? = nil) throws -> URL {
         lock.lock(); defer { lock.unlock() }
 
         if _isRecording, let url = _outputURL {
@@ -128,6 +133,26 @@ public final class AudioRecorder {
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
+        // Route to the chosen device BEFORE reading the format — the input
+        // node's format follows whatever device is current. Must touch the
+        // node's audio unit first so it instantiates.
+        if let uid = inputDeviceUID, !uid.isEmpty,
+           let deviceID = AudioInputDevices.deviceID(forUID: uid),
+           let unit = inputNode.audioUnit {
+            var dev = deviceID
+            let status = AudioUnitSetProperty(
+                unit,
+                kAudioOutputUnitProperty_CurrentDevice,
+                kAudioUnitScope_Global,
+                0,
+                &dev,
+                UInt32(MemoryLayout<AudioDeviceID>.size))
+            if status != noErr {
+                FileHandle.standardError.write(
+                    "[AudioRecorder] could not select input device \(uid): \(status)\n"
+                        .data(using: .utf8) ?? Data())
+            }
+        }
         let inputFormat = inputNode.outputFormat(forBus: 0)
 
         // WAV at the input device's native sample rate and channel count.

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -37,6 +37,13 @@ public enum RecorderError: Error, CustomStringConvertible {
 /// tap closure runs on the audio thread and writes via a closure-captured
 /// file reference. `removeTap` before nilling our reference is what
 /// serialises teardown.
+/// Holds the WAV writer for the audio-thread tap. Set once on the start thread
+/// before `engine.start()` (so there's no concurrent mutation), then read by
+/// the tap without locking.
+private final class CaptureFileSink {
+    var file: AVAudioFile?
+}
+
 public final class AudioRecorder {
     private let lock = NSLock()
     private var engine: AVAudioEngine?
@@ -44,6 +51,13 @@ public final class AudioRecorder {
     private var _outputURL: URL?
     private var _startTime: Date?
     private var _isRecording = false
+    private var _activeInputDeviceUID: String?
+
+    /// Dedicated lock for `_peakRMS` only. The audio-thread tap touches *this*
+    /// lock, never the lifecycle `lock` — so `stop()`, which holds `lock` while
+    /// calling `removeTap` (which drains in-flight tap callbacks), can never
+    /// deadlock against a tap callback waiting on a lock `stop()` owns.
+    private let peakLock = NSLock()
     private var _peakRMS: Float = 0
 
     /// Peak raw-RMS (float32, ~0…1) seen across the current or most recent
@@ -53,8 +67,17 @@ public final class AudioRecorder {
     /// emits silence stays near zero — letting callers warn the user instead
     /// of feeding silence to Whisper (which hallucinates "You." / "Thank you.").
     public var peakRMS: Float {
-        lock.lock(); defer { lock.unlock() }
+        peakLock.lock(); defer { peakLock.unlock() }
         return _peakRMS
+    }
+
+    /// UID of the input device the most recent `start()` actually captured
+    /// from — which may be the system default (`nil`) if the chosen device
+    /// failed and we fell back. Callers should name *this* device in any
+    /// "no sound from …" messaging, not the user's saved preference.
+    public var activeInputDeviceUID: String? {
+        lock.lock(); defer { lock.unlock() }
+        return _activeInputDeviceUID
     }
 
     /// Captures whose peak RMS stays under this are treated as "no usable
@@ -150,6 +173,10 @@ public final class AudioRecorder {
                 self._outputURL = url
                 self._startTime = Date()
                 self._isRecording = true
+                // Record which device actually won (nil = system default), so
+                // silent-capture messaging names the real device, not the saved
+                // preference we may have just fallen back from.
+                self._activeInputDeviceUID = (deviceUID?.isEmpty == false) ? deviceUID : nil
                 return url
             } catch {
                 lastError = error
@@ -170,7 +197,7 @@ public final class AudioRecorder {
     /// format actually wins — no rate/channel mismatch, no wrong-speed audio.
     private func startEngineLocked(url: URL, inputDeviceUID: String?) throws -> AVAudioEngine {
         outputFile = nil
-        _peakRMS = 0
+        peakLock.lock(); _peakRMS = 0; peakLock.unlock()
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
@@ -184,28 +211,27 @@ public final class AudioRecorder {
 
         let levelHandler = self.levelHandler
         let framesHandler = self.framesHandler
+        // The WAV is created on this (start) thread once the winning tap format
+        // is known, and published into `sink` BEFORE engine.start(). The tap
+        // then reads an immutable, ready file with no lock and never touches the
+        // lifecycle `lock` — so stop()'s removeTap (which drains in-flight
+        // callbacks while holding `lock`) cannot deadlock against it.
+        let sink = CaptureFileSink()
 
         let tapBlock: AVAudioNodeTapBlock = { [weak self] buffer, _ in
             guard let self else { return }
-            self.lock.lock()
-            if self.outputFile == nil {
-                self.outputFile = Self.makeWAVFile(at: url, matching: buffer.format)
-            }
-            let file = self.outputFile
-            let rms = Self.rawRMS(from: buffer)
-            self._peakRMS = max(self._peakRMS, rms)
-            self.lock.unlock()
-
-            if let file {
+            if let file = sink.file {
                 do { try file.write(from: buffer) }
                 catch {
                     FileHandle.standardError.write(
                         "[AudioRecorder] write error: \(error)\n".data(using: .utf8) ?? Data())
                 }
             }
+            let rms = Self.rawRMS(from: buffer)
+            self.peakLock.lock(); self._peakRMS = max(self._peakRMS, rms); self.peakLock.unlock()
+
             if let levelHandler {
-                let level = Self.uiLevel(fromRMS: rms)
-                DispatchQueue.main.async { levelHandler(level) }
+                DispatchQueue.main.async { levelHandler(Self.uiLevel(fromRMS: rms)) }
             }
             if let framesHandler,
                let channelData = buffer.floatChannelData?[0],
@@ -230,18 +256,33 @@ public final class AudioRecorder {
             candidates.append(outFormat)
         }
 
-        var installed = false
+        var winningFormat: AVAudioFormat?
         for fmt in candidates {
             let err = OQTryCatch {
                 inputNode.installTap(onBus: 0, bufferSize: 4096, format: fmt, block: tapBlock)
             }
-            if err == nil { installed = true; break }
+            if err == nil {
+                // A nil candidate makes the tap deliver the node's own format.
+                winningFormat = fmt ?? inputNode.outputFormat(forBus: 0)
+                break
+            }
             // The failed attempt installed nothing, but be defensive before retry.
             _ = OQTryCatch { inputNode.removeTap(onBus: 0) }
         }
-        guard installed else {
+        guard let format = winningFormat else {
             throw RecorderError.engineFailed("could not install an audio tap on this input device")
         }
+
+        // Create the WAV eagerly from the winning format and publish it before
+        // engine.start(). Surfacing a creation failure here (rather than a
+        // silent nil inside the tap) means a broken sink fails the recording
+        // loudly instead of "succeeding" into an empty/missing file.
+        guard let file = Self.makeWAVFile(at: url, matching: format) else {
+            _ = OQTryCatch { inputNode.removeTap(onBus: 0) }
+            throw RecorderError.fileWriteFailed("could not create WAV at \(url.lastPathComponent)")
+        }
+        sink.file = file
+        self.outputFile = file
 
         do {
             try engine.start()

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -43,6 +43,23 @@ public final class AudioRecorder {
     private var _outputURL: URL?
     private var _startTime: Date?
     private var _isRecording = false
+    private var _peakRMS: Float = 0
+
+    /// Peak raw-RMS (float32, ~0…1) seen across the current or most recent
+    /// recording. Reset on `start()`, retained after `stop()` so callers can
+    /// inspect it. Conversational speech peaks well above
+    /// `silenceRMSThreshold`; a dead/muted mic or a virtual input device that
+    /// emits silence stays near zero — letting callers warn the user instead
+    /// of feeding silence to Whisper (which hallucinates "You." / "Thank you.").
+    public var peakRMS: Float {
+        lock.lock(); defer { lock.unlock() }
+        return _peakRMS
+    }
+
+    /// Captures whose peak RMS stays under this are treated as "no usable
+    /// audio". Conversational speech sits at RMS ~0.02–0.1; ambient room
+    /// noise and silent virtual devices are well below this floor.
+    public static let silenceRMSThreshold: Float = 0.005
 
     /// Called on the main queue with each buffer's RMS level (0…1, gently
     /// scaled for UI). Set this before calling `start` to drive a level meter.
@@ -145,7 +162,7 @@ public final class AudioRecorder {
         let framesHandler = self.framesHandler
         let inputSampleRate = inputFormat.sampleRate
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
             do {
                 try file.write(from: buffer)
             } catch {
@@ -154,9 +171,14 @@ public final class AudioRecorder {
                 )
             }
 
+            // One RMS pass per buffer, reused for both the silence detector and
+            // the UI meter.
+            let rms = Self.rawRMS(from: buffer)
+            self?.recordPeak(rms)
+
             // Emit a UI-friendly level if anyone is subscribed.
             if let levelHandler {
-                let level = Self.uiLevel(from: buffer)
+                let level = Self.uiLevel(fromRMS: rms)
                 DispatchQueue.main.async { levelHandler(level) }
             }
 
@@ -185,7 +207,15 @@ public final class AudioRecorder {
         self._outputURL = url
         self._startTime = Date()
         self._isRecording = true
+        self._peakRMS = 0
         return url
+    }
+
+    /// Audio-thread hook: fold this buffer's RMS into the running peak. Held
+    /// under the same lock as start/stop; the critical section is a single
+    /// `max`, so contention with the (infrequent) lifecycle calls is negligible.
+    private func recordPeak(_ rms: Float) {
+        lock.lock(); _peakRMS = max(_peakRMS, rms); lock.unlock()
     }
 
     /// Stop capture; returns the URL of the finalised WAV (caller owns cleanup).
@@ -211,22 +241,25 @@ public final class AudioRecorder {
         try? FileManager.default.removeItem(at: url)
     }
 
-    /// Compute a 0…1 UI level from a PCM buffer. Conversational speech sits
-    /// around RMS 0.02–0.1 in float32. Loudness is roughly logarithmic so
-    /// raw amplitude × constant feels dead — sqrt + a healthy multiplier
-    /// makes a normal speaking voice swing across most of the meter.
-    private static func uiLevel(from buffer: AVAudioPCMBuffer) -> Float {
+    /// Raw RMS of a PCM buffer in float32 amplitude (0…~1). Subsamples every
+    /// 4th frame — plenty for both the meter and the silence detector.
+    static func rawRMS(from buffer: AVAudioPCMBuffer) -> Float {
         guard let channelData = buffer.floatChannelData?[0],
               buffer.frameLength > 0 else { return 0 }
         let count = Int(buffer.frameLength)
         var sumSq: Float = 0
-        for i in stride(from: 0, to: count, by: 4) {  // every 4th sample is plenty for a meter
+        for i in stride(from: 0, to: count, by: 4) {
             let s = channelData[i]
             sumSq += s * s
         }
-        let rms = sqrt(sumSq / Float(count / 4 + 1))
-        // sqrt(rms) approximates a perceptual curve; ×3 spreads conversational
-        // voice (RMS ~0.02–0.1) across roughly 0.4–0.95 of the meter.
+        return sqrt(sumSq / Float(count / 4 + 1))
+    }
+
+    /// Map a raw RMS to a 0…1 UI level. Loudness is roughly logarithmic so
+    /// raw amplitude × constant feels dead — sqrt + a healthy multiplier makes
+    /// a normal speaking voice swing across most of the meter. ×3 spreads
+    /// conversational voice (RMS ~0.02–0.1) across roughly 0.4–0.95.
+    static func uiLevel(fromRMS rms: Float) -> Float {
         let scaled = sqrt(rms) * 3.0
         return max(0, min(1.0, scaled))
     }

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -134,24 +134,13 @@ public final class AudioRecorder {
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         // Route to the chosen device BEFORE reading the format — the input
-        // node's format follows whatever device is current. Must touch the
-        // node's audio unit first so it instantiates.
+        // node's format follows whatever device is current. Empty/unknown UID
+        // leaves the system default in place.
         if let uid = inputDeviceUID, !uid.isEmpty,
-           let deviceID = AudioInputDevices.deviceID(forUID: uid),
-           let unit = inputNode.audioUnit {
-            var dev = deviceID
-            let status = AudioUnitSetProperty(
-                unit,
-                kAudioOutputUnitProperty_CurrentDevice,
-                kAudioUnitScope_Global,
-                0,
-                &dev,
-                UInt32(MemoryLayout<AudioDeviceID>.size))
-            if status != noErr {
-                FileHandle.standardError.write(
-                    "[AudioRecorder] could not select input device \(uid): \(status)\n"
-                        .data(using: .utf8) ?? Data())
-            }
+           !AudioInputDevices.route(inputNode, toUID: uid) {
+            FileHandle.standardError.write(
+                "[AudioRecorder] could not select input device \(uid)\n"
+                    .data(using: .utf8) ?? Data())
         }
         let inputFormat = inputNode.outputFormat(forBus: 0)
 

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import OQObjCSupport
 
 public enum RecorderError: Error, CustomStringConvertible {
     case permissionDenied
@@ -131,116 +132,143 @@ public final class AudioRecorder {
                 .appendingPathComponent("openquack-\(UUID().uuidString).wav")
         }
 
+        // Graceful degradation: try the chosen device, then the system default.
+        // A device whose formats all fail to install a tap degrades to the next
+        // candidate instead of aborting the process.
+        let deviceAttempts: [String?]
+        if let uid = inputDeviceUID, !uid.isEmpty {
+            deviceAttempts = [uid, nil]
+        } else {
+            deviceAttempts = [nil]
+        }
+
+        var lastError: Error?
+        for deviceUID in deviceAttempts {
+            do {
+                let engine = try startEngineLocked(url: url, inputDeviceUID: deviceUID)
+                self.engine = engine
+                self._outputURL = url
+                self._startTime = Date()
+                self._isRecording = true
+                return url
+            } catch {
+                lastError = error
+                FileHandle.standardError.write(
+                    "[AudioRecorder] device \(deviceUID ?? "<default>") failed: \(error)\n"
+                        .data(using: .utf8) ?? Data())
+            }
+        }
+        throw lastError ?? RecorderError.engineFailed("no usable input device")
+    }
+
+    /// Build + start a capture engine for one device. Caller holds `lock`.
+    /// Routes to `inputDeviceUID` (nil = system default), then installs the tap
+    /// trying a chain of candidate formats — each guarded by `OQTryCatch` so a
+    /// format/hardware mismatch surfaces as a Swift error instead of an
+    /// uncatchable Objective-C exception (SIGABRT). The WAV file is created
+    /// lazily from the first buffer's real format, so it always matches whatever
+    /// format actually wins — no rate/channel mismatch, no wrong-speed audio.
+    private func startEngineLocked(url: URL, inputDeviceUID: String?) throws -> AVAudioEngine {
+        outputFile = nil
+        _peakRMS = 0
+
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
-        // Route to the chosen device BEFORE reading the format — the input
-        // node's format follows whatever device is current. Empty/unknown UID
-        // leaves the system default in place.
         if let uid = inputDeviceUID, !uid.isEmpty,
            !AudioInputDevices.route(inputNode, toUID: uid) {
-            FileHandle.standardError.write(
-                "[AudioRecorder] could not select input device \(uid)\n"
-                    .data(using: .utf8) ?? Data())
+            throw RecorderError.engineFailed("could not select input device \(uid)")
         }
-        // Prepare BEFORE reading the format: after a device switch the input
-        // node only reconciles its output format once the engine is prepared.
-        // Reading it earlier returns the *previous* device's format, and then
-        // installTap(format:) raises an uncatchable Objective-C exception
-        // (AVAudioIONodeImpl::SetOutputFormat) → SIGABRT on record start.
+        // Prepare so the node reconciles to the (possibly just-switched) device
+        // before we read its formats.
         engine.prepare()
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-        // A not-ready / disconnected device can report a 0-rate / 0-channel
-        // format; installTap would crash on it. Surface a Swift error instead.
-        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
-            throw RecorderError.engineFailed(
-                "input device has no usable audio format (sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount))")
-        }
-
-        // WAV at the input device's native sample rate and channel count.
-        // Stored as Int16 PCM (compact, broadly compatible). WhisperKit
-        // resamples internally on read; the bench reads through the same path.
-        let fileSettings: [String: Any] = [
-            AVFormatIDKey:             kAudioFormatLinearPCM,
-            AVSampleRateKey:           inputFormat.sampleRate,
-            AVNumberOfChannelsKey:     Int(inputFormat.channelCount),
-            AVLinearPCMBitDepthKey:    16,
-            AVLinearPCMIsFloatKey:     false,
-            AVLinearPCMIsBigEndianKey: false,
-        ]
-
-        // Match the file's processing format to the tap format (Float32
-        // non-interleaved at the input's native rate). `write(from:)` only has
-        // a bit-depth conversion to do (Float32 → Int16) — same rate, same
-        // channels — which it handles cleanly.
-        let file: AVAudioFile
-        do {
-            file = try AVAudioFile(
-                forWriting: url,
-                settings: fileSettings,
-                commonFormat: .pcmFormatFloat32,
-                interleaved: false
-            )
-        } catch {
-            throw RecorderError.fileWriteFailed("\(error)")
-        }
 
         let levelHandler = self.levelHandler
         let framesHandler = self.framesHandler
-        let inputSampleRate = inputFormat.sampleRate
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            do {
-                try file.write(from: buffer)
-            } catch {
-                FileHandle.standardError.write(
-                    "[AudioRecorder] write error: \(error)\n".data(using: .utf8) ?? Data()
-                )
+        let tapBlock: AVAudioNodeTapBlock = { [weak self] buffer, _ in
+            guard let self else { return }
+            self.lock.lock()
+            if self.outputFile == nil {
+                self.outputFile = Self.makeWAVFile(at: url, matching: buffer.format)
             }
-
-            // One RMS pass per buffer, reused for both the silence detector and
-            // the UI meter.
+            let file = self.outputFile
             let rms = Self.rawRMS(from: buffer)
-            self?.recordPeak(rms)
+            self._peakRMS = max(self._peakRMS, rms)
+            self.lock.unlock()
 
-            // Emit a UI-friendly level if anyone is subscribed.
+            if let file {
+                do { try file.write(from: buffer) }
+                catch {
+                    FileHandle.standardError.write(
+                        "[AudioRecorder] write error: \(error)\n".data(using: .utf8) ?? Data())
+                }
+            }
             if let levelHandler {
                 let level = Self.uiLevel(fromRMS: rms)
                 DispatchQueue.main.async { levelHandler(level) }
             }
-
-            // SPEC-012 streaming: emit raw float samples on the audio thread.
-            // Consumer (StreamingTranscriber) is an actor; it'll re-enter on
-            // its own queue, so this stays cheap on the capture thread.
             if let framesHandler,
                let channelData = buffer.floatChannelData?[0],
                buffer.frameLength > 0 {
                 let count = Int(buffer.frameLength)
                 let samples = Array(UnsafeBufferPointer(start: channelData, count: count))
-                framesHandler(samples, inputSampleRate)
+                framesHandler(samples, buffer.format.sampleRate)
             }
+        }
+
+        // Candidate tap formats, most-likely-correct first. installTap asserts
+        // the passed format's sampleRate/channelCount against the hardware
+        // format, so the hardware input format is the safest explicit choice;
+        // `nil` lets the node pick its own; outputFormat is a last resort.
+        let hwFormat = inputNode.inputFormat(forBus: 0)
+        let outFormat = inputNode.outputFormat(forBus: 0)
+        var candidates: [AVAudioFormat?] = []
+        if hwFormat.sampleRate > 0, hwFormat.channelCount > 0 { candidates.append(hwFormat) }
+        candidates.append(nil)
+        if outFormat.sampleRate > 0, outFormat.channelCount > 0,
+           outFormat.sampleRate != hwFormat.sampleRate {
+            candidates.append(outFormat)
+        }
+
+        var installed = false
+        for fmt in candidates {
+            let err = OQTryCatch {
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: fmt, block: tapBlock)
+            }
+            if err == nil { installed = true; break }
+            // The failed attempt installed nothing, but be defensive before retry.
+            _ = OQTryCatch { inputNode.removeTap(onBus: 0) }
+        }
+        guard installed else {
+            throw RecorderError.engineFailed("could not install an audio tap on this input device")
         }
 
         do {
             try engine.start()
         } catch {
-            inputNode.removeTap(onBus: 0)
+            _ = OQTryCatch { inputNode.removeTap(onBus: 0) }
             throw RecorderError.engineFailed("\(error)")
         }
-
-        self.engine = engine
-        self.outputFile = file
-        self._outputURL = url
-        self._startTime = Date()
-        self._isRecording = true
-        self._peakRMS = 0
-        return url
+        return engine
     }
 
-    /// Audio-thread hook: fold this buffer's RMS into the running peak. Held
-    /// under the same lock as start/stop; the critical section is a single
-    /// `max`, so contention with the (infrequent) lifecycle calls is negligible.
-    private func recordPeak(_ rms: Float) {
-        lock.lock(); _peakRMS = max(_peakRMS, rms); lock.unlock()
+    /// Create the Int16 WAV writer matching a captured buffer's format, so the
+    /// file's rate/channels always equal what the tap actually delivers.
+    private static func makeWAVFile(at url: URL, matching format: AVAudioFormat) -> AVAudioFile? {
+        let settings: [String: Any] = [
+            AVFormatIDKey:             kAudioFormatLinearPCM,
+            AVSampleRateKey:           format.sampleRate,
+            AVNumberOfChannelsKey:     Int(format.channelCount),
+            AVLinearPCMBitDepthKey:    16,
+            AVLinearPCMIsFloatKey:     false,
+            AVLinearPCMIsBigEndianKey: false,
+        ]
+        return try? AVAudioFile(
+            forWriting: url,
+            settings: settings,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
     }
 
     /// Stop capture; returns the URL of the finalised WAV (caller owns cleanup).

--- a/Sources/OpenQuackKit/Audio/MicMonitor.swift
+++ b/Sources/OpenQuackKit/Audio/MicMonitor.swift
@@ -1,0 +1,67 @@
+import AVFoundation
+import Foundation
+
+/// Listen-only level meter for "is this mic actually picking up my voice?"
+/// checks in Settings and onboarding. Unlike `AudioRecorder` it writes no
+/// file and keeps no transcript — it just taps the input, computes a 0…1 UI
+/// level per buffer, and hands it to `levelHandler` on the main queue.
+///
+/// Routes to a specific device UID (via `AudioInputDevices.route`) or the
+/// system default when the UID is empty. Safe to `start`/`stop` repeatedly;
+/// starting again switches device cleanly.
+public final class MicMonitor {
+    private let lock = NSLock()
+    private var engine: AVAudioEngine?
+
+    /// Delivered on the main queue with each buffer's UI level (0…1).
+    public var levelHandler: ((Float) -> Void)?
+
+    public init() {}
+
+    public var isRunning: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return engine != nil
+    }
+
+    /// Begin monitoring. `deviceUID` empty/nil → system default. Throws if the
+    /// audio engine can't start (e.g. no permission, no device).
+    public func start(deviceUID: String? = nil) throws {
+        lock.lock(); defer { lock.unlock() }
+        stopLocked()
+
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        if let uid = deviceUID, !uid.isEmpty {
+            AudioInputDevices.route(inputNode, toUID: uid)
+        }
+        let format = inputNode.outputFormat(forBus: 0)
+        let handler = levelHandler
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+            let level = AudioRecorder.uiLevel(fromRMS: AudioRecorder.rawRMS(from: buffer))
+            if let handler {
+                DispatchQueue.main.async { handler(level) }
+            }
+        }
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            throw error
+        }
+        self.engine = engine
+    }
+
+    public func stop() {
+        lock.lock(); defer { lock.unlock() }
+        stopLocked()
+    }
+
+    private func stopLocked() {
+        engine?.inputNode.removeTap(onBus: 0)
+        engine?.stop()
+        engine = nil
+    }
+
+    deinit { stopLocked() }
+}

--- a/Sources/OpenQuackKit/Audio/MicMonitor.swift
+++ b/Sources/OpenQuackKit/Audio/MicMonitor.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import OQObjCSupport
 
 /// Listen-only level meter for "is this mic actually picking up my voice?"
 /// checks in Settings and onboarding. Unlike `AudioRecorder` it writes no
@@ -34,19 +35,45 @@ public final class MicMonitor {
         if let uid = deviceUID, !uid.isEmpty {
             AudioInputDevices.route(inputNode, toUID: uid)
         }
-        let format = inputNode.outputFormat(forBus: 0)
+        engine.prepare()
+
         let handler = levelHandler
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+        let tapBlock: AVAudioNodeTapBlock = { buffer, _ in
             let level = AudioRecorder.uiLevel(fromRMS: AudioRecorder.rawRMS(from: buffer))
             if let handler {
                 DispatchQueue.main.async { handler(level) }
             }
         }
-        engine.prepare()
+
+        // Same exception-guarded format chain as AudioRecorder: try the hardware
+        // format, then nil, then outputFormat — under OQTryCatch so a mismatch
+        // can't abort the process when the user hits "Test" on a quirky mic.
+        let hwFormat = inputNode.inputFormat(forBus: 0)
+        let outFormat = inputNode.outputFormat(forBus: 0)
+        var candidates: [AVAudioFormat?] = []
+        if hwFormat.sampleRate > 0, hwFormat.channelCount > 0 { candidates.append(hwFormat) }
+        candidates.append(nil)
+        if outFormat.sampleRate > 0, outFormat.channelCount > 0,
+           outFormat.sampleRate != hwFormat.sampleRate {
+            candidates.append(outFormat)
+        }
+
+        var installed = false
+        for fmt in candidates {
+            let err = OQTryCatch {
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: fmt, block: tapBlock)
+            }
+            if err == nil { installed = true; break }
+            _ = OQTryCatch { inputNode.removeTap(onBus: 0) }
+        }
+        guard installed else {
+            throw RecorderError.engineFailed("could not install an audio tap on this input device")
+        }
+
         do {
             try engine.start()
         } catch {
-            inputNode.removeTap(onBus: 0)
+            _ = OQTryCatch { inputNode.removeTap(onBus: 0) }
             throw error
         }
         self.engine = engine

--- a/Sources/OpenQuackKit/Audio/MicMonitor.swift
+++ b/Sources/OpenQuackKit/Audio/MicMonitor.swift
@@ -32,8 +32,12 @@ public final class MicMonitor {
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
-        if let uid = deviceUID, !uid.isEmpty {
-            AudioInputDevices.route(inputNode, toUID: uid)
+        // A "Test" must verify the *selected* device — if routing fails, error
+        // out rather than silently metering the system default (which would
+        // give false confidence that the chosen mic works).
+        if let uid = deviceUID, !uid.isEmpty,
+           !AudioInputDevices.route(inputNode, toUID: uid) {
+            throw RecorderError.engineFailed("could not select input device \(uid)")
         }
         engine.prepare()
 

--- a/Tests/OpenQuackKitTests/AudioInputDevicesTests.swift
+++ b/Tests/OpenQuackKitTests/AudioInputDevicesTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AVFoundation
 @testable import OpenQuackKit
 
 final class AudioInputDevicesTests: XCTestCase {
@@ -24,5 +25,18 @@ final class AudioInputDevicesTests: XCTestCase {
         for device in AudioInputDevices.list() {
             XCTAssertEqual(AudioInputDevices.deviceID(forUID: device.uid), device.id)
         }
+    }
+
+    // Routing to an unknown/empty UID must fail (and leave the default in place),
+    // never crash — short-circuits before touching the audio unit.
+    func testRoute_withUnknownOrEmptyUID_returnsFalse() {
+        let engine = AVAudioEngine()
+        XCTAssertFalse(AudioInputDevices.route(engine.inputNode, toUID: "__definitely_not_a_real_device_uid__"))
+        XCTAssertFalse(AudioInputDevices.route(engine.inputNode, toUID: ""))
+    }
+
+    // A freshly constructed monitor is idle.
+    func testMicMonitor_initIsNotRunning() {
+        XCTAssertFalse(MicMonitor().isRunning)
     }
 }

--- a/Tests/OpenQuackKitTests/AudioInputDevicesTests.swift
+++ b/Tests/OpenQuackKitTests/AudioInputDevicesTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import OpenQuackKit
+
+final class AudioInputDevicesTests: XCTestCase {
+    // Hardware-independent: a bogus UID must never resolve, on any host
+    // (including CI boxes with no audio input devices at all).
+    func testDeviceID_forUnknownUID_isNil() {
+        XCTAssertNil(AudioInputDevices.deviceID(forUID: "__definitely_not_a_real_device_uid__"))
+        XCTAssertNil(AudioInputDevices.deviceID(forUID: ""))
+    }
+
+    // list() must not crash and every returned device must carry a non-empty
+    // uid/name and at least one input channel. Empty is a valid result on a
+    // host with no mic.
+    func testList_returnsWellFormedDevices() {
+        for device in AudioInputDevices.list() {
+            XCTAssertFalse(device.uid.isEmpty, "device uid should be non-empty")
+            XCTAssertFalse(device.name.isEmpty, "device name should be non-empty")
+        }
+    }
+
+    // Any device list() reports must round-trip through deviceID(forUID:).
+    func testListedDevices_resolveByUID() {
+        for device in AudioInputDevices.list() {
+            XCTAssertEqual(AudioInputDevices.deviceID(forUID: device.uid), device.id)
+        }
+    }
+}

--- a/Tests/OpenQuackKitTests/AudioRecorderDeviceTests.swift
+++ b/Tests/OpenQuackKitTests/AudioRecorderDeviceTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import AVFoundation
+@testable import OpenQuackKit
+
+/// Live-hardware test for the device-routed capture path (the one that was
+/// crashing on the UGREEN USB mic). Skips when no non-default input device is
+/// present so it's a no-op on CI / built-in-mic-only machines.
+final class AudioRecorderDeviceTests: XCTestCase {
+    func testStart_onEachInputDevice_doesNotCrashAndWritesWAV() async throws {
+        let devices = AudioInputDevices.list()
+        try XCTSkipIf(devices.isEmpty, "no input devices present")
+
+        var producedAtLeastOneWAV = false
+        for device in devices {
+            let rec = AudioRecorder()
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("oqrec-\(UUID().uuidString).wav")
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            // The regression we guard: the crash was an *uncatchable* ObjC
+            // exception in installTap (SIGABRT). With the OQTryCatch bridge it
+            // must degrade to a Swift error — never abort. Reaching the next
+            // line at all (the process didn't abort) is the core proof; a throw
+            // is also acceptable graceful handling.
+            do {
+                _ = try rec.start(outputURL: url, inputDeviceUID: device.uid)
+            } catch {
+                print("DEVICE \(device.name): start() degraded to error (no crash): \(error)")
+                continue
+            }
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+            _ = rec.stop()
+
+            // Any WAV that IS produced must be valid. Devices that deliver no
+            // buffers in the short window (some USB webcams/virtual devices) are
+            // not a failure here — they didn't crash, which is the point.
+            if let f = try? AVAudioFile(forReading: url) {
+                XCTAssertGreaterThan(f.fileFormat.sampleRate, 0, "device \(device.name)")
+                producedAtLeastOneWAV = true
+            }
+        }
+        XCTAssertTrue(producedAtLeastOneWAV, "expected at least one input device to capture audio")
+    }
+}

--- a/Tests/OpenQuackKitTests/AudioRecorderLevelTests.swift
+++ b/Tests/OpenQuackKitTests/AudioRecorderLevelTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import AVFoundation
+@testable import OpenQuackKit
+
+final class AudioRecorderLevelTests: XCTestCase {
+    private let sampleRate = 16_000.0
+    private let frames: AVAudioFrameCount = 1_600   // 0.1 s
+
+    private func buffer(fill: (Int) -> Float) -> AVAudioPCMBuffer {
+        let fmt = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                sampleRate: sampleRate,
+                                channels: 1,
+                                interleaved: false)!
+        let buf = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: frames)!
+        buf.frameLength = frames
+        let ch = buf.floatChannelData![0]
+        for i in 0..<Int(frames) { ch[i] = fill(i) }
+        return buf
+    }
+
+    func testRawRMS_silentBuffer_isBelowSilenceThreshold() {
+        let buf = buffer { _ in 0 }
+        let rms = AudioRecorder.rawRMS(from: buf)
+        XCTAssertLessThan(rms, AudioRecorder.silenceRMSThreshold)
+    }
+
+    func testRawRMS_veryQuietNoise_isBelowSilenceThreshold() {
+        // Ambient floor (~0.002 amplitude) should not count as speech.
+        var seed: UInt64 = 0x9E3779B97F4A7C15
+        let buf = buffer { _ in
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            let unit = Float(seed >> 40) / Float(1 << 24) * 2 - 1  // -1…1
+            return unit * 0.002
+        }
+        let rms = AudioRecorder.rawRMS(from: buf)
+        XCTAssertLessThan(rms, AudioRecorder.silenceRMSThreshold)
+    }
+
+    func testRawRMS_conversationalSine_isAboveSilenceThreshold() {
+        // Amplitude 0.05 → RMS ≈ 0.035, squarely in conversational range.
+        let buf = buffer { i in 0.05 * sin(2 * .pi * 220 * Float(i) / Float(sampleRate)) }
+        let rms = AudioRecorder.rawRMS(from: buf)
+        XCTAssertGreaterThan(rms, AudioRecorder.silenceRMSThreshold)
+        XCTAssertEqual(rms, 0.05 / Float(2).squareRoot(), accuracy: 0.01)  // A/√2
+    }
+
+    func testUILevel_isClampedAndMonotonic() {
+        XCTAssertEqual(AudioRecorder.uiLevel(fromRMS: 0), 0, accuracy: 1e-6)
+        let quiet = AudioRecorder.uiLevel(fromRMS: 0.02)
+        let loud = AudioRecorder.uiLevel(fromRMS: 0.1)
+        XCTAssertGreaterThan(loud, quiet)
+        XCTAssertLessThanOrEqual(AudioRecorder.uiLevel(fromRMS: 5.0), 1.0)  // clamps
+        XCTAssertGreaterThanOrEqual(AudioRecorder.uiLevel(fromRMS: 0), 0.0)
+    }
+}

--- a/docs/WHISPER-ON-MAC-FAQ.md
+++ b/docs/WHISPER-ON-MAC-FAQ.md
@@ -56,7 +56,7 @@ In our experience, the first transcription takes ~10-30 s even on `medium`; the 
 
 ## How do I prevent silence-induced hallucinations?
 
-Whisper occasionally produces fluent text for silent audio — e.g. "Thanks for watching!" or "Subtitles by [name]" from Whisper's training data leaking through. Causes and mitigations:
+Whisper occasionally produces fluent text for silent audio — e.g. a bare "You.", "Thank you.", "Thanks for watching!", or "Subtitles by [name]" from Whisper's training data leaking through. Causes and mitigations:
 
 1. **VAD prefilter.** Strip silence before sending to Whisper. OpenQuack's auto-stop-after-silence uses a simple energy threshold; production systems use Silero VAD or similar. Strip leading and trailing silence; on long clips, strip mid-recording silence too.
 2. **`no_speech_threshold` parameter.** Whisper exposes a probability threshold below which it returns empty. Default is around 0.6; you can raise it to 0.8 or higher if hallucinations are frequent.
@@ -64,6 +64,8 @@ Whisper occasionally produces fluent text for silent audio — e.g. "Thanks for 
 4. **Clip-length lower bound.** Audio shorter than ~0.5 s often produces nonsense regardless. Reject sub-half-second clips at the application layer.
 
 Whisper-mini-tier models hallucinate more under silence than the larger ones; if you're seeing this on `tiny` or `base`, model size may be a faster fix than parameter-tuning.
+
+**If you're an end user seeing this on every recording:** the trigger usually isn't the model at all — it's an empty recording. A bare "You." or "Thank you." almost always means the mic captured silence. Confirm the recording overlay's level meter moves when you speak, and that the app has Microphone permission (System Settings → Privacy & Security → Microphone; restart OpenQuack after granting it). Play back `~/Library/Application Support/OpenQuack/last-recording.wav` to hear exactly what was captured.
 
 ## Can I bias Whisper toward specific words (proper nouns, jargon, project names)?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,9 @@ OpenQuack pastes at wherever your cursor is — including the prompt bars of Cla
 **Why does the first launch take a long time?**
 The speech model downloads once on first run and is cached permanently in `~/Library/Application Support/OpenQuack/models/`. Every subsequent launch is instant.
 
+**Why is my transcript just "You.", "Thank you.", or "Thanks for watching"?**
+That short, oddly generic output is Whisper hallucinating on *silent* audio — those exact phrases leak from its training data when it's given little or no speech. It almost always means OpenQuack recorded silence instead of your voice. Check, in order: (1) while recording, watch the level meter in the recording overlay — if the bars don't move when you talk, no audio is reaching the app; (2) open **System Settings → Privacy & Security → Microphone** and make sure OpenQuack is listed and enabled (after granting it, restart OpenQuack so the grant takes effect); (3) confirm your active input device under **System Settings → Sound → Input** is the mic you're actually speaking into, not a silent virtual device. To hear exactly what was captured, play back the last recording at `~/Library/Application Support/OpenQuack/last-recording.wav`.
+
 **Is there a Windows or Linux version?**
 Not currently. OpenQuack uses WhisperKit and CoreML, which are Apple-platform technologies.
 

--- a/scripts/diagnose-capture.sh
+++ b/scripts/diagnose-capture.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Diagnose & fix the "transcript is just 'You.' / 'Thank you.'" problem.
+#
+# That output is Whisper hallucinating on SILENT audio — it almost always
+# means the mic wasn't actually captured (permission not effective, or the
+# wrong input device), not a model bug. This script:
+#   1. Shows the active input device.
+#   2. Records 3 s straight from the mic (independent of OpenQuack) and
+#      reports the peak level, so you can tell signal from silence.
+#   3. Resets OpenQuack's stale Microphone/Accessibility TCC grants.
+#   4. Restarts the app so macOS re-prompts cleanly.
+#
+# Usage: bash scripts/diagnose-capture.sh          # full: probe + reset + restart
+#        bash scripts/diagnose-capture.sh probe    # mic probe only (no reset)
+set -uo pipefail
+
+MODE="${1:-full}"
+BUNDLE_ID="org.openquack.OpenQuack"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP="$ROOT/build/OpenQuack.app"
+[[ -d "$APP" ]] || APP="/Applications/OpenQuack.app"
+
+echo "──────────────────────────────────────────────"
+echo " OpenQuack capture diagnosis"
+echo "──────────────────────────────────────────────"
+
+echo
+echo "▸ Active audio input device(s):"
+system_profiler SPAudioDataType 2>/dev/null \
+  | awk '/Input Source|Default Input Device|Manufacturer:/{print "   "$0}' \
+  | sed 's/^   *//' | sed 's/^/   /' || echo "   (could not read)"
+
+echo
+echo "▸ Mic signal probe — recording 3 s directly from the system mic."
+PROBE="$(mktemp -t oqmicprobe).swift"
+cat > "$PROBE" <<'SWIFT'
+import AVFoundation
+import Foundation
+
+let status = AVCaptureDevice.authorizationStatus(for: .audio)
+if status == .denied || status == .restricted {
+    print("RESULT: TERMINAL_DENIED — the terminal running this script has no")
+    print("        Microphone permission. Grant it in System Settings →")
+    print("        Privacy & Security → Microphone (enable your terminal app),")
+    print("        then re-run. This is about the terminal, not OpenQuack.")
+    exit(2)
+}
+let sem = DispatchSemaphore(value: 0)
+var granted = true
+if status == .notDetermined {
+    AVCaptureDevice.requestAccess(for: .audio) { ok in granted = ok; sem.signal() }
+    sem.wait()
+}
+guard granted else {
+    print("RESULT: TERMINAL_DENIED — permission request was declined.")
+    exit(2)
+}
+
+let engine = AVAudioEngine()
+let input = engine.inputNode
+let fmt = input.inputFormat(forBus: 0)
+guard fmt.sampleRate > 0 else {
+    print("RESULT: NO_DEVICE — no usable input device/format (sampleRate=0).")
+    exit(3)
+}
+var peak: Float = 0
+var sumSq: Double = 0
+var count: Int = 0
+input.installTap(onBus: 0, bufferSize: 1024, format: fmt) { buf, _ in
+    guard let ch = buf.floatChannelData?[0] else { return }
+    let n = Int(buf.frameLength)
+    for i in 0..<n {
+        let v = ch[i]
+        peak = max(peak, abs(v))
+        sumSq += Double(v * v)
+        count += 1
+    }
+}
+do { try engine.start() } catch {
+    print("RESULT: ENGINE_FAILED — \(error.localizedDescription)")
+    exit(3)
+}
+FileHandle.standardOutput.write("   >>> please speak now (3s)…\n".data(using: .utf8)!)
+Thread.sleep(forTimeInterval: 3)
+engine.stop()
+let rms = count > 0 ? (sumSq / Double(count)).squareRoot() : 0
+print(String(format: "   device sample rate: %.0f Hz", fmt.sampleRate))
+print(String(format: "   peak amplitude: %.4f   rms: %.4f", peak, rms))
+if peak < 0.01 {
+    print("RESULT: SILENT — the mic captured essentially no signal.")
+    print("        Either nothing was spoken, the input device is wrong/muted,")
+    print("        or the mic is dead. Try System Settings → Sound → Input and")
+    print("        watch the input level bar while you talk.")
+} else {
+    print("RESULT: OK — the mic IS capturing audio at the system level.")
+    print("        So if OpenQuack still returns 'You.', it's OpenQuack's mic")
+    print("        permission specifically — the reset below fixes that.")
+}
+SWIFT
+swift "$PROBE" 2>&1
+PROBE_RC=$?
+rm -f "$PROBE"
+
+[[ "$MODE" == "probe" ]] && { echo; echo "(probe-only mode — skipping reset/restart)"; exit "$PROBE_RC"; }
+
+echo
+echo "▸ Resetting OpenQuack's TCC grants (clears stale entries so macOS"
+echo "  re-prompts cleanly on next recording)…"
+tccutil reset Microphone   "$BUNDLE_ID" 2>&1 | sed 's/^/   /' || true
+tccutil reset Accessibility "$BUNDLE_ID" 2>&1 | sed 's/^/   /' || true
+echo "   done."
+
+echo
+echo "▸ Restarting OpenQuack…"
+pkill -f "OpenQuack.app/Contents/MacOS/openquack" 2>/dev/null && echo "   stopped old instance" || echo "   (no running instance)"
+sleep 1
+if [[ -d "$APP" ]]; then
+    open "$APP" && echo "   launched: $APP"
+else
+    echo "   ⚠ app bundle not found at $APP — build it with scripts/wrap_app.sh"
+fi
+
+echo
+echo "──────────────────────────────────────────────"
+echo " Next: record once in OpenQuack. macOS will re-ask for the mic —"
+echo " click Allow. Watch the overlay's level meter move as you speak."
+echo " Probe exit code: $PROBE_RC"
+echo "──────────────────────────────────────────────"


### PR DESCRIPTION
## SPEC

SPEC-001 (Voice capture) + SPEC-010 (App shell). Consolidates the full "pick the right microphone and actually capture audio" story into one reviewable PR. Supersedes #82, #83, #85, #86.

## Why

Dictation silently failed when the wrong input device was active — an external mic that wasn't the system default, or a virtual device (Lark/飞书, Teams) emitting silence. Whisper then hallucinated a bare "You." on the empty audio, with no in-app way to choose a mic, no feedback that one worked, and — once device routing landed — a hard crash on mics whose advertised format differs from their hardware format.

## What's in here

**Pick a mic, in-app**
- `AudioInputDevices` (CoreAudio enumeration) + a **Settings → General → Microphone** picker keyed on device UID (stable across reboots), with "System default".

**Know it works**
- A **"Test"** button + live level meter in Settings and in onboarding (new `MicMonitor`, listen-only). Speak, watch the bars, get a "Sounds good" confirmation.
- First-run onboarding now shows the picker + Test instead of auto-advancing, so a working mic is confirmed on day one.

**Recover when it doesn't**
- Silent-capture detection (`AudioRecorder.peakRMS` vs `silenceRMSThreshold`): a silent recording shows an amber "Switch mic" banner in the popover **and** a system notification, instead of pasting a hallucination.

**Never crash on a quirky device**
- New `OQObjCSupport` C target: `OQTryCatch` converts the uncatchable `NSException` that `installTapOnBus:format:` raises on a format/hardware mismatch into a Swift error.
- `AudioRecorder.start` tries a format-candidate chain (hardware `inputFormat` → `nil` → `outputFormat`) under `OQTryCatch`; the WAV is created lazily from the first buffer's real format (no wrong-speed audio); and it falls back from the chosen device to the system default before failing with a clean error.
- `MicMonitor` uses the same guarded chain.

## Docs

- `docs/index.md` FAQ entry + `docs/WHISPER-ON-MAC-FAQ.md` note on the "You."/blank-audio cause and the mic/permission checklist; a **FAQ / Help…** item in the menu-bar menu.

## Tests

- `AudioInputDevicesTests`, `AudioRecorderLevelTests`, `AudioRecorderDeviceTests` (records from every input device — verifies no crash + valid WAV). All green.
- Verified live across 5 input devices (UGREEN USB, Logitech, built-in, Lark, Teams): zero crashes; UGREEN captures real audio (388KB WAV, peakRMS > 0).

## Privacy impact

None. Device enumeration, the level meter, and silence detection are all local; the notification is local. No new capture/transcription/network behaviour.
