### PR TITLE
fix(transcription): restore ANE compute units regressed by #89

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -985,6 +985,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // Teardown drains the audio-thread pump first so finish()
                 // sees every frame; cancel() is fine to call after teardown
                 // (any frames still queued become a no-op once cancelled).
+                let transcribeStart = Date()
                 let result: EngineTranscription
                 // SPEC-036 — streaming-only stats for the diagnostics summary.
                 let pathLabel: String
@@ -1013,6 +1014,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         customWords: customWords
                     )
                 }
+                let transcribeWall = Date().timeIntervalSince(transcribeStart)
 
                 // SPEC-036 — recording-health + transcription summary. `captured`
                 // survives `recorder.stop()` (reset only on the next start), so it
@@ -1060,7 +1062,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if polishEngineKind != .off {
                     await MainActor.run { appState.phase = .polishing }
                 }
+                let polishStart = Date()
                 let polished = (await polishedTranscript(from: scripted)).text
+                let polishWall = Date().timeIntervalSince(polishStart)
 
                 // Hold the progress bar at full briefly so the user sees the
                 // transition land instead of jumping straight to "Pasted".
@@ -1072,6 +1076,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     let remaining = Self.minTranscribeDwell - elapsed
                     try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
                 }
+
+                // Post-stop wait breakdown, so a "thinking" stall pins to a step.
+                // `stall` = seconds the bar sat at 95% (transcribe ran past the
+                // ramp estimate); transcribe−engine is drain/teardown overhead.
+                let stall = max(0, transcribeWall - estimatedTranscribe)
+                Diagnostics.shared.log(
+                    .transcription, stall > 1.0 ? .warn : .info,
+                    "timing: est=\(String(format: "%.2f", estimatedTranscribe))s"
+                    + " transcribe=\(String(format: "%.2f", transcribeWall))s"
+                    + " engine=\(String(format: "%.2f", result.wallSeconds))s"
+                    + " stall=\(String(format: "%.2f", stall))s"
+                    + " polish=\(String(format: "%.2f", polishWall))s \(pathLabel)"
+                )
 
                 // SPEC-005 / SPEC-031: branch the output path on
                 // recordingMode. Dictation pastes at the focused app's

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -1082,7 +1082,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // ramp estimate); transcribe−engine is drain/teardown overhead.
                 let stall = max(0, transcribeWall - estimatedTranscribe)
                 Diagnostics.shared.log(
-                    .transcription, stall > 1.0 ? .warn : .info,
+                    .transcription, .info,
                     "timing: est=\(String(format: "%.2f", estimatedTranscribe))s"
                     + " transcribe=\(String(format: "%.2f", transcribeWall))s"
                     + " engine=\(String(format: "%.2f", result.wallSeconds))s"

--- a/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
+++ b/Sources/OpenQuackKit/Transcription/WhisperKitEngine.swift
@@ -62,20 +62,18 @@ public final class WhisperKitEngine: TranscriptionEngine {
             : nil
 
         do {
-            // Force CPU+GPU for every stage instead of the Apple Neural
-            // Engine. The ANE path requires a per-model compile/specialize
-            // pass on first load that can take ~80s for `medium` and isn't
-            // reliably cached across process launches (observed e5bundlecache
-            // staying empty, ANECompilerService re-compiling every cold start).
-            // CPU+GPU skips that compile entirely — warm drops to a few
-            // seconds. Inference is marginally slower than ANE but still well
-            // under real-time on Apple Silicon, a worthwhile trade for not
-            // blocking the hotkey behind a minute-plus model load.
+            // ANE for every stage: it decodes ~34% faster than CPU+GPU
+            // (rtf 0.28 vs 0.42 on M3 Pro medium). The first load per
+            // (model × signing identity × OS build) pays a one-time compile,
+            // but it caches in e5bundlecache and is reused across launches —
+            // the "recompiles every cold start" that drove #89 to CPU+GPU was
+            // ad-hoc dev builds getting a fresh signature each rebuild, not an
+            // ANE limitation. See #92 for the measurements.
             let compute = ModelComputeOptions(
-                melCompute: .cpuAndGPU,
-                audioEncoderCompute: .cpuAndGPU,
-                textDecoderCompute: .cpuAndGPU,
-                prefillCompute: .cpuAndGPU
+                melCompute: .cpuAndNeuralEngine,
+                audioEncoderCompute: .cpuAndNeuralEngine,
+                textDecoderCompute: .cpuAndNeuralEngine,
+                prefillCompute: .cpuAndNeuralEngine
             )
             let config = WhisperKitConfig(
                 model: model,


### PR DESCRIPTION
## SPEC

SPEC-030 (ANE cache volunteer bench)

## Milestone

—

## Why

#89 forced WhisperKit to CPU+GPU to dodge an ANE compile it believed recurred every launch — but that was an ad-hoc dev-build signing artifact, not an ANE property. The switch permanently slowed every short dictation: the offline path (<~30s) now decodes at rtf ~0.42, so the "Thinking" pill parks at 95% for 2–3s every time. Closes #92.

## Change

- `WhisperKitEngine.swift`: compute stages back to `.cpuAndNeuralEngine`.
- `OpenQuackApp.swift`: add a `timing:` diagnostics line (est / transcribe / engine / stall / polish) to quantify the post-stop wait.

## Tests

- [x] `swift build && swift test` green locally (252 passed, 2 skipped)
- [x] bench delta (M3 Pro, macOS 14.4, `medium`, 11.8s clip): ANE warm **rtf 0.276 vs CPU+GPU 0.42** (~34% faster). ANE cold compile 23s, **persists across process restart** (1.28s reload); CPU+GPU cold compile was 529s. Full A/B/C table in #92.

## Privacy impact

None. Compute-unit selection plus a local diagnostics line — no change to capture, transcription content, or output. Privacy contract preserved.

## Out of scope

Background pre-warm UX for the one-time first-launch compile — the existing `.warming` phase already covers it.

## AI coding brief

- **Original request**: the "Thinking" pill stalls 2–3s at the end of every dictation; user suspected transcription got slower and asked to add logs and locate it.
- **Manual interventions**: user steered away from a progress-coefficient patch toward "a recent PR slowed it", and asked for the branch, the controlled A/B/C experiment, and this PR.
- **Retro**: when a latency regression appears, scan `git log` for compute/model changes before instrumenting — would have pointed at #89 sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
