### PR TITLE
feat(SPEC-041): "Money saved" estimate in usage stats

### DIFF
--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -872,6 +872,11 @@ private struct StatsPane: View {
     @AppStorage("showUsageStats")  private var showUsageStats: Bool = false
     @AppStorage("trackUsageStats") private var trackUsageStats: Bool = true
     @AppStorage("typingWPM")       private var typingWPM: Int = 50
+    // SPEC-041 — money-saved comparison choice + custom rate.
+    @AppStorage("moneySavedBaselineID")     private var moneySavedBaselineID: String = "openai-4o-transcribe"
+    @AppStorage("moneySavedCustomRate")     private var moneySavedCustomRate: Double = 0.006
+    @AppStorage("moneySavedCustomPerMonth") private var moneySavedCustomPerMonth: Bool = false
+    private static let customBaselineID = "custom"
     @State private var snapshot: UsageStatsSnapshot?
     // SPEC-028 — recomputed when the pane appears or `showUsageStats` flips.
     // Not persisted; recomputing over ≤50 entries is microseconds.
@@ -909,6 +914,10 @@ private struct StatsPane: View {
                 } header: {
                     SectionHeader("This Mac")
                 }
+
+                // SPEC-041 — what this much on-device dictation would have cost
+                // on a paid cloud alternative. Local-only; prices baked in.
+                moneySavedSection
 
                 // SPEC-028 — length distribution. Only rendered when there's
                 // at least one bucketed entry so an empty pane stays quiet.
@@ -957,6 +966,91 @@ private struct StatsPane: View {
         .onChange(of: showUsageStats) { _ in
             Task { await refresh() }
         }
+    }
+
+    // MARK: - SPEC-041 money saved
+
+    /// Local-only estimate of what this much on-device dictation would have cost
+    /// on a paid cloud alternative. Shown only once there's audio to compare.
+    @ViewBuilder
+    private var moneySavedSection: some View {
+        if let snap = snapshot, snap.audioSeconds > 0 {
+            let basis = currentBasis
+            let saved = MoneySaved.savedUSD(
+                audioSeconds: snap.audioSeconds,
+                firstRecordedAt: snap.firstRecordedAt,
+                now: Date(),
+                basis: basis
+            )
+            Section {
+                Picker("Compared to", selection: $moneySavedBaselineID) {
+                    ForEach(MoneySaved.builtIns) { b in
+                        Text("\(b.label) — \(b.priceNote)").tag(b.id)
+                    }
+                    Text("Custom rate…").tag(Self.customBaselineID)
+                }
+                if moneySavedBaselineID == Self.customBaselineID {
+                    HStack {
+                        Text("$")
+                        TextField("rate", value: $moneySavedCustomRate, format: .number)
+                            .frame(width: 64)
+                            .multilineTextAlignment(.trailing)
+                        Picker("", selection: $moneySavedCustomPerMonth) {
+                            Text("per min").tag(false)
+                            Text("per month").tag(true)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 170)
+                    }
+                }
+                statRow("Money saved", value: Self.formatUSD(saved))
+                Text(moneySavedMath(snap: snap, basis: basis))
+                    .font(.caption).foregroundStyle(.secondary)
+                Text("Estimate vs a paid alternative — OpenQuack runs on your Mac for free. Prices as of June 2026; nothing leaves your Mac.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            } header: {
+                SectionHeader("Money saved")
+            }
+        }
+    }
+
+    private var currentBasis: MoneySaved.Basis {
+        if moneySavedBaselineID == Self.customBaselineID {
+            return moneySavedCustomPerMonth
+                ? .perMonth(usd: moneySavedCustomRate)
+                : .perAudioMinute(usd: moneySavedCustomRate)
+        }
+        return MoneySaved.builtIns.first { $0.id == moneySavedBaselineID }?.basis
+            ?? MoneySaved.builtIns[0].basis
+    }
+
+    private func moneySavedMath(snap: UsageStatsSnapshot, basis: MoneySaved.Basis) -> String {
+        switch basis {
+        case .perAudioMinute(let usd):
+            let mins = snap.audioSeconds / 60.0
+            return "\(Self.formatMinutes(mins)) transcribed × \(Self.formatRate(usd))/min"
+        case .perMonth(let usd):
+            if let months = MoneySaved.monthsActive(firstRecordedAt: snap.firstRecordedAt, now: Date()) {
+                return "\(String(format: "%.1f", months)) months × \(Self.formatRate(usd))/mo"
+            }
+            return "\(Self.formatRate(usd))/mo"
+        }
+    }
+
+    private static func formatUSD(_ usd: Double) -> String {
+        usd >= 100 ? String(format: "$%.0f", usd) : String(format: "$%.2f", usd)
+    }
+
+    /// "$0.006", "$15", "$9.99" — drop trailing zeros for whole / 2dp rates.
+    private static func formatRate(_ usd: Double) -> String {
+        if usd == usd.rounded() { return String(format: "$%.0f", usd) }
+        if (usd * 100).rounded() == usd * 100 { return String(format: "$%.2f", usd) }
+        return String(format: "$%.3f", usd)
+    }
+
+    private static func formatMinutes(_ mins: Double) -> String {
+        mins >= 60 ? String(format: "%.1f hours", mins / 60.0)
+                   : String(format: "%.0f min", mins.rounded())
     }
 
     private static var stats: UsageStats? {

--- a/Sources/OpenQuackKit/Stats/MoneySaved.swift
+++ b/Sources/OpenQuackKit/Stats/MoneySaved.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// SPEC-041 — "Money saved" estimate for the usage-stats pane.
+///
+/// OpenQuack transcribes on-device for free. This expresses the usage already
+/// done as what a paid cloud alternative would have cost — on a usage-metered
+/// (per audio minute) basis or a subscription (per month) basis. Pure +
+/// table-driven so the numbers are auditable and unit-tested; no network, prices
+/// are compiled-in constants, dated in `builtIns`.
+public enum MoneySaved {
+    /// How a baseline charges.
+    public enum Basis: Equatable, Sendable {
+        /// Metered transcription APIs (OpenAI, Deepgram, …).
+        case perAudioMinute(usd: Double)
+        /// Flat consumer-app subscriptions (Wispr Flow, Superwhisper, …).
+        case perMonth(usd: Double)
+    }
+
+    public struct Baseline: Identifiable, Equatable, Sendable {
+        public let id: String
+        public let label: String      // e.g. "OpenAI gpt-4o-transcribe"
+        public let priceNote: String  // e.g. "$0.006 / min"
+        public let basis: Basis
+        public init(id: String, label: String, priceNote: String, basis: Basis) {
+            self.id = id
+            self.label = label
+            self.priceNote = priceNote
+            self.basis = basis
+        }
+    }
+
+    /// Reference baselines. Prices verified June 2026; the UI offers a custom
+    /// rate for anything unlisted or out of date.
+    public static let builtIns: [Baseline] = [
+        Baseline(id: "openai-4o-transcribe",
+                 label: "OpenAI gpt-4o-transcribe", priceNote: "$0.006 / min",
+                 basis: .perAudioMinute(usd: 0.006)),
+        Baseline(id: "openai-4o-mini-transcribe",
+                 label: "OpenAI gpt-4o-mini-transcribe", priceNote: "$0.003 / min",
+                 basis: .perAudioMinute(usd: 0.003)),
+        Baseline(id: "wispr-flow",
+                 label: "Wispr Flow", priceNote: "$15 / mo",
+                 basis: .perMonth(usd: 15)),
+        Baseline(id: "superwhisper",
+                 label: "Superwhisper Pro", priceNote: "$9.99 / mo",
+                 basis: .perMonth(usd: 9.99)),
+    ]
+
+    /// Average seconds per month (365.25 / 12 days), for month-fraction math.
+    private static let secondsPerMonth: Double = 30.4375 * 24 * 60 * 60
+
+    /// Estimated USD saved versus `basis`, given usage so far. `now` is passed
+    /// in (not read) so the calc stays pure + deterministically testable.
+    public static func savedUSD(
+        audioSeconds: Double,
+        firstRecordedAt: Date?,
+        now: Date,
+        basis: Basis
+    ) -> Double {
+        switch basis {
+        case .perAudioMinute(let usd):
+            guard audioSeconds > 0 else { return 0 }
+            return (audioSeconds / 60.0) * usd
+        case .perMonth(let usd):
+            guard let months = monthsActive(firstRecordedAt: firstRecordedAt, now: now) else { return 0 }
+            return months * usd
+        }
+    }
+
+    /// Months active (≥ 1) since first use, or nil when there's no start date or
+    /// `now` precedes it. Floored at 1 because a subscription bills from day one.
+    public static func monthsActive(firstRecordedAt: Date?, now: Date) -> Double? {
+        guard let first = firstRecordedAt, now > first else { return nil }
+        return max(1.0, now.timeIntervalSince(first) / secondsPerMonth)
+    }
+}

--- a/Tests/OpenQuackKitTests/MoneySavedTests.swift
+++ b/Tests/OpenQuackKitTests/MoneySavedTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import OpenQuackKit
+
+/// SPEC-041 — the "money saved" calculator.
+final class MoneySavedTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_000_000_000)
+    private let day = 24.0 * 60 * 60
+    private let month = 30.4375 * 24 * 60 * 60
+
+    // MARK: per audio minute
+
+    func testPerMinute_oneHour() {
+        // 3600 s = 60 min × $0.006 = $0.36
+        let v = MoneySaved.savedUSD(audioSeconds: 3600, firstRecordedAt: nil, now: now,
+                                    basis: .perAudioMinute(usd: 0.006))
+        XCTAssertEqual(v, 0.36, accuracy: 1e-9)
+    }
+
+    func testPerMinute_zeroAudio_isZero() {
+        XCTAssertEqual(MoneySaved.savedUSD(audioSeconds: 0, firstRecordedAt: nil, now: now,
+                                           basis: .perAudioMinute(usd: 0.006)), 0)
+    }
+
+    func testPerMinute_ignoresStartDate() {
+        let withDate = MoneySaved.savedUSD(audioSeconds: 600, firstRecordedAt: now.addingTimeInterval(-month), now: now,
+                                           basis: .perAudioMinute(usd: 0.003))
+        let withoutDate = MoneySaved.savedUSD(audioSeconds: 600, firstRecordedAt: nil, now: now,
+                                              basis: .perAudioMinute(usd: 0.003))
+        XCTAssertEqual(withDate, withoutDate, accuracy: 1e-12)
+        XCTAssertEqual(withDate, 10.0 * 0.003, accuracy: 1e-12)  // 10 min × $0.003
+    }
+
+    // MARK: per month
+
+    func testPerMonth_threeMonths() {
+        let first = now.addingTimeInterval(-3 * month)
+        let v = MoneySaved.savedUSD(audioSeconds: 1234, firstRecordedAt: first, now: now,
+                                    basis: .perMonth(usd: 15))
+        XCTAssertEqual(v, 45.0, accuracy: 1e-6)  // 3 × $15
+    }
+
+    func testPerMonth_flooredAtOneMonth() {
+        let first = now.addingTimeInterval(-5 * day)   // < 1 month
+        let v = MoneySaved.savedUSD(audioSeconds: 100, firstRecordedAt: first, now: now,
+                                    basis: .perMonth(usd: 15))
+        XCTAssertEqual(v, 15.0, accuracy: 1e-9)        // not a fraction
+    }
+
+    func testPerMonth_noStartDate_isZero() {
+        XCTAssertEqual(MoneySaved.savedUSD(audioSeconds: 999, firstRecordedAt: nil, now: now,
+                                           basis: .perMonth(usd: 15)), 0)
+    }
+
+    func testMonthsActive() {
+        XCTAssertNil(MoneySaved.monthsActive(firstRecordedAt: nil, now: now))
+        XCTAssertEqual(MoneySaved.monthsActive(firstRecordedAt: now.addingTimeInterval(-2 * month), now: now)!,
+                       2.0, accuracy: 1e-6)
+        // future start date → nil
+        XCTAssertNil(MoneySaved.monthsActive(firstRecordedAt: now.addingTimeInterval(day), now: now))
+    }
+
+    func testBuiltInsPresentAndTagged() {
+        let ids = Set(MoneySaved.builtIns.map(\.id))
+        XCTAssertTrue(ids.contains("openai-4o-transcribe"))
+        XCTAssertTrue(ids.contains("wispr-flow"))
+        XCTAssertEqual(ids.count, MoneySaved.builtIns.count)  // ids unique
+    }
+}

--- a/docs/SPECS/SPEC-041-money-saved.md
+++ b/docs/SPECS/SPEC-041-money-saved.md
@@ -1,0 +1,79 @@
+# SPEC-041 — "Money saved" estimate in usage stats
+
+## Goal
+
+Show the user, in Settings → Stats, roughly how much their on-device dictation
+would have cost on a paid cloud alternative — so the free + private value is
+legible, not implied. Two comparison bases, user-selectable:
+
+- **Usage-metered** (transcription APIs): audio minutes × $/min.
+- **Subscription** (consumer dictation apps): months active × $/month.
+
+## Background
+
+SPEC-013's Stats pane already tracks `audioSeconds`, `wordsDictated`,
+`dictationCount`, and `firstRecordedAt` locally, and frames a value story
+("Time saved vs. typing"). "Money saved" is the natural companion: OpenQuack
+transcribes on the user's Mac for free, while the alternatives are metered APIs
+(OpenAI, Deepgram, …) or flat subscriptions (Wispr Flow, Superwhisper, …). The
+two billing models give two honest framings; the user picks which they find
+meaningful, or supplies a custom rate.
+
+## Mechanism
+
+`MoneySaved` (OpenQuackKit/Stats) is a pure, table-driven calculator — no UI, no
+network, prices baked in and dated so the numbers are auditable and unit-tested.
+
+```
+Basis = .perAudioMinute(usd)   // saved = audioMinutes × usd
+      | .perMonth(usd)         // saved = monthsActive × usd  (monthsActive ≥ 1)
+```
+
+`monthsActive` derives from `firstRecordedAt`..`now`, floored at 1 (a
+subscription bills from day one). Per-minute is the precise, assumption-free
+default; per-month is the relatable alternative with an explicit caveat that it
+assumes you'd have carried the subscription the whole time.
+
+**Built-in baselines** (prices verified June 2026; the UI offers a custom rate
+for anything unlisted or out of date):
+
+| Baseline | Basis | Price |
+|---|---|---|
+| OpenAI gpt-4o-transcribe | per minute | $0.006 / min |
+| OpenAI gpt-4o-mini-transcribe | per minute | $0.003 / min |
+| Wispr Flow | per month | $15 / mo |
+| Superwhisper Pro | per month | $9.99 / mo |
+
+The Stats pane adds a **Money saved** section (gated behind the existing
+`showUsageStats` toggle): a "Compared to" picker (the baselines + "Custom rate…"),
+the headline dollar figure, the transparent math (`X min × $0.006/min` or
+`Y months × $15/mo`), and a dated-source caption. Only shown once there is audio
+to compare.
+
+## Privacy impact
+
+Preserves the `docs/VISION.md` contract. Prices are compiled-in constants;
+**no network IO**, no third-party calls, no new data collected. The estimate is
+computed from the same local counters the pane already shows — nothing leaves the
+Mac.
+
+## Acceptance criteria
+
+- [ ] `MoneySaved.savedUSD` returns `$0.36` for 1 hour of audio at
+      `.perAudioMinute(0.006)`, `$0` for zero audio, and `$45` for a 3-month-old
+      `firstRecordedAt` at `.perMonth(15)`. (unit test)
+- [ ] Per-month is floored at 1 month: a 5-day-old start at `.perMonth(15)`
+      returns `$15`, not a fraction. (unit test)
+- [ ] `.perMonth` with no `firstRecordedAt` returns `$0`. (unit test)
+- [ ] Settings → Stats shows a "Money saved" section (when stats are revealed and
+      audio > 0) with a working "Compared to" picker, a custom-rate option, the
+      headline figure, and the transparent math line. (manual)
+- [ ] `swift build && swift test` green.
+
+## Out of scope
+
+- Live price fetching / per-provider API integration — prices are static + dated;
+  a custom rate covers drift.
+- Currencies other than USD (format is `$`); localise later if asked.
+- Counting tiers/free-allowances of the paid alternatives — the estimate is a
+  simple upper-bound-ish "list price × usage", stated as an estimate.


### PR DESCRIPTION
## SPEC

SPEC-041 (Money saved estimate in usage stats)

## Milestone

Adoption focus — value story / stats.

## Why

OpenQuack transcribes on-device for free; the paid alternatives are metered transcription APIs or flat subscriptions. This makes that value legible in Settings → Stats — "you've saved ~$X vs a cloud alternative" — a concrete, shareable reinforcement of the free + private positioning, alongside the existing "Time saved vs. typing".

## Change

- **`MoneySaved`** (`OpenQuackKit/Stats`): a pure, table-driven calculator. Built-in baselines (OpenAI gpt-4o-transcribe `$0.006/min`, mini `$0.003/min`, Wispr Flow `$15/mo`, Superwhisper Pro `$9.99/mo` — verified June 2026) + `savedUSD(audioSeconds:firstRecordedAt:now:basis:)` and `monthsActive(...)`. No network; prices are compiled-in constants.
- **`StatsPane`** (`SettingsView`): a "Money saved" section gated behind the existing `showUsageStats` toggle, shown once `audioSeconds > 0` — a "Compared to" picker (baselines + Custom rate…), the headline figure, the transparent math (`X min × $/min` or `Y months × $/mo`), and a dated-source caption.

## Tests

- [x] unit tests added: `MoneySavedTests` (8) — per-minute ($0.36/hr), per-month ($45/3mo), ≥1-month floor, no-date → $0, `monthsActive`, built-ins
- [x] `swift build && swift test` green locally (260 tests)
- [ ] bench: n/a — no transcription path touched

## Privacy impact

Preserves the `docs/VISION.md` contract. Prices are compiled-in constants; **no network IO**, no third-party calls, no new data collected. Computed from the same local counters the pane already shows — nothing leaves the Mac.

## Out of scope

- Live price fetching (prices are static + dated; the custom rate covers drift).
- Non-USD currencies (format is `$`).
- Free-tier / allowance modeling of the paid alternatives — it's a stated list-price × usage estimate.
- UI is build-verified; a visual eyeball in the running app remains a manual check.
