### PR TITLE
chore(release): prep v2.0.0-alpha.20 (reliability + diagnostics)

### DIFF
--- a/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
+++ b/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
@@ -4,5 +4,5 @@ import Foundation
 /// Carries no UI / KeyboardShortcuts / WhisperKit deps so the bench targets
 /// can build without Xcode-only macro plugins.
 public enum OpenQuackPlatform {
-    public static let version = "2.0.0-alpha.19"
+    public static let version = "2.0.0-alpha.20"
 }


### PR DESCRIPTION
## SPEC

SPEC-011 (update/release flow) — release-prep.

## Milestone

Release — v2.0.0-alpha.20.

## Why

Cut the next alpha. This is largely the **reliability + diagnostics** release that addresses the freeze/crash issues behind the recent rollbacks (stable is currently alpha.16), plus the features merged since alpha.18.

## Change

- Version stamp `2.0.0-alpha.19` → `2.0.0-alpha.20`.

### Draft release notes (since alpha.18)

**Reliability**
- Recording diagnostics + **graceful interruption handling** — an audio device change mid-recording now stops cleanly and transcribes what was captured instead of freezing; recording-health view in Settings → Stats; attachable diagnostics from Report Bug (#77, SPEC-036).
- Crash fix — no more SIGABRT on stop when the sample rate isn't Opus-compatible; falls back to AAC (#81).
- Swift 6 concurrency cleanups (#80).

**Features**
- **Local LLM transcript polish** — on-device llama.cpp, auto-download (#75, SPEC-007).
- **In-app speech-model download + switch** — tiny → large-v3 with a model library (#88, SPEC-002).
- **Faster first use** — loads Whisper on CPU+GPU to skip the slow ANE compile (#89).
- **Microphone selection + crash-safe tap** — pick your input device in-app; capture recovers from silent-tap failures (#90).

## Tests

- [x] `swift build && swift test` green (252 tests)

## Privacy impact

No change — version string only. Bundled features preserve the on-device contract.

## Out of scope — maintainer's cut steps (gated on you)

This PR only bumps the stamp. Before/at the cut, **you**:
1. **Run the on-device freeze test** (SPEC-036 interruption) — I built the `main` app at `/tmp/oq-build/build/OpenQuack.app`; this is the precondition you set for shipping.
2. Decide on **#89 (CPU+GPU)** — inference RTF is unbenched and could affect transcription speed; bench or accept-and-monitor.
3. **Signing** — you chose individual enrollment (not done yet) → alpha.20 ships unsigned/ad-hoc like prior alphas per your earlier call, or wait for the cert.
4. README "What's new" copy (your hand-revise), cask version + sha256, `git tag v2.0.0-alpha.20`, GitHub release, appcast.

## Open decisions for you

- Confirm **alpha.20** is the right number (stable is alpha.16; alpha.17–19 were withdrawn).
- Confirm everything merged should ride in this release (esp. #89 unbenched, #88's large-v3 download).
