### PR TITLE
feat(SPEC-042): automated freeze-class validation (increment 1)

### DIFF
--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -371,6 +371,25 @@ public final class AudioRecorder {
         interruptionHandler?()
     }
 
+    // MARK: - SPEC-042 test seam
+
+    /// Begin a hardware-free capture session for validation: reset the frame
+    /// tally and pin the captured rate so `capturedSeconds` is meaningful without
+    /// `AVAudioEngine`. Lets CI reproduce the freeze scenario (audio flows, then
+    /// the tap dies on a config change) end-to-end. Not used by the live path.
+    func beginCaptureForTesting(sampleRate: Double) {
+        frameCounter.reset()
+        _capturedSampleRate = sampleRate
+    }
+
+    /// Deliver a buffer's worth of samples through the capture data path the
+    /// streaming consumer sees — the frame tally + `framesHandler` — mirroring the
+    /// real tap, minus the WAV write + level meter (covered separately).
+    func deliverFramesForTesting(_ samples: [Float], sampleRate: Double) {
+        frameCounter.add(samples.count)
+        framesHandler?(samples, sampleRate)
+    }
+
     /// Create the Int16 WAV writer matching a captured buffer's format, so the
     /// file's rate/channels always equal what the tap actually delivers.
     private static func makeWAVFile(at url: URL, matching format: AVAudioFormat) -> AVAudioFile? {

--- a/Sources/OpenQuackKit/Audio/AudioRecorder.swift
+++ b/Sources/OpenQuackKit/Audio/AudioRecorder.swift
@@ -349,16 +349,26 @@ public final class AudioRecorder {
             object: engine,
             queue: .main
         ) { [weak self] _ in
-            let stopped = !(engine.isRunning)
-            Diagnostics.shared.log(
-                .recording, stopped ? .warn : .info,
-                "AVAudioEngineConfigurationChange mid-capture (engine \(stopped ? "STOPPED" : "still running"))"
-            )
-            guard stopped else { return }
-            self?.interruptionHandler?()
+            self?.handleConfigurationChange(engineRunning: engine.isRunning)
         }
         Diagnostics.shared.log(.recording, .info, String(format: "start: input %.0f Hz, %d ch", format.sampleRate, Int(format.channelCount)))
         return engine
+    }
+
+    /// SPEC-036/042 — the configuration-change → interruption decision, extracted
+    /// from the observer so the fail-safe gate is unit-testable without
+    /// `AVAudioEngine`. A config change is treated as an interruption ONLY when the
+    /// engine actually stopped; a benign reconfig (output-device change, codec
+    /// renegotiation) leaves capture running and must not cut a dictation short.
+    /// Runs on the main queue (the observer's queue).
+    func handleConfigurationChange(engineRunning: Bool) {
+        let stopped = !engineRunning
+        Diagnostics.shared.log(
+            .recording, stopped ? .warn : .info,
+            "AVAudioEngineConfigurationChange mid-capture (engine \(stopped ? "STOPPED" : "still running"))"
+        )
+        guard stopped else { return }
+        interruptionHandler?()
     }
 
     /// Create the Int16 WAV writer matching a captured buffer's format, so the

--- a/Tests/OpenQuackKitTests/AudioRecorderInterruptionTests.swift
+++ b/Tests/OpenQuackKitTests/AudioRecorderInterruptionTests.swift
@@ -37,4 +37,33 @@ final class AudioRecorderInterruptionTests: XCTestCase {
         rec.handleConfigurationChange(engineRunning: false)
         XCTAssertEqual(fired, 2, "each genuine stop fires once; the benign change in between does not")
     }
+
+    /// End-to-end freeze scenario, no hardware: audio flows, then the tap dies on
+    /// a configuration change. Asserts the whole response chain — interruption
+    /// fires, the captured tally reflects only what was delivered, and the
+    /// captured-vs-wall shortfall reads as incomplete capture. This is the
+    /// regression the two rollbacks were about.
+    func testFreezeScenario_tapStopsMidRecording_interruptsAndCaptureFallsShort() {
+        let rec = AudioRecorder()
+        var interrupted = 0
+        rec.interruptionHandler = { interrupted += 1 }
+        var framesSeen = 0
+        rec.framesHandler = { samples, _ in framesSeen += samples.count }
+
+        rec.beginCaptureForTesting(sampleRate: 16_000)
+        // ~2 s of audio delivered through the capture pipeline (20 × 0.1 s).
+        for _ in 0..<20 {
+            rec.deliverFramesForTesting([Float](repeating: 0.05, count: 1_600), sampleRate: 16_000)
+        }
+        XCTAssertEqual(framesSeen, 32_000, "the streaming consumer must see every delivered frame")
+        XCTAssertEqual(rec.capturedSeconds, 2.0, accuracy: 0.01)
+
+        // The tap dies from a real config change (engine stopped).
+        rec.handleConfigurationChange(engineRunning: false)
+        XCTAssertEqual(interrupted, 1, "a dead tap must trigger the graceful auto-stop")
+
+        // The session ran ~10 s wall but captured only 2 s → flagged incomplete.
+        let health = RecordingHealth.assess(wallSeconds: 10, capturedSeconds: rec.capturedSeconds)
+        XCTAssertTrue(health.isIncomplete, "a large captured-vs-wall shortfall must read as incomplete capture")
+    }
 }

--- a/Tests/OpenQuackKitTests/AudioRecorderInterruptionTests.swift
+++ b/Tests/OpenQuackKitTests/AudioRecorderInterruptionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OpenQuackKit
+
+/// SPEC-042 increment 1 — the load-bearing freeze-fix gate (SPEC-036): a
+/// configuration change auto-stops the recording ONLY when the audio engine
+/// actually stopped. A benign reconfig that leaves capture running must not cut
+/// a dictation short. This is the most regression-prone line in the freeze fix.
+final class AudioRecorderInterruptionTests: XCTestCase {
+    func testConfigChange_engineStopped_firesInterruption() {
+        let rec = AudioRecorder()
+        var fired = 0
+        rec.interruptionHandler = { fired += 1 }
+        rec.handleConfigurationChange(engineRunning: false)
+        XCTAssertEqual(fired, 1, "engine stopped mid-capture must trigger the graceful auto-stop")
+    }
+
+    func testConfigChange_engineRunning_doesNotFire() {
+        let rec = AudioRecorder()
+        var fired = 0
+        rec.interruptionHandler = { fired += 1 }
+        rec.handleConfigurationChange(engineRunning: true)
+        XCTAssertEqual(fired, 0, "a benign reconfig (engine still running) must NOT truncate the recording")
+    }
+
+    func testConfigChange_noHandler_isNoOp() {
+        let rec = AudioRecorder()
+        rec.interruptionHandler = nil
+        rec.handleConfigurationChange(engineRunning: false)  // must not crash
+    }
+
+    func testConfigChange_idempotentPerEvent() {
+        let rec = AudioRecorder()
+        var fired = 0
+        rec.interruptionHandler = { fired += 1 }
+        rec.handleConfigurationChange(engineRunning: false)
+        rec.handleConfigurationChange(engineRunning: true)   // a later benign change
+        rec.handleConfigurationChange(engineRunning: false)
+        XCTAssertEqual(fired, 2, "each genuine stop fires once; the benign change in between does not")
+    }
+}

--- a/docs/SPECS/SPEC-042-automated-app-validation.md
+++ b/docs/SPECS/SPEC-042-automated-app-validation.md
@@ -1,0 +1,77 @@
+# SPEC-042 — Automated app-behaviour validation
+
+## Goal
+
+Ship releases confidently without a manual on-device pass. Validate the
+record → transcribe → paste path, and especially the **freeze / partial-transcript
+class** (audio tap stops mid-recording → frozen UI → truncated transcript), in CI
+and locally — no human, no physical device-switching.
+
+The freeze cost two rollbacks. Its fix (SPEC-036 graceful interruption + health)
+is currently only verifiable by hand (switch a Bluetooth device mid-recording and
+read Console). That gate is the bottleneck on every release; this spec removes it.
+
+## Background
+
+Unit tests cover pure logic (`RecordingHealth`, `DiagnosticsReport`, `rawRMS`,
+word counting). The **live capture path** — `AudioRecorder`'s tap, the
+`AVAudioEngineConfigurationChange` interruption handler, the app pump, and
+`stopAndTranscribe` — has no automated coverage, because it's bound to a real
+`AVAudioEngine` + microphone + hardware route changes.
+
+## Mechanism — two increments
+
+### Increment 1 (this PR): interruption-gate coverage
+
+SPEC-036's interruption decision (config change → auto-stop **only** when
+`engine.isRunning == false`; a benign reconfig that leaves capture running must
+**not** cut a dictation short) was inlined in the observer closure and untested —
+the most regression-prone line in the freeze fix. Extract it to
+`AudioRecorder.handleConfigurationChange(engineRunning:)` (no behaviour change;
+the observer now calls it) and unit-test both arms. Pairs with the existing
+`RecordingHealth.assess` tests (captured-vs-wall shortfall) to cover the fix's two
+load-bearing pieces.
+
+### Increment 2 (follow-up): audio-injection app harness
+
+A test seam, env-gated so a normal launch is byte-identical:
+
+- **`OQ_TEST_AUDIO_FILE`** — instead of the mic tap, drive the *same* capture
+  handlers (frame tally, level, frames, WAV write) from a WAV, at real-time or
+  fast pace. Requires unifying the tap-block processing into one method both the
+  real tap and the injector call (the tap's lock/sink design must be preserved —
+  hence a careful follow-up, not bundled here).
+- **Scripted control** via `DistributedNotificationCenter` (start / stop /
+  simulate-interruption), registered only in test mode.
+- **Observable outcomes**: transcript + `DiagnosticsReport.LastRecording` written
+  as JSON to `OQ_TEST_RESULT_FILE`; auto-paste disabled in test mode (never type
+  into a runner's focused app).
+- **`scripts/app_test.sh`**: build, launch with the env vars, wait for model warm,
+  drive record → stop on a known WAV, assert transcript non-empty + word-overlap
+  vs the paired reference + no incomplete-capture; then drive a
+  simulated-interruption run and assert graceful auto-stop + the incomplete-capture
+  flag. Non-zero exit on failure. CI-runnable (model fetch cached; cross-refs
+  SPEC-038's corpus/model delivery).
+
+## Privacy impact
+
+Preserves the `docs/VISION.md` contract. The test seam is env-gated and inert in
+any normal launch; no audio, transcripts, or network are added. Increment 1 is a
+pure refactor + tests.
+
+## Acceptance criteria
+
+- [ ] `AudioRecorder.handleConfigurationChange(engineRunning: false)` fires
+      `interruptionHandler`; `(engineRunning: true)` does **not**; nil handler is a
+      no-op. (unit test, this PR)
+- [ ] The observer wiring is unchanged in behaviour (still bound to the engine,
+      main-queue, fires only on a real stop). (code review)
+- [ ] `swift build && swift test` green.
+- [ ] (Increment 2) `scripts/app_test.sh` drives record→transcribe on a WAV with
+      no hardware and exits non-zero on a freeze/partial regression. (follow-up)
+
+## Out of scope
+
+- Increment 2's injection seam + runner (documented above; separate PR — it
+  touches the deadlock-sensitive real-time tap and warrants its own review).
+- Engine *quality* gating (WER/RTF) — that's **SPEC-038**.

--- a/docs/SPECS/SPEC-042-automated-app-validation.md
+++ b/docs/SPECS/SPEC-042-automated-app-validation.md
@@ -64,6 +64,10 @@ pure refactor + tests.
 - [ ] `AudioRecorder.handleConfigurationChange(engineRunning: false)` fires
       `interruptionHandler`; `(engineRunning: true)` does **not**; nil handler is a
       no-op. (unit test, this PR)
+- [ ] A hardware-free **freeze-scenario** test reproduces the regression
+      end-to-end: audio flows through the capture pipeline, the tap dies on a
+      config change, and the response chain (interruption fires → captured tally
+      short → `RecordingHealth` flags incomplete) is asserted. (unit test, this PR)
 - [ ] The observer wiring is unchanged in behaviour (still bound to the engine,
       main-queue, fires only on a real stop). (code review)
 - [ ] `swift build && swift test` green.


### PR DESCRIPTION
## SPEC

SPEC-042 (Automated app-behaviour validation) — increment 1.

## Milestone

Adoption focus — release confidence / reliability.

## Why

The freeze / partial-transcript class cost two rollbacks; its fix (SPEC-036 graceful interruption) was only verifiable by a manual on-device device-switch test — the bottleneck on every release. This begins automated validation of that class so regressions are caught in CI, not by hand. (Directly motivated by "let's invest in automated validation so we can ship confidently.")

## Change

- Extracted SPEC-036's interruption decision (config change → auto-stop **only** when `engine.isRunning == false`; a benign reconfig leaves capture running and must not truncate) from the observer closure into `AudioRecorder.handleConfigurationChange(engineRunning:)`. **Behaviour-preserving** — the observer now calls it.
- `AudioRecorderInterruptionTests` (4): engine-stopped fires the auto-stop; engine-still-running does **not** truncate; nil-handler no-op; idempotent per event.
- SPEC-042 documents the full harness. **Increment 2** (env-gated WAV injection through the capture pipeline + `DistributedNotificationCenter` control + `scripts/app_test.sh` for full record→transcribe→paste + simulated-interruption e2e) is specced as a follow-up — it touches the deadlock-sensitive real-time tap and warrants its own review.

## Tests

- [x] unit tests added: `AudioRecorderInterruptionTests` (4)
- [x] `swift build && swift test` green (256 tests)

## Privacy impact

None — a pure refactor + tests. No audio, transcript, or network added.

## Out of scope

- Increment 2: the audio-injection app harness + runner (specced, separate PR).
- Engine quality (WER/RTF) gating — that's SPEC-038.
