### PR TITLE
chore: release v2.0.0-alpha.20

### DIFF
--- a/Casks/openquack.rb
+++ b/Casks/openquack.rb
@@ -1,9 +1,9 @@
 cask "openquack" do
-  version "2.0.0-alpha.16"
+  version "2.0.0-alpha.20"
   # Set per-release by scripts/make_dmg.sh — paste the printed value in
   # before each tag is pushed. `:no_check` is the placeholder while no
   # release has been tagged yet.
-  sha256 "db0838c6c9217662fc171d44b0009a02da4ff5b201a2b7442470e5b36590b972"
+  sha256 "3fda59551fa12a1176d8cde44d8ec4e46d94fe1c37bec98c631380b7f301234f"
 
   url "https://github.com/larryxiao/openquack/releases/download/v#{version}/OpenQuack-#{version}.dmg"
   name "OpenQuack"

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ Voice dictation for macOS. Nothing leaves your device — audio, text, nothing.
 
 > 📢 **What's new** — full notes on the [Releases page →](https://github.com/larryxiao/openquack/releases)
 >
+> - 🛡️ **[v2.0.0-alpha.20](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.20) — it doesn't freeze on you anymore.** If your mic changes mid-recording — AirPods connecting, switching devices — OpenQuack stops cleanly and keeps what you said instead of locking up. Plus on-device transcript polish, in-app model switching, and a faster first launch.
 > - 🌏 **[v2.0.0-alpha.18](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.18) — code-switch without the chaos.** Start a sentence in English and finish it in 中文: your Chinese now comes back as Chinese across a whole recording, not a garbled English "translation," and it's tidied into your system's script (简体 or 繁體).
 > - 🎧 **[v2.0.0-alpha.17](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.17) — auto-detect that actually detects.** Just talk in any language, no menu-fiddling. Non-English speech stopped getting silently translated to English (253% → 17% WER on the multilingual set).
-> - 🦆 **[v2.0.0-alpha.16](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.16) — updates that get out of your way.** Homebrew upgrades run quietly in the background and relaunch the duck for you — no surprise Terminal window.
-
 ## What it is
 
 OpenQuack is a tiny menu-bar app for macOS. Press a hotkey, speak, press it again — your transcript appears at the cursor. Wherever you can type, you can talk.

--- a/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
+++ b/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
@@ -4,5 +4,5 @@ import Foundation
 /// Carries no UI / KeyboardShortcuts / WhisperKit deps so the bench targets
 /// can build without Xcode-only macro plugins.
 public enum OpenQuackPlatform {
-    public static let version = "2.0.0-alpha.19"
+    public static let version = "2.0.0-alpha.20"
 }


### PR DESCRIPTION
Release commit for **v2.0.0-alpha.20** (reliability-led). Version bump + cask version/sha256 for the built DMG + README What's-new. Tag + GitHub release follow on merge. Supersedes #95 (version-bump-only). Per maintainer call: ships everything live, unsigned.