### PR TITLE
feat(SPEC-043): release cadence, feature flags & runbook

### DIFF
--- a/Sources/OpenQuackPlatform/FeatureFlags.swift
+++ b/Sources/OpenQuackPlatform/FeatureFlags.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// SPEC-043 — feature flags for "release behind a flag first".
+///
+/// New or risky features merge to `main` behind a flag that **defaults off in a
+/// release**, so they ship dark and get flipped on — per test build, or for
+/// everyone in a later release — once validated. This decouples *merge* from
+/// *release*: the freeze/instability that caused past rollbacks can't ride out
+/// to users in an unvetted feature. UserDefaults-backed, matching the app's
+/// existing toggle convention; no remote-config platform.
+public struct FeatureFlag: Sendable, Equatable {
+    public let key: String
+    /// State in a release when the user hasn't overridden it. New/risky features
+    /// default `false` ("behind a flag first"); flip to `true` — or delete the
+    /// flag and inline the behaviour — once the feature is proven.
+    public let defaultEnabled: Bool
+
+    public init(key: String, defaultEnabled: Bool = false) {
+        self.key = key
+        self.defaultEnabled = defaultEnabled
+    }
+}
+
+public enum FeatureFlags {
+    /// The registry. A flag is added here the moment a feature lands dark, and
+    /// removed when the feature graduates. **Empty today** — alpha.20 shipped
+    /// without flags by maintainer call; the next risky feature registers here,
+    /// defaulting `false`.
+    ///
+    /// Example (when a feature lands behind a flag):
+    /// ```
+    /// static let cpuGpuWarm = FeatureFlag(key: "transcription.cpuGpuWarm")
+    /// public static let all = [cpuGpuWarm]
+    /// ```
+    public static let all: [FeatureFlag] = []
+
+    private static func storageKey(_ flag: FeatureFlag) -> String {
+        "com.openquack.flag.\(flag.key)"
+    }
+
+    /// Whether `flag` is on: an explicit override if the user/build set one, else
+    /// the flag's release default.
+    public static func isEnabled(_ flag: FeatureFlag, defaults: UserDefaults = .standard) -> Bool {
+        if let override = defaults.object(forKey: storageKey(flag)) as? Bool { return override }
+        return flag.defaultEnabled
+    }
+
+    /// Override a flag (an advanced/hidden settings row, or a test build).
+    public static func setEnabled(_ flag: FeatureFlag, _ enabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: storageKey(flag))
+    }
+
+    /// Clear an override → revert to the release default.
+    public static func reset(_ flag: FeatureFlag, defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: storageKey(flag))
+    }
+}

--- a/Tests/OpenQuackKitTests/FeatureFlagsTests.swift
+++ b/Tests/OpenQuackKitTests/FeatureFlagsTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import OpenQuackPlatform
+
+/// SPEC-043 — feature-flag resolution (override beats default; reset reverts).
+final class FeatureFlagsTests: XCTestCase {
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        // Isolated store so tests never touch the real app defaults.
+        defaults = UserDefaults(suiteName: "FeatureFlagsTests")!
+        defaults.removePersistentDomain(forName: "FeatureFlagsTests")
+    }
+
+    func testDefaultOff_whenNoOverride() {
+        let f = FeatureFlag(key: "x.off")  // defaults false
+        XCTAssertFalse(FeatureFlags.isEnabled(f, defaults: defaults))
+    }
+
+    func testDefaultOn_whenDeclaredOn() {
+        let f = FeatureFlag(key: "x.on", defaultEnabled: true)
+        XCTAssertTrue(FeatureFlags.isEnabled(f, defaults: defaults))
+    }
+
+    func testOverrideBeatsDefault_bothDirections() {
+        let off = FeatureFlag(key: "x.a")             // default false
+        FeatureFlags.setEnabled(off, true, defaults: defaults)
+        XCTAssertTrue(FeatureFlags.isEnabled(off, defaults: defaults))
+
+        let on = FeatureFlag(key: "x.b", defaultEnabled: true)
+        FeatureFlags.setEnabled(on, false, defaults: defaults)
+        XCTAssertFalse(FeatureFlags.isEnabled(on, defaults: defaults))
+    }
+
+    func testReset_revertsToDefault() {
+        let f = FeatureFlag(key: "x.c")  // default false
+        FeatureFlags.setEnabled(f, true, defaults: defaults)
+        XCTAssertTrue(FeatureFlags.isEnabled(f, defaults: defaults))
+        FeatureFlags.reset(f, defaults: defaults)
+        XCTAssertFalse(FeatureFlags.isEnabled(f, defaults: defaults))
+    }
+}

--- a/docs/SPECS/SPEC-043-release-cadence-and-flags.md
+++ b/docs/SPECS/SPEC-043-release-cadence-and-flags.md
@@ -1,0 +1,77 @@
+# SPEC-043 — Release cadence, feature flags & runbook
+
+## Goal
+
+Make releases boring and safe: a predictable **cadence**, features shipped
+**behind a flag first**, and a codified **runbook** so cutting a release is a
+checklist, not a bespoke event. This is the process answer to the freeze/crash
+rollbacks — risky work should reach users dark and gated, not live-on-merge.
+
+## Background
+
+Releases have been ad-hoc, and instability has shipped straight to users (two
+rollbacks to alpha.16/18). Three practices fix that: decouple merge from release
+(flags), make the cut repeatable (runbook), and ship to opt-in users first
+(existing prerelease channel).
+
+## Mechanism
+
+### Feature flags — "behind a flag first"
+
+`FeatureFlags` (OpenQuackPlatform): a `FeatureFlag` is `{ key, defaultEnabled }`,
+resolved against `UserDefaults` (explicit override beats the release default).
+New/risky features merge with their flag **defaulting `false`**, ship dark, and
+flip on — per test build or for everyone in a later release — once validated.
+The flag graduates (deleted, behaviour inlined) when proven. No remote config; it
+matches the app's existing `@AppStorage` toggle convention.
+
+The registry (`FeatureFlags.all`) is empty today — alpha.20 shipped flagless by
+maintainer call. The **next** unvalidated feature (the kind of thing #88/#89
+were) registers a flag here instead of going live.
+
+### Cadence
+
+- Cut an **alpha** when a batch of merges has accumulated, targeting a steady
+  drumbeat (≈ weekly) rather than on-demand heroics. Prereleases reach opt-in
+  users first via the existing alpha channel (`receivePrereleases` +
+  `appcast-alpha.xml`); promote to "Latest" once it's held up.
+- A flagged feature graduates on its **own** schedule, independent of the release
+  it merged in.
+
+### Runbook (the steps, as executed for alpha.20)
+
+1. Bump `OpenQuackPlatform.version`.
+2. `bash scripts/make_dmg.sh` → builds + signs the app, packs `OpenQuack-<v>.dmg`,
+   prints the **sha256**.
+3. Update `Casks/openquack.rb`: `version` + `sha256` (the printed value).
+4. Update the README "What's new" banner (newest first; keep ~3).
+5. Appcast: add a signed `<item>` to `docs/appcast-alpha.xml` — **blocked on the
+   Sparkle EdDSA key** (SPEC-026); until then it stays empty and brew is the alpha
+   path.
+6. Commit (version + cask + README) → release PR → merge to `main`.
+7. `gh release create v<v> --target <main-sha> --latest --notes-file … <dmg>`.
+8. **Verify**: release asset name == cask URL; cask `sha256` == `shasum -a 256`
+   of the uploaded DMG; GitHub "Latest" == the new tag.
+
+> A `release-bot` (SPEC-037) can automate steps 1–8 once signing/notarisation
+> lands (SPEC-025); until then it's the maintainer's gated, checklist-driven cut.
+
+## Privacy impact
+
+None. `FeatureFlags` is local UserDefaults; no network, no telemetry. The runbook
+ships the same on-device app.
+
+## Acceptance criteria
+
+- [ ] `FeatureFlags.isEnabled` returns the flag default with no override, the
+      override when set, and the default again after `reset`. (unit test)
+- [ ] New unvalidated features land with a flag defaulting `false` and are absent
+      from the shipped UI/behaviour until flipped. (convention — enforced in review)
+- [ ] The runbook above reproduces a release (it cut alpha.20). (manual)
+- [ ] `swift build && swift test` green.
+
+## Out of scope
+
+- Remote / server-driven flags, percentage rollouts — local boolean flags only.
+- Automated release CI — documented as a `release-bot` follow-up (SPEC-037),
+  gated on signing (SPEC-025).


### PR DESCRIPTION
## SPEC

SPEC-043 (Release cadence, feature flags & runbook)

## Milestone

Adoption focus — release engineering / ship confidently.

## Why

Releases were ad-hoc and instability shipped straight to users (two rollbacks). This sets up **"release behind a flag first"** (risky features ship dark + gated), a steady alpha cadence, and a codified runbook so a cut is a checklist, not a bespoke event. Directly motivated by "let's have a release cadence and release behind a flag first."

## Change

- **`FeatureFlags`** (OpenQuackPlatform): UserDefaults-backed boolean flags; new/risky features default **off** in a release and flip on once validated. Registry empty today (alpha.20 shipped flagless by maintainer call); the next risky feature — the #88/#89 kind — registers here instead of going live.
- **SPEC-043**: the flag convention + an alpha cadence + the release runbook (the exact steps that just cut alpha.20).
- **FeatureFlagsTests** (4).

## Tests

- [x] unit tests added: `FeatureFlagsTests` (4)
- [x] `swift build && swift test` green

## Privacy impact

None — local UserDefaults flags, no network or telemetry.

## Out of scope

- Remote / percentage rollouts — local booleans only.
- Automated release CI (a `release-bot`, SPEC-037; gated on signing, SPEC-025).
