### PR TITLE
feat(SPEC-044): agent-driven UI snapshot validation (local)

### DIFF
--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -21,8 +21,21 @@ struct OpenQuackApp {
         // packages with resources. See BundleModuleFallback.swift.
         BundleModuleFallback.install()
 
-        let delegate = AppDelegate()
         let app = NSApplication.shared
+
+        // SPEC-044 — snapshot mode: render UI surfaces to PNG + exit, so an agent
+        // can validate the UI against the specs locally without launching the
+        // menu-bar app or capturing the screen. AppKit is initialised above so
+        // offscreen ImageRenderer drawing works; we stay headless and exit.
+        if let dir = ProcessInfo.processInfo.environment["OQ_SNAPSHOT_DIR"] {
+            app.setActivationPolicy(.prohibited)
+            MainActor.assumeIsolated {
+                SnapshotRenderer.renderAll(to: URL(fileURLWithPath: dir))
+            }
+            exit(0)
+        }
+
+        let delegate = AppDelegate()
         app.delegate = delegate
         app.run()
     }
@@ -232,7 +245,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return }
             guard case .recording = self.appState.phase else { return }
             self.recordingInterrupted = true
-            self.appState.lastNotice = "Recording interrupted by an audio device change"
+            self.appState.lastNotice = "Saved what we captured"
             Diagnostics.shared.log(.recording, .warn, "interruption → auto-stopping mid-recording")
             self.stopAndTranscribe()
         }

--- a/Sources/OpenQuackApp/RecordingOverlay.swift
+++ b/Sources/OpenQuackApp/RecordingOverlay.swift
@@ -210,6 +210,9 @@ struct OverlayPill: View {
         case .transcribing: return "Thinking"
         case .polishing:    return "Polishing"
         case .ready:
+            // SPEC-036 — an interruption takes the headline; "Copied to clipboard"
+            // misreads on a recording that was cut short.
+            if state.lastNotice != nil { return "Recording interrupted" }
             if state.recordingMode == .agentKickoff {
                 return state.lastKickoffSucceeded ? "Launched claude" : "Kickoff failed"
             }

--- a/Sources/OpenQuackApp/SnapshotRenderer.swift
+++ b/Sources/OpenQuackApp/SnapshotRenderer.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import AppKit
+
+/// SPEC-044 — render UI surfaces to PNG so an agent (or a human) can SEE the UI
+/// and validate it against the specs, locally — no launching the menu-bar app,
+/// no screen-capture permissions, deterministic (fixed states, no live data).
+///
+/// Driven by `OQ_SNAPSHOT_DIR`: the app renders + exits instead of running.
+enum SnapshotRenderer {
+    static let overlaySize = CGSize(width: 320, height: 60)
+
+    @MainActor
+    static func renderAll(to dir: URL) {
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var written: [String] = []
+        for (name, state) in overlayStates() {
+            let url = dir.appendingPathComponent("overlay-\(name).png")
+            if render(OverlayPill(state: state), size: overlaySize, to: url) {
+                written.append(url.lastPathComponent)
+            }
+        }
+        FileHandle.standardError.write(
+            "rendered \(written.count) snapshots → \(dir.path)\n  \(written.joined(separator: "\n  "))\n"
+                .data(using: .utf8) ?? Data()
+        )
+    }
+
+    /// The recording overlay (SPEC-004) in each phase, including the SPEC-036
+    /// "interrupted" notice and the SPEC-031 kickoff mode.
+    @MainActor
+    private static func overlayStates() -> [(String, AppState)] {
+        func make(_ configure: (AppState) -> Void) -> AppState {
+            let a = AppState(); configure(a); return a
+        }
+        let wave: [Float] = [0.1, 0.2, 0.45, 0.7, 0.85, 0.6, 0.9, 0.5, 0.3, 0.55, 0.4]
+        return [
+            ("listening", make {
+                $0.phase = .recording; $0.recordingMode = .dictation
+                $0.elapsedSeconds = 3.2; $0.levelHistory = wave
+            }),
+            ("thinking", make {
+                $0.phase = .transcribing; $0.transcriptionProgress = 0.6
+            }),
+            ("pasted", make {
+                $0.phase = .ready; $0.recordingMode = .dictation
+                $0.lastPasted = true
+                $0.lastTranscript = "Hello, this is a quick test of dictation."
+            }),
+            ("interrupted", make {
+                $0.phase = .ready; $0.recordingMode = .dictation
+                $0.lastNotice = "Saved what we captured"
+            }),
+            ("kickoff-listening", make {
+                $0.phase = .recording; $0.recordingMode = .agentKickoff
+                $0.elapsedSeconds = 2.0; $0.levelHistory = wave
+            }),
+            ("kickoff-launched", make {
+                $0.phase = .ready; $0.recordingMode = .agentKickoff
+                $0.lastKickoffSucceeded = true
+            }),
+        ]
+    }
+
+    @MainActor
+    @discardableResult
+    private static func render<V: View>(_ view: V, size: CGSize, to url: URL) -> Bool {
+        let renderer = ImageRenderer(content: view.frame(width: size.width, height: size.height))
+        renderer.scale = 2
+        guard let nsImage = renderer.nsImage,
+              let tiff = nsImage.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let png = rep.representation(using: .png, properties: [:]) else { return false }
+        do { try png.write(to: url); return true } catch { return false }
+    }
+}

--- a/docs/SPECS/SPEC-044-ui-snapshot-validation.md
+++ b/docs/SPECS/SPEC-044-ui-snapshot-validation.md
@@ -1,0 +1,65 @@
+# SPEC-044 — Agent-driven UI snapshot validation
+
+## Goal
+
+Let an agent **see** the app's UI and validate it against the specs, **locally**
+— render each surface to a PNG, look at the pixels, check them against the
+governing spec's acceptance criteria, fix discrepancies, and re-render. No cloud,
+no launching the menu-bar app, no screen-capture, no live mic. Catches the class
+of bug unit tests miss: a state whose *logic* is correct but whose *rendered UI*
+is wrong (truncated, mislabelled, off-layout).
+
+## Background
+
+Unit tests cover logic; SPEC-042 covers recording behaviour. Neither sees what
+the user sees. The recording overlay, Settings panes, and onboarding are SwiftUI
+— and on macOS 13+ `ImageRenderer` renders any `View` to a bitmap deterministically
+and headlessly, so the UI can be captured without the WindowServer dance.
+
+## Mechanism
+
+### Snapshot mode
+
+`OQ_SNAPSHOT_DIR=<dir> openquack` renders fixed UI states to `<dir>/*.png` and
+exits, instead of running the menu bar (`SnapshotRenderer`, gated in `main()`).
+States are deterministic (constructed `AppState`, no live data). Today it covers
+`OverlayPill` in its phases — listening, thinking, pasted, **interrupted**
+(SPEC-036), kickoff (SPEC-031). The Settings panes reach into `NSApp.delegate`
+(~10 spots) and need light decoupling (inject the data) before they render
+standalone — added incrementally.
+
+### The validation loop
+
+An agent runs snapshot mode → for each PNG, reads the image *and* the governing
+spec's `## Acceptance criteria` → judges whether the rendered UI matches → reports
+or fixes → re-renders to confirm. The "improve on its own" is that
+render → see → validate → fix → re-render cycle; it runs locally (e.g. a Workflow
+`ui-validator` agent per SPEC-037).
+
+**Proven on the first run:** the loop caught two bugs in the interrupted-overlay
+state that no unit test would — the notice was **truncated** ("…audio devic…")
+and the headline misread **"Copied to clipboard"** on a cut-short recording.
+Both are fixed in this PR (headline → "Recording interrupted"; notice →
+"Saved what we captured", which fits the pill), confirmed by re-rendering.
+
+## Privacy impact
+
+None. Snapshot mode renders local SwiftUI views to local PNGs; it's inert unless
+`OQ_SNAPSHOT_DIR` is set, and adds no network or data collection.
+
+## Acceptance criteria
+
+- [ ] `OQ_SNAPSHOT_DIR=<dir> openquack` writes one PNG per overlay state and exits
+      0, without showing a menu-bar item or requiring mic/screen permission. (manual)
+- [ ] Each rendered overlay matches its spec: listening shows the level meter +
+      "Listening" + elapsed; interrupted shows "Recording interrupted" + an
+      untruncated notice; kickoff shows the claude affordance. (agent visual check)
+- [ ] `swift build && swift test` green.
+
+## Out of scope
+
+- The full app-launch **behaviour** harness (inject a WAV, assert the transcript)
+  — that's **SPEC-042 increment 2**; this spec is the *visual* half.
+- Pixel-diff golden-image testing — the agent validates against the *spec*, not a
+  frozen baseline, so intentional UI changes don't need golden re-baselining.
+- Decoupling every Settings pane from `NSApp.delegate` — tracked, incremental.


### PR DESCRIPTION
## SPEC
SPEC-044 (Agent-driven UI snapshot validation)

## Milestone
Adoption focus — auto-validation / ship confidently.

## Why
Lets an agent **see** the UI and validate it against the specs **locally** (no cloud, no mic, no screen-capture) — catching the bug class unit tests miss: correct logic, wrong rendered UI. Directly from "the agent should drive testing, see the UI to validate by the specs, and improve on its own, run locally."

## Change
- `SnapshotRenderer` + a `main()` gate: `OQ_SNAPSHOT_DIR=<dir> openquack` renders the recording-overlay states to PNG via `ImageRenderer` and exits — deterministic, headless.
- **The validation loop, run once, already paid for itself**: it caught two interrupted-overlay bugs (truncated notice; misleading "Copied to clipboard" headline) — **fixed in this PR** (headline → "Recording interrupted"; notice → "Saved what we captured"), confirmed by re-render.

## Tests
- [x] `swift build && swift test` green (269)
- [ ] snapshot render + agent visual check (manual; demonstrated in the PR thread)

## Privacy impact
None — local SwiftUI → local PNG, inert unless `OQ_SNAPSHOT_DIR` is set; no network.

## Out of scope
- The app-launch **behaviour** harness (inject WAV → assert transcript) = SPEC-042 increment 2 (this is the *visual* half).
- Pixel-diff golden images — the agent validates against the *spec*, not a baseline.
- Decoupling every Settings pane from `NSApp.delegate` (incremental).