### PR TITLE
feat(SPEC-007): onboarding opt-in to introduce local LLM polish

### DIFF
--- a/Sources/OpenQuackApp/OnboardingFlow.swift
+++ b/Sources/OpenQuackApp/OnboardingFlow.swift
@@ -43,8 +43,6 @@ final class OnboardingState: ObservableObject {
     @Published var modelError: String? = nil
     @Published var demoTranscript: String = ""
 
-    /// User's onboarding opt-in for local LLM polish. Drives the toggle and,
-    /// on Continue, whether we kick off the background model download.
     @Published var enablePolish: Bool = false
 
     /// Fires the moment the speech model finishes downloading. AppDelegate
@@ -225,7 +223,7 @@ struct OnboardingView: View {
         case .install:        InstallStep(state: state)
         case .demo:           DemoStep(state: state)
         case .polish:         PolishStep(state: state)
-        case .done:           DoneStep(polishEnabled: state.enablePolish)
+        case .done:           DoneStep(polishHint: polishDoneHint)
         }
     }
 
@@ -248,10 +246,16 @@ struct OnboardingView: View {
                     return
                 }
                 if state.step == .polish {
-                    // Off-by-default: only an explicitly enabled toggle spends the download.
-                    if state.enablePolish && !PolishModelCatalog.isInstalled() {
-                        state.polishDownload.confirm()
-                        state.polishDownload.detachToBackground()
+                    // Off-by-default: only an explicit opt-in enables polish. If the
+                    // model is already on disk, flip the engine on directly; otherwise
+                    // the download commits the engine on verified success.
+                    if state.enablePolish {
+                        if PolishModelCatalog.isInstalled() {
+                            UserDefaults.standard.set("llamaCpp", forKey: "polishEngine")
+                        } else {
+                            state.polishDownload.confirm()
+                            state.polishDownload.detachToBackground()
+                        }
                     }
                     state.advance()
                     return
@@ -276,12 +280,24 @@ struct OnboardingView: View {
         case .install where !state.modelDownloaded:
             return "Waiting…"
         case .polish where state.enablePolish:
-            return "Download & continue"
+            return PolishModelCatalog.isInstalled() ? "Enable & continue" : "Download & continue"
         case .done:
             return "Done"
         default:
             return "Continue"
         }
+    }
+
+    /// The done-step polish line, derived from the real outcome rather than the
+    /// opt-in flag: a download in flight, an engine just switched on, or nothing.
+    private var polishDoneHint: String? {
+        if case .downloading = state.polishDownload.phase {
+            return "Local LLM polish is downloading in the background — we'll let you know when it's ready."
+        }
+        if UserDefaults.standard.string(forKey: "polishEngine") == "llamaCpp" {
+            return "Local LLM polish is on."
+        }
+        return nil
     }
 
     private var continueDisabled: Bool {
@@ -643,8 +659,12 @@ private struct DemoStep: View {
 
 private struct PolishStep: View {
     @ObservedObject var state: OnboardingState
+    @AppStorage("polishEngine") private var polishEngine: String = "off"
 
     var body: some View {
+        // "Enabled" is the engine setting, not mere file presence — the model
+        // can be on disk while polish is switched off.
+        let installed = PolishModelCatalog.isInstalled()
         VStack(spacing: Theme.s16) {
             StepGlyph(symbol: "sparkles")
             Text("Polish your dictation").font(.oqTitleSerif)
@@ -654,7 +674,7 @@ private struct PolishStep: View {
                 .frame(maxWidth: 420)
             Spacer().frame(height: Theme.s8)
 
-            if PolishModelCatalog.isInstalled() {
+            if polishEngine == "llamaCpp" {
                 Label("Already enabled — ready to use.", systemImage: "checkmark.circle.fill")
                     .font(.body.weight(.medium))
                     .foregroundStyle(Theme.moss)
@@ -662,7 +682,9 @@ private struct PolishStep: View {
                 VStack(spacing: Theme.s8) {
                     Toggle("Enable local LLM polish", isOn: $state.enablePolish)
                         .frame(maxWidth: 360)
-                    Text("One-time \(PolishModelCatalog.sizeLabel) download · stays on your Mac")
+                    Text(installed
+                         ? "The model is already on your Mac — no download needed."
+                         : "One-time \(PolishModelCatalog.sizeLabel) download · stays on your Mac")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Link("Model license", destination: PolishModelCatalog.licenseURL)
@@ -676,7 +698,7 @@ private struct PolishStep: View {
 }
 
 private struct DoneStep: View {
-    let polishEnabled: Bool
+    let polishHint: String?
 
     var body: some View {
         VStack(spacing: Theme.s16) {
@@ -688,9 +710,8 @@ private struct DoneStep: View {
                 .frame(maxWidth: 420)
             Spacer().frame(height: Theme.s8)
             VStack(alignment: .leading, spacing: Theme.s8) {
-                if polishEnabled {
-                    tipRow(symbol: "sparkles",
-                           text: "Local LLM polish is downloading in the background — we'll let you know when it's ready.")
+                if let polishHint {
+                    tipRow(symbol: "wand.and.stars", text: polishHint)
                 }
                 tipRow(symbol: "slider.horizontal.3",
                        text: "Push-to-talk, custom dictionary, and auto-stop live in Settings.")

--- a/Sources/OpenQuackApp/OnboardingFlow.swift
+++ b/Sources/OpenQuackApp/OnboardingFlow.swift
@@ -42,6 +42,10 @@ final class OnboardingState: ObservableObject {
     @Published var modelError: String? = nil
     @Published var demoTranscript: String = ""
 
+    /// User's onboarding opt-in for local LLM polish. Drives the toggle and,
+    /// on Continue, whether we kick off the background model download.
+    @Published var enablePolish: Bool = false
+
     /// Fires the moment the speech model finishes downloading. AppDelegate
     /// hooks this to warm the WhisperKit transcriber in parallel — without
     /// it the demo step has a downloaded model on disk but no in-memory
@@ -49,11 +53,13 @@ final class OnboardingState: ObservableObject {
     var onModelReady: (() -> Void)?
 
     private let appState: AppState
+    let polishDownload: PolishModelDownloadController
     private var cancellables = Set<AnyCancellable>()
     private var permissionTimer: Timer?
 
-    init(appState: AppState) {
+    init(appState: AppState, polishDownload: PolishModelDownloadController) {
         self.appState = appState
+        self.polishDownload = polishDownload
         refreshPermissions()
 
         appState.$lastTranscript
@@ -665,15 +671,17 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
 
     static func showIfFirstLaunch(
         appState: AppState,
+        polishDownload: PolishModelDownloadController,
         onModelReady: @escaping () -> Void,
         onComplete: @escaping () -> Void
     ) {
         let done = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-        if !done { show(appState: appState, onModelReady: onModelReady, onComplete: onComplete) }
+        if !done { show(appState: appState, polishDownload: polishDownload, onModelReady: onModelReady, onComplete: onComplete) }
     }
 
     static func show(
         appState: AppState,
+        polishDownload: PolishModelDownloadController,
         onModelReady: @escaping () -> Void,
         onComplete: @escaping () -> Void
     ) {
@@ -688,6 +696,7 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
         NSApp.setActivationPolicy(.regular)
         let controller = OnboardingWindowController(
             appState: appState,
+            polishDownload: polishDownload,
             onModelReady: onModelReady,
             onComplete: onComplete
         )
@@ -696,8 +705,8 @@ final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    init(appState: AppState, onModelReady: @escaping () -> Void, onComplete: @escaping () -> Void) {
-        let state = OnboardingState(appState: appState)
+    init(appState: AppState, polishDownload: PolishModelDownloadController, onModelReady: @escaping () -> Void, onComplete: @escaping () -> Void) {
+        let state = OnboardingState(appState: appState, polishDownload: polishDownload)
         state.onModelReady = onModelReady
         self.state = state
         self.onComplete = onComplete

--- a/Sources/OpenQuackApp/OnboardingFlow.swift
+++ b/Sources/OpenQuackApp/OnboardingFlow.swift
@@ -225,7 +225,7 @@ struct OnboardingView: View {
         case .install:        InstallStep(state: state)
         case .demo:           DemoStep(state: state)
         case .polish:         PolishStep(state: state)
-        case .done:           DoneStep()
+        case .done:           DoneStep(polishEnabled: state.enablePolish)
         }
     }
 
@@ -247,8 +247,15 @@ struct OnboardingView: View {
                     onClose()
                     return
                 }
-                // For permission steps, Continue drives the OS grant flow
-                // directly — no separate "Grant access" button.
+                if state.step == .polish {
+                    // Off-by-default: only an explicitly enabled toggle spends the download.
+                    if state.enablePolish && !PolishModelCatalog.isInstalled() {
+                        state.polishDownload.confirm()
+                        state.polishDownload.detachToBackground()
+                    }
+                    state.advance()
+                    return
+                }
                 let triggeredPrompt = state.continueWillTriggerPermissionPrompt()
                 if !triggeredPrompt {
                     state.advance()
@@ -268,6 +275,8 @@ struct OnboardingView: View {
             return "Open System Settings"
         case .install where !state.modelDownloaded:
             return "Waiting…"
+        case .polish where state.enablePolish:
+            return "Download & continue"
         case .done:
             return "Done"
         default:
@@ -667,6 +676,8 @@ private struct PolishStep: View {
 }
 
 private struct DoneStep: View {
+    let polishEnabled: Bool
+
     var body: some View {
         VStack(spacing: Theme.s16) {
             StepGlyph(symbol: "checkmark")
@@ -677,6 +688,10 @@ private struct DoneStep: View {
                 .frame(maxWidth: 420)
             Spacer().frame(height: Theme.s8)
             VStack(alignment: .leading, spacing: Theme.s8) {
+                if polishEnabled {
+                    tipRow(symbol: "sparkles",
+                           text: "Local LLM polish is downloading in the background — we'll let you know when it's ready.")
+                }
                 tipRow(symbol: "slider.horizontal.3",
                        text: "Push-to-talk, custom dictionary, and auto-stop live in Settings.")
                 tipRow(symbol: "lock.shield",

--- a/Sources/OpenQuackApp/OnboardingFlow.swift
+++ b/Sources/OpenQuackApp/OnboardingFlow.swift
@@ -29,6 +29,7 @@ enum OnboardingStep: Int, CaseIterable {
     case hotkey
     case install
     case demo
+    case polish
     case done
 }
 
@@ -223,6 +224,7 @@ struct OnboardingView: View {
         case .hotkey:         HotkeyStep()
         case .install:        InstallStep(state: state)
         case .demo:           DemoStep(state: state)
+        case .polish:         PolishStep(state: state)
         case .done:           DoneStep()
         }
     }
@@ -627,6 +629,40 @@ private struct DemoStep: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { focused = true }
+    }
+}
+
+private struct PolishStep: View {
+    @ObservedObject var state: OnboardingState
+
+    var body: some View {
+        VStack(spacing: Theme.s16) {
+            StepGlyph(symbol: "sparkles")
+            Text("Polish your dictation").font(.oqTitleSerif)
+            Text("An optional on-device model cleans up filler words, grammar, and punctuation before your text is pasted. Experimental.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 420)
+            Spacer().frame(height: Theme.s8)
+
+            if PolishModelCatalog.isInstalled() {
+                Label("Already enabled — ready to use.", systemImage: "checkmark.circle.fill")
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(Theme.moss)
+            } else {
+                VStack(spacing: Theme.s8) {
+                    Toggle("Enable local LLM polish", isOn: $state.enablePolish)
+                        .frame(maxWidth: 360)
+                    Text("One-time \(PolishModelCatalog.sizeLabel) download · stays on your Mac")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Link("Model license", destination: PolishModelCatalog.licenseURL)
+                        .font(.caption)
+                }
+                .frame(maxWidth: 400)
+            }
+            Spacer()
+        }
     }
 }
 

--- a/Sources/OpenQuackApp/OpenQuackApp.swift
+++ b/Sources/OpenQuackApp/OpenQuackApp.swift
@@ -257,6 +257,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // for users who close the window before the install step.
             OnboardingWindowController.showIfFirstLaunch(
                 appState: appState,
+                polishDownload: polishDownload,
                 onModelReady: { [weak self] in
                     Task { @MainActor in self?.startWarm() }
                 },
@@ -337,6 +338,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
         OnboardingWindowController.show(
             appState: appState,
+            polishDownload: polishDownload,
             onModelReady: { [weak self] in
                 Task { @MainActor in self?.startWarm() }
             },

--- a/Sources/OpenQuackApp/SettingsView.swift
+++ b/Sources/OpenQuackApp/SettingsView.swift
@@ -18,6 +18,8 @@ struct SettingsView: View {
     enum Tab: Hashable { case general, shortcut, stats, history, about }
     @State private var selection: Tab = .general
     @ObservedObject var appState: AppState
+    @ObservedObject private var polishDownload = (NSApp.delegate as! AppDelegate).polishDownload
+    @ObservedObject private var speechDownload = (NSApp.delegate as! AppDelegate).speechDownload
 
     var body: some View {
         TabView(selection: $selection) {
@@ -38,6 +40,16 @@ struct SettingsView: View {
                 .tag(Tab.about)
         }
         .frame(minWidth: 580, idealWidth: 580, minHeight: 500, idealHeight: 500)
+        // Download sheets live at the window root, not inside General, so the
+        // menu-bar "Show" affordance can surface them whatever tab is open.
+        .sheet(isPresented: $speechDownload.isPresented,
+               onDismiss: { speechDownload.detachToBackground() }) {
+            SpeechModelDownloadSheet(model: speechDownload)
+        }
+        .sheet(isPresented: $polishDownload.isPresented,
+               onDismiss: { polishDownload.detachToBackground() }) {
+            PolishModelDownloadSheet(model: polishDownload)
+        }
     }
 }
 
@@ -220,10 +232,6 @@ private struct GeneralPane: View {
         .onChange(of: model) { pickerModel = $0; refreshDownloadedModels() }
         .onChange(of: pickerModel) { selectSpeechModel($0) }
         .onChange(of: appState.speechDownload) { _ in refreshDownloadedModels() }
-        .sheet(isPresented: $speechDownload.isPresented,
-               onDismiss: { speechDownload.detachToBackground() }) {
-            SpeechModelDownloadSheet(model: speechDownload)
-        }
     }
 
     var body: some View {
@@ -459,9 +467,6 @@ private struct GeneralPane: View {
         // button) so "Last checked" stays in sync.
         .onChange(of: receivePrereleases) { _ in
             handleCheckNowTap()
-        }
-        .sheet(isPresented: $modelDownload.isPresented, onDismiss: { modelDownload.detachToBackground() }) {
-            PolishModelDownloadSheet(model: modelDownload)
         }
     }
 


### PR DESCRIPTION
## SPEC
SPEC-007 (Local LLM polish)

## Milestone
M2.5

## Why
Polish shipped buried in Settings → Behaviour, so new users never discovered it and the one-time model download only fired if they found the picker. This adds an onboarding step that introduces the feature and lets the user opt in there — explicit, off-by-default. Closes #74.

## Change
- New `.polish` onboarding step (toggle, default off) after the demo. Opt-in starts the background model download via the existing `PolishModelDownloadController`, or — if the model is already on disk — flips `polishEngine` on directly (no re-download).
- `polishEngine` is committed only on verified download success; the done step shows a status line derived from the real download/engine state.
- Moved the Settings download sheets to the window-root `TabView` so the menu-bar "Show" surfaces them regardless of the open tab (fixed the same latent bug for the speech-model download).

## Tests
- [ ] unit test added/updated: n/a — app layer is an executable target, untestable by SwiftPM; flow verified manually
- [x] `swift build && swift test` green locally (269 tests, 0 failures, 2 skipped)
- [ ] bench delta: n/a — no transcription path change

## Privacy impact
Preserves the docs/VISION.md privacy contract. No new hot-path network calls — the only network is the existing, consent-gated polish-model download. Audio capture and transcription are untouched.

## Out of scope
Review nits deferred as #74 follow-ups: caching the `isInstalled()` stat out of the view body, and moving the opt-in side-effect from the footer closure onto the state/controller.

## AI coding brief
- Original request: introduce polish during onboarding and offer the model download (SPEC-007 follow-up, #74); keep it an explicit, off-by-default choice.
- Manual interventions: chose step placement (after demo) and toggle-default-off via Q&A; caught that "already enabled" was keyed off file presence rather than engine state, and that the download sheets didn't surface from non-General tabs.
- Retro: stating up front "enable engine only on verified success" and "Settings sheets must present tab-independently" would have avoided two review rounds.