### PR TITLE
chore: release v2.0.0-alpha.21

### DIFF
--- a/Casks/openquack.rb
+++ b/Casks/openquack.rb
@@ -1,9 +1,9 @@
 cask "openquack" do
-  version "2.0.0-alpha.20"
+  version "2.0.0-alpha.21"
   # Set per-release by scripts/make_dmg.sh — paste the printed value in
   # before each tag is pushed. `:no_check` is the placeholder while no
   # release has been tagged yet.
-  sha256 "3fda59551fa12a1176d8cde44d8ec4e46d94fe1c37bec98c631380b7f301234f"
+  sha256 "931cae94bc9708ce6558174394d819459d1ace65392448ffa1180ac6e24538d7"
 
   url "https://github.com/larryxiao/openquack/releases/download/v#{version}/OpenQuack-#{version}.dmg"
   name "OpenQuack"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Voice dictation for macOS. Nothing leaves your device — audio, text, nothing.
 
 > 📢 **What's new** — full notes on the [Releases page →](https://github.com/larryxiao/openquack/releases)
 >
+> - ✨ **[v2.0.0-alpha.21](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.21) — faster transcription + opt-in AI polish.** ANE performance restored (transcription speed regression fixed), plus onboarding now walks you through enabling on-device LLM polish so you can try it without hunting through settings.
 > - 🛡️ **[v2.0.0-alpha.20](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.20) — it doesn't freeze on you anymore.** If your mic changes mid-recording — AirPods connecting, switching devices — OpenQuack stops cleanly and keeps what you said instead of locking up. Plus on-device transcript polish, in-app model switching, and a faster first launch.
 > - 🌏 **[v2.0.0-alpha.18](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.18) — code-switch without the chaos.** Start a sentence in English and finish it in 中文: your Chinese now comes back as Chinese across a whole recording, not a garbled English "translation," and it's tidied into your system's script (简体 or 繁體).
-> - 🎧 **[v2.0.0-alpha.17](https://github.com/larryxiao/openquack/releases/tag/v2.0.0-alpha.17) — auto-detect that actually detects.** Just talk in any language, no menu-fiddling. Non-English speech stopped getting silently translated to English (253% → 17% WER on the multilingual set).
 ## What it is
 
 OpenQuack is a tiny menu-bar app for macOS. Press a hotkey, speak, press it again — your transcript appears at the cursor. Wherever you can type, you can talk.

--- a/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
+++ b/Sources/OpenQuackPlatform/OpenQuackPlatform.swift
@@ -4,5 +4,5 @@ import Foundation
 /// Carries no UI / KeyboardShortcuts / WhisperKit deps so the bench targets
 /// can build without Xcode-only macro plugins.
 public enum OpenQuackPlatform {
-    public static let version = "2.0.0-alpha.20"
+    public static let version = "2.0.0-alpha.21"
 }


### PR DESCRIPTION
## Summary

- Bumps version `2.0.0-alpha.20 → 2.0.0-alpha.21`
- Updates cask sha256 for the new DMG
- Updates README What's new banner

**Includes since alpha.20:**
- `fix(transcription)`: restore ANE compute units regressed by #89 (#93) — transcription speed fully restored
- `feat(SPEC-007)`: onboarding opt-in to introduce local LLM polish (#100) — new users are now walked through enabling AI polish in onboarding
- `feat(SPEC-043)`: release cadence, feature flags & runbook (#98) — `FeatureFlags` system + this runbook

## Checklist

- [x] Version bumped in `OpenQuackPlatform.swift`
- [x] `scripts/make_dmg.sh` run; sha256 matches cask
- [x] README What's new banner updated (newest first, ~3 entries)
- [ ] Appcast — blocked on SPEC-026 (Sparkle EdDSA key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkQQHvNkJFzAF2XKzkA2uV