### PR TITLE
fix(SPEC-004): surface recording overlay onto the active Space

### DIFF
--- a/Sources/OpenQuackApp/RecordingOverlay.swift
+++ b/Sources/OpenQuackApp/RecordingOverlay.swift
@@ -84,7 +84,10 @@ final class RecordingOverlay {
         guard let panel else { return }
         if panel.isVisible && panel.alphaValue > 0.95 { return }
         positionTopCentre(panel: panel)
-        panel.orderFront(nil)
+        // `orderFrontRegardless` (not `orderFront`): we're a background accessory
+        // app, so this surfaces the pill onto the currently active Space —
+        // including another app's fullscreen Space — without stealing focus.
+        panel.orderFrontRegardless()
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.18
             panel.animator().alphaValue = 1


### PR DESCRIPTION
## SPEC
SPEC-004 (Recording overlay)

## Milestone
M1

## Why
The recording pill intermittently shows on a background desktop instead of the user's current Space. Reproducible when dictation is triggered while another app is in native fullscreen (which owns a separate Space) — confirmed via CGWindowList: panel stayed alpha=1 on the correct screen but `isOnActiveSpace=false`.

## Change
`RecordingOverlay.showAnimated` uses `panel.orderFrontRegardless()` instead of `panel.orderFront(nil)`. As a background accessory app, this surfaces the pill onto the active Space (incl. another app's fullscreen Space) without stealing keyboard focus from the app being dictated into.

## Tests
- [ ] unit test: n/a — app layer is an executableTarget (untestable by SwiftPM); needs a real fullscreen Space to verify
- [x] `swift build && swift test` green locally (269 passed, 2 skipped)

## Privacy impact
None — windowing only; no audio/transcription/dispatch/output path touched.

## ⚠️ Tentative — not guaranteed
Best-effort, single-variable attempt. The bug is **intermittent** and depends on macOS Space/fullscreen state, so it can't be reproduced on demand or covered by tests. `orderFrontRegardless` is the strongest-grounded lever (the API for a background app to surface a window onto the active Space) but is **not yet confirmed against a live repro**. If it doesn't hold, next levers: drop `.stationary`, or a momentary key-window surface.

## Out of scope
Other window-config levers (`.stationary`, window level) left untouched — single-variable change so the fix is attributable.

## AI coding brief
- Original request: overlay sometimes shows on the wrong desktop when another app is fullscreen.
- Manual interventions: human rejected two earlier wrong guesses (raise window level; recreate panel), enforced single-variable discipline, picked `orderFrontRegardless` after reviewing the open-source Sol launcher.
- Retro: flag "intermittent + Space/fullscreen" upfront and demand one variable with an explicit pass/fail check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)