### PR TITLE
chore: ignore graphify-out/ knowledge-graph output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ bench/engines/.venv/
 
 # Zed editor (local per-developer LSP/index config)
 .zed/
+
+# graphify knowledge-graph output (rebuilt locally via post-commit hook)
+graphify-out/


### PR DESCRIPTION
## Why
`graphify-out/` is local knowledge-graph output, rebuilt by a post-commit hook — it should not be tracked.

## Change
Add `graphify-out/` to `.gitignore`.

## Tests
- [x] `git status` no longer lists `graphify-out/`

## Privacy impact
None — gitignore only.

## AI coding brief
- Original request: push the `.gitignore` change as its own PR; the repo has local graphify data under `graphify-out/`.
- Manual interventions: none.
- Retro: n/a — trivial infra change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)